### PR TITLE
Reviewer Ellie - Add virtual keyword to ChronosConnection APIs for UT purposes

### DIFF
--- a/include/chronosconnection.h
+++ b/include/chronosconnection.h
@@ -54,17 +54,17 @@ public:
   virtual HTTPCode send_delete(const std::string& delete_id,
                                SAS::TrailId trail);
   virtual HTTPCode send_put(const std::string& put_identity,
-                    uint32_t timer_interval,
-                    uint32_t repeat_for,
-                    const std::string& callback_uri,
-                    const std::string& opaque_data,
-                    SAS::TrailId trail);
+                            uint32_t timer_interval,
+                            uint32_t repeat_for,
+                            const std::string& callback_uri,
+                            const std::string& opaque_data,
+                            SAS::TrailId trail);
   virtual HTTPCode send_post(std::string& post_identity,
-                     uint32_t timer_interval,
-                     uint32_t repeat_for,
-                     const std::string& callback_uri,
-                     const std::string& opaque_data,
-                     SAS::TrailId trail);
+                             uint32_t timer_interval,
+                             uint32_t repeat_for,
+                             const std::string& callback_uri,
+                             const std::string& opaque_data,
+                             SAS::TrailId trail);
 
   // Versions without repeat_for (i.e. timers that only fire once)
   virtual HTTPCode send_put(const std::string& put_identity,


### PR DESCRIPTION
This fixes some dodgy `delete`'s and makes it possible to override the remaining two API calls in UT.
