### PR TITLE
Reviewer Rob - Allow multiple vendors when searching for AVPs

### DIFF
--- a/include/diameterstack.h
+++ b/include/diameterstack.h
@@ -90,9 +90,13 @@ public:
   {
   public:
     inline AVP(const std::string avp) : Object(find(avp)) {};
-    inline AVP(const std::string vendor, const std::string avp) : Object(find(vendor, avp)) {};
+    inline AVP(const std::string vendor, 
+               const std::string avp) : Object(find(vendor, avp)) {};
+    inline AVP(const std::vector<std::string>& vendors,
+               const std::string avp) : Object(find(vendors, avp)) {};
     static struct dict_object* find(const std::string avp);
     static struct dict_object* find(const std::string vendor, const std::string avp);
+    static struct dict_object* find(const std::vector<std::string>& vendor, const std::string avp);
   };
 
   Dictionary();
@@ -159,6 +163,19 @@ public:
     Dictionary::AVP dict(name);
     fd_msg_avp_new(dict.dict(), 0, &_avp);
   }
+  AVP(const std::string& vendor,
+      const std::string& name)
+  {
+    Dictionary::AVP dict(vendor, name);
+    fd_msg_avp_new(dict.dict(), 0, &_avp);
+  }
+  AVP(const std::vector<std::string>& vendors,
+      const std::string& name)
+  {
+    Dictionary::AVP dict(vendors, name);
+    fd_msg_avp_new(dict.dict(), 0, &_avp);
+  }
+
   inline AVP(struct avp* avp) : _avp(avp) {}
   inline AVP(AVP const& avp) : _avp(avp.avp()) {}
   inline AVP& operator=(AVP const& avp) {_avp = avp.avp(); return *this;}
@@ -198,35 +215,28 @@ public:
   }
   inline AVP& val_i32(int32_t i32)
   {
-    union avp_value val;
-    val.i32 = i32;
-    fd_msg_avp_setvalue(_avp, &val);
+    fd_msg_avp_value_encode(&i32, _avp);
     return *this;
   }
   inline AVP& val_i64(int64_t i64)
   {
-    union avp_value val;
-    val.i64 = i64;
-    fd_msg_avp_setvalue(_avp, &val);
+    fd_msg_avp_value_encode(&i64, _avp);
     return *this;
   }
   inline AVP& val_u32(uint32_t u32)
   {
-    union avp_value val;
-    val.u32 = u32;
-    fd_msg_avp_setvalue(_avp, &val);
+    fd_msg_avp_value_encode(&u32, _avp);
     return *this;
   }
   inline AVP& val_u64(uint64_t u64)
   {
-    union avp_value val;
-    val.u64 = u64;
-    fd_msg_avp_setvalue(_avp, &val);
+    fd_msg_avp_value_encode(&u64, _avp);
     return *this;
   }
 
   // Populate this AVP from a JSON object
-  AVP& val_json(const rapidjson::Value& contents);
+  AVP& val_json(const std::vector<std::string>& vendors, 
+                const rapidjson::Value& contents);
 
   inline AVP& add(AVP& avp)
   {


### PR DESCRIPTION
This is a sub-review for the Ralf review you currently have on your table.

This allows us to:
- find AVPs by name even if they're owned by a vendor
- render AVPs by using the built in value encoder, which means we can pass an integer to TIME AVPs and have them automatically rendered correctly.
