### PR TITLE
[Reviewer: Mike] Avoid invalid memory access and memory leak on expiry of DNS entries

### DIFF
--- a/include/dnscachedresolver.h
+++ b/include/dnscachedresolver.h
@@ -120,7 +120,6 @@ private:
 
   struct DnsCacheEntry
   {
-    int valid;
     pthread_mutex_t lock;
     bool pending_query;
     std::string domain;
@@ -151,7 +150,7 @@ private:
   };
 
   typedef std::pair<int, std::string> DnsCacheKey;
-  typedef std::multimap<int, DnsCacheEntry*> DnsCacheExpiryList;
+  typedef std::multimap<int, DnsCacheKey> DnsCacheExpiryList;
   typedef std::map<DnsCacheKey,
                    DnsCacheEntry,
                    DnsCacheKeyCompare> DnsCache;

--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -494,7 +494,6 @@ DnsCachedResolver::DnsCacheEntry* DnsCachedResolver::create_cache_entry(const st
 {
   DnsCacheEntry& ce = _cache[std::make_pair(dnstype, domain)];
   pthread_mutex_init(&ce.lock, NULL);
-  ce.valid = 3008;
   ce.domain = domain;
   ce.dnstype = dnstype;
   ce.expires = DEFAULT_NEGATIVE_CACHE_TTL + time(NULL);
@@ -506,7 +505,7 @@ DnsCachedResolver::DnsCacheEntry* DnsCachedResolver::create_cache_entry(const st
 void DnsCachedResolver::add_to_expiry_list(DnsCacheEntry* ce)
 {
   LOG_DEBUG("Adding %s to cache expiry list with expiry time of %d", ce->domain.c_str(), ce->expires);
-  _cache_expiry_list.insert(std::make_pair(ce->expires, ce));
+  _cache_expiry_list.insert(std::make_pair(ce->expires, std::make_pair(ce->dnstype, ce->domain)));
 }
 
 /// Scans for expired cache entries.  In most case records are created then
@@ -521,24 +520,19 @@ void DnsCachedResolver::expire_cache()
   while ((!_cache_expiry_list.empty()) &&
          (_cache_expiry_list.begin()->first < now))
   {
-    std::multimap<int, DnsCacheEntry*>::iterator i = _cache_expiry_list.begin();
+    std::multimap<int, DnsCacheKey>::iterator i = _cache_expiry_list.begin();
+    LOG_DEBUG("Removing record for %s (type %d, expiry time %d) from the expiry list", i->second.second.c_str(), i->second.first, i->first);
 
-    // Check that the record really is due for expiry and hasn't been refreshed.
-    DnsCacheEntry* ce = _cache_expiry_list.begin()->second;
-    LOG_DEBUG("Removing record (type %d, expiry time %d, valid %d) from the expiry list", ce->dnstype, i->first, ce->valid);
-    LOG_DEBUG("Removing record for %s (type %d, expiry time %d, valid %d) from the expiry list", ce->domain.c_str(), ce->dnstype, i->first, ce->valid);
-    if (ce->expires == i->first)
+    // Check that the record really is due for expiry and hasn't been
+    // refreshed or already deleted.
+    DnsCache::iterator j = _cache.find(i->second);
+    if ((j != _cache.end()) && (j->second.expires == i->first))
     {
+      clear_cache_entry(&(j->second));
       // Record really is ready to expire, so remove it from the main cache
       // map.
-      DnsCache::iterator j = _cache.find(std::make_pair(ce->dnstype, ce->domain));
-      if (j != _cache.end())
-      {
-        LOG_DEBUG("Pointer &(j->second) is %d, ce is %d", &(j->second), ce);
-        LOG_DEBUG("Expiring record for %s (type %d, valid %d) from the DNS cache", j->second.domain.c_str(), j->second.dnstype, j->second.valid);
-        j->second.valid = -1;
-        _cache.erase(j);
-      }
+      LOG_DEBUG("Expiring record for %s (type %d) from the DNS cache", j->second.domain.c_str(), j->second.dnstype);
+      _cache.erase(j);
     }
 
     _cache_expiry_list.erase(i);


### PR DESCRIPTION
Mike,

This switches the value stored in the DnsCacheExpiryList from a pointer to the cache entry to a DnsCacheKey which we can then use to look up the entry. This is marginally less efficient but much safer - it avoids https://github.com/Metaswitch/sprout/issues/414.

I've also fixed https://github.com/Metaswitch/sprout/issues/415 by clearing the cache before we expire it.
