### PR TITLE
[Reviewer Matt] Fixes to leaks and uninitialized conditions flagged by valgrind

### DIFF
--- a/include/baseresolver.h
+++ b/include/baseresolver.h
@@ -111,7 +111,7 @@ class BaseResolver
 {
 public:
   BaseResolver(DnsCachedResolver* dns_client);
-  ~BaseResolver();
+  virtual ~BaseResolver();
 
   void blacklist(const AddrInfo& ai, int ttl);
 

--- a/include/dnsrrecords.h
+++ b/include/dnsrrecords.h
@@ -84,6 +84,10 @@ public:
     _expires = _ttl + time(NULL);
   }
 
+  virtual ~DnsRRecord()
+  {
+  }
+
   const std::string& rrname() const { return _rrname; }
   int rrtype() const { return _rrtype; }
   int rrclass() const { return _rrclass; }

--- a/src/baseresolver.cpp
+++ b/src/baseresolver.cpp
@@ -361,7 +361,7 @@ BaseResolver::NAPTRReplacement* BaseResolver::NAPTRCacheFactory::get(std::string
             repl->replacement = replacement;
             repl->flags = naptr->flags();
             repl->transport = _services[naptr->service()];
-            ttl = ttl - time(NULL);
+            ttl = expires - time(NULL);
             terminated = true;
           }
           break;

--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -321,9 +321,6 @@ std::string DnsCachedResolver::display_cache()
        ++i)
   {
     const DnsCacheEntry& ce = i->second;
-    LOG_DEBUG("Displaying cache entry (%p) %s %s",
-              &ce, ce.domain.c_str(),
-              DnsRRecord::rrtype_to_string(ce.dnstype).c_str());
     oss << "Cache entry " << ce.domain
         << " type=" << DnsRRecord::rrtype_to_string(ce.dnstype)
         << " expires=" << ce.expires-now << std::endl;


### PR DESCRIPTION
Can you review these minor updates to the DNS functions to fix the leaks and uninitialized conditions flagged by valgrind.  The leak is probably pretty serious all things considered, so would definitely be good to get it in before the end of this sprint so we can have it in the next release.

(NB - this doesn't cover your code review feedback yet - I'm hoping to get to that tomorrow.)
