### PR TITLE
Add a _master_msg field to Diameter::Message to aid reference counting

### DIFF
--- a/include/diameterstack.h
+++ b/include/diameterstack.h
@@ -248,20 +248,26 @@ private:
 class Message
 {
 public:
-  inline Message(const Dictionary* dict, const Dictionary::Message& type, Stack* stack) : _dict(dict), _stack(stack), _free_on_delete(true)
+  inline Message(const Dictionary* dict, const Dictionary::Message& type, Stack* stack) : _dict(dict), _stack(stack), _free_on_delete(true), _master_msg(this)
   {
     fd_msg_new(type.dict(), MSGFL_ALLOC_ETEID, &_fd_msg);
   }
-  inline Message(Dictionary* dict, struct msg* msg, Stack* stack) : _dict(dict), _fd_msg(msg), _stack(stack),  _free_on_delete(true) {};
-  inline Message(const Message& msg) : _dict(msg._dict), _fd_msg(msg._fd_msg), _stack(msg._stack),  _free_on_delete(false) {};
+  inline Message(Dictionary* dict, struct msg* msg, Stack* stack) : _dict(dict), _fd_msg(msg), _stack(stack),  _free_on_delete(true), _master_msg(this) {};
+  inline Message(const Message& msg) : _dict(msg._dict), _fd_msg(msg._fd_msg), _stack(msg._stack),  _free_on_delete(false), _master_msg(msg._master_msg) {};
   virtual ~Message();
   inline const Dictionary* dict() const {return _dict;}
   inline struct msg* fd_msg() const {return _fd_msg;}
   inline uint32_t command_code() const {return msg_hdr()->msg_code;}
-  inline void build_response()
+  inline void build_response(Message &msg)
   {
+    // When we construct an answer from a request, freeDiameter associates
+    // the request with the new answer, so we only need to keep track of the
+    // answer.
+    msg.revoke_ownership();
+
     // _msg will point to the answer once this function is done.
     fd_msg_new_answer_from_req(fd_g_config->cnf_dict, &_fd_msg, 0);
+    claim_ownership();
   }
   inline Message& add_new_session_id()
   {
@@ -326,6 +332,18 @@ private:
   struct msg* _fd_msg;
   Stack* _stack;
   bool _free_on_delete;
+  Message* _master_msg;
+
+  inline void revoke_ownership()
+  {
+    _master_msg->_free_on_delete = false;
+  }
+
+  inline void claim_ownership()
+  {
+    _free_on_delete = true;
+    _master_msg = this;
+  }
 
   inline struct msg_hdr* msg_hdr() const
   {

--- a/src/diameterstack.cpp
+++ b/src/diameterstack.cpp
@@ -452,7 +452,8 @@ void Message::operator=(Message const& msg)
   }
   _dict = msg._dict;
   _fd_msg = msg._fd_msg;
-  _free_on_delete = msg._free_on_delete;
+  _free_on_delete = false;
+  _master_msg = msg._master_msg;
 }
 
 // Given an AVP type, search a Diameter message for an AVP of this type. If one exists,
@@ -527,16 +528,16 @@ int32_t Message::vendor_id() const
 void Message::send()
 {
   LOG_VERBOSE("Sending Diameter message of type %u", command_code());
+  revoke_ownership();
   _stack->send(_fd_msg);
-  _free_on_delete = false;
 }
 
 void Message::send(Transaction* tsx)
 {
   LOG_VERBOSE("Sending Diameter message of type %u on transaction %p", command_code(), tsx);
   tsx->start_timer();
+  revoke_ownership();
   _stack->send(_fd_msg, tsx);
-  _free_on_delete = false;
 }
 
 void Message::send(Transaction* tsx, unsigned int timeout_ms)
@@ -544,6 +545,6 @@ void Message::send(Transaction* tsx, unsigned int timeout_ms)
   LOG_VERBOSE("Sending Diameter message of type %u on transaction %p with timeout %u",
               command_code(), tsx, timeout_ms);
   tsx->start_timer();
+  revoke_ownership();
   _stack->send(_fd_msg, tsx, timeout_ms);
-  _free_on_delete = false;
 }


### PR DESCRIPTION
Still not perfect, but better.

Hasn't broken anything in Ralf either.

Not live tested. Maybe I'll do some live testing once I resolve the other couple of issues I've got in homestead?
