### PR TITLE
[Reviewer: Andy] Support vendor-specific applications

### DIFF
--- a/include/diameterstack.h
+++ b/include/diameterstack.h
@@ -474,6 +474,7 @@ public:
   virtual void initialize();
   virtual void configure(std::string filename);
   virtual void advertize_application(const Dictionary::Application& app);
+  virtual void advertize_application(const Dictionary::Vendor& vendor, const Dictionary::Application& app);
   virtual void register_handler(const Dictionary::Application& app, const Dictionary::Message& msg, BaseHandlerFactory* factory);
   virtual void register_fallback_handler(const Dictionary::Application& app);
   virtual void start();

--- a/src/diameterstack.cpp
+++ b/src/diameterstack.cpp
@@ -92,6 +92,16 @@ void Stack::advertize_application(const Dictionary::Application& app)
   }
 }
 
+void Stack::advertize_application(const Dictionary::Vendor& vendor, const Dictionary::Application& app)
+{
+  initialize();
+  int rc = fd_disp_app_support(app.dict(), vendor.dict(), 1, 0);
+  if (rc != 0)
+  {
+    throw Exception("fd_disp_app_support", rc); // LCOV_EXCL_LINE
+  }
+}
+
 void Stack::register_handler(const Dictionary::Application& app, const Dictionary::Message& msg, BaseHandlerFactory* factory)
 {
   // Register a callback for messages from our application with the specified message type.


### PR DESCRIPTION
Andy,

Please can you review this fix to allow a vendor to be specified as well as an application when advertising support for applications?

Thanks,

Matt
