### PR TITLE
Reviewer Matt - Add add_session_id entry point to Message

### DIFF
--- a/include/diameterstack.h
+++ b/include/diameterstack.h
@@ -278,27 +278,15 @@ public:
     fd_msg_new_answer_from_req(fd_g_config->cnf_dict, &_fd_msg, 0);
     claim_ownership();
   }
+
+  // Add a Session-ID to a message (either a new one or a specified).
   inline Message& add_new_session_id()
   {
     fd_msg_new_session(_fd_msg, NULL, 0);
     return *this;
   }
-  inline Message& add_session_id(const std::string& session_id)
-  {
-    struct session* session;
+  Message& add_session_id(const std::string& session_id);
 
-    // Horrible casting to get round freeDiameter's poor use of types to
-    // represent SIDs.
-    fd_sess_fromsid((uint8_t*)const_cast<char*>(session_id.data()),
-                    session_id.length(),
-                    &session,
-                    NULL);
-    fd_msg_sess_set(_fd_msg, session);
-    Diameter::AVP session_id_avp(dict()->SESSION_ID);
-    session_id_avp.val_str(session_id);
-    add(session_id_avp);
-    return *this;
-  }
   inline Message& add_vendor_spec_app_id()
   {
     Diameter::AVP vendor_specific_application_id(dict()->VENDOR_SPECIFIC_APPLICATION_ID);

--- a/src/diameterstack.cpp
+++ b/src/diameterstack.cpp
@@ -608,6 +608,28 @@ int32_t Message::vendor_id() const
   return vendor_id;
 }
 
+Message& Message::add_session_id(const std::string& session_id)
+{
+  struct session* session;
+
+  // Horrible casting to get round freeDiameter's poor use of types to
+  // represent SIDs.  Although the function doesn't modify the supplied string
+  // it's not marked as const so we aren't allowed to pass session_id.data()
+  // in.
+  //
+  // For bonus points, the session_id is specified as an unsigned char, despite
+  // being ASCII only, so we also have to do a sign-cast.
+  fd_sess_fromsid((uint8_t*)const_cast<char*>(session_id.data()),
+                  session_id.length(),
+                  &session,
+                  NULL);
+  fd_msg_sess_set(_fd_msg, session);
+  Diameter::AVP session_id_avp(dict()->SESSION_ID);
+  session_id_avp.val_str(session_id);
+  add(session_id_avp);
+  return *this;
+}
+
 void Message::send()
 {
   LOG_VERBOSE("Sending Diameter message of type %u", command_code());


### PR DESCRIPTION
For Rf billing, we need to create DIAMETER messages in a given DIAMETER session so I've added a method to add a given Session-Id to a message.

Tested in Rf's unit tests.
