### PR TITLE
[Reviewer: Graeme] Add methods to set the Auth-Application-Id or Acct-Application-Id

### DIFF
--- a/include/diameterstack.h
+++ b/include/diameterstack.h
@@ -70,22 +70,45 @@ public:
   class Vendor : public Object
   {
   public:
-    inline Vendor(const std::string vendor) : Object(find(vendor)) {};
+    inline Vendor(const std::string vendor) : Object(find(vendor))
+    {
+      fd_dict_getval(dict(), &_vendor_data);
+    }
     static struct dict_object* find(const std::string vendor);
+    inline uint32_t vendor_id() const { return _vendor_data.vendor_id; }
+    inline const struct dict_vendor_data* vendor_data() const { return &_vendor_data; }
+
+  private:
+    struct dict_vendor_data _vendor_data;
   };
 
   class Application : public Object
   {
   public:
-    inline Application(const std::string application) : Object(find(application)) {};
+    inline Application(const std::string application) : Object(find(application))
+    {
+      fd_dict_getval(dict(), &_application_data);
+    }
     static struct dict_object* find(const std::string application);
+    inline uint32_t application_id() const { return _application_data.application_id; }
+    inline const struct dict_application_data* application_data() const { return &_application_data; }
+
+  private:
+    struct dict_application_data _application_data;
   };
 
   class Message : public Object
   {
   public:
-    inline Message(const std::string message) : Object(find(message)) {};
+    inline Message(const std::string message) : Object(find(message))
+    {
+      fd_dict_getval(dict(), &_cmd_data);
+    }
     static struct dict_object* find(const std::string message);
+    inline const struct dict_cmd_data* cmd_data() const { return &_cmd_data; }
+
+  private:
+    struct dict_cmd_data _cmd_data;
   };
 
   class AVP : public Object
@@ -109,6 +132,7 @@ public:
     static struct dict_object* find(const std::string vendor, const std::string avp);
     static struct dict_object* find(const std::vector<std::string>& vendor, const std::string avp);
 
+    inline const struct dict_avp_data* avp_data() const { return &_avp_data; }
     inline enum dict_avp_basetype base_type() const { return _avp_data.avp_basetype; };
 
   private:
@@ -119,6 +143,8 @@ public:
   const AVP SESSION_ID;
   const AVP VENDOR_SPECIFIC_APPLICATION_ID;
   const AVP VENDOR_ID;
+  const AVP AUTH_APPLICATION_ID;
+  const AVP ACCT_APPLICATION_ID;
   const AVP AUTH_SESSION_STATE;
   const AVP ORIGIN_REALM;
   const AVP ORIGIN_HOST;
@@ -236,6 +262,9 @@ public:
     return *this;
   }
 
+  bool get_str_from_avp(const Dictionary::AVP& type, std::string& str) const;
+  bool get_i32_from_avp(const Dictionary::AVP& type, int32_t& i32) const;
+
   // Populate this AVP from a JSON object
   AVP& val_json(const std::vector<std::string>& vendors,
                 const Diameter::Dictionary::AVP& dict,
@@ -291,10 +320,19 @@ public:
   }
   Message& add_session_id(const std::string& session_id);
 
-  inline Message& add_vendor_spec_app_id()
+  inline Message& add_auth_app_id(const Dictionary::Vendor& vendor, const Dictionary::Application& app)
   {
     Diameter::AVP vendor_specific_application_id(dict()->VENDOR_SPECIFIC_APPLICATION_ID);
-    vendor_specific_application_id.add(Diameter::AVP(dict()->VENDOR_ID).val_i32(10415));
+    vendor_specific_application_id.add(Diameter::AVP(dict()->VENDOR_ID).val_i32(vendor.vendor_id()));
+    vendor_specific_application_id.add(Diameter::AVP(dict()->AUTH_APPLICATION_ID).val_i32(app.application_id()));
+    add(vendor_specific_application_id);
+    return *this;
+  }
+  inline Message& add_acct_app_id(const Dictionary::Vendor& vendor, const Dictionary::Application& app)
+  {
+    Diameter::AVP vendor_specific_application_id(dict()->VENDOR_SPECIFIC_APPLICATION_ID);
+    vendor_specific_application_id.add(Diameter::AVP(dict()->VENDOR_ID).val_i32(vendor.vendor_id()));
+    vendor_specific_application_id.add(Diameter::AVP(dict()->ACCT_APPLICATION_ID).val_i32(app.application_id()));
     add(vendor_specific_application_id);
     return *this;
   }
@@ -387,9 +425,9 @@ class AVP::iterator
 {
 public:
   inline iterator(const AVP& parent_avp) : _avp(find_first_child(parent_avp.avp())) {memset(&_filter_avp_data, 0, sizeof(_filter_avp_data));}
-  inline iterator(const AVP& parent_avp, const Dictionary::AVP& child_type) : _filter_avp_data(get_avp_data(child_type.dict())), _avp(find_first_child(parent_avp.avp(), _filter_avp_data)) {}
+  inline iterator(const AVP& parent_avp, const Dictionary::AVP& child_type) : _filter_avp_data(*child_type.avp_data()), _avp(find_first_child(parent_avp.avp(), _filter_avp_data)) {}
   inline iterator(const Message& parent_msg) : _avp(find_first_child(parent_msg.fd_msg())) {memset(&_filter_avp_data, 0, sizeof(_filter_avp_data));}
-  inline iterator(const Message& parent_msg, const Dictionary::AVP& child_type) : _filter_avp_data(get_avp_data(child_type.dict())), _avp(find_first_child(parent_msg.fd_msg(), _filter_avp_data)) {}
+  inline iterator(const Message& parent_msg, const Dictionary::AVP& child_type) : _filter_avp_data(*child_type.avp_data()), _avp(find_first_child(parent_msg.fd_msg(), _filter_avp_data)) {}
   inline iterator(struct avp* avp) : _avp(avp) {memset(&_filter_avp_data, 0, sizeof(_filter_avp_data));};
   inline ~iterator() {};
 
@@ -421,12 +459,6 @@ public:
   inline AVP* operator->() {return &_avp;}
 
 private:
-  inline static dict_avp_data get_avp_data(struct dict_object* dict)
-  {
-    struct dict_avp_data avp_data;
-    fd_dict_getval(dict, &avp_data);
-    return avp_data;
-  }
   inline static struct avp* find_first_child(msg_or_avp* parent)
   {
     msg_or_avp* first_child = NULL;

--- a/src/diameterstack.cpp
+++ b/src/diameterstack.cpp
@@ -376,6 +376,8 @@ Dictionary::Dictionary() :
   SESSION_ID("Session-Id"),
   VENDOR_SPECIFIC_APPLICATION_ID("Vendor-Specific-Application-Id"),
   VENDOR_ID("Vendor-Id"),
+  AUTH_APPLICATION_ID("Auth-Application-Id"),
+  ACCT_APPLICATION_ID("Acct-Application-Id"),
   AUTH_SESSION_STATE("Auth-Session-State"),
   ORIGIN_REALM("Origin-Realm"),
   ORIGIN_HOST("Origin-Host"),
@@ -433,6 +435,38 @@ void Transaction::on_timeout(void* data, DiamId_t to, size_t to_len, struct msg*
   delete tsx;
   // Null out the message so that freeDiameter doesn't try to send it on.
   *req = NULL;
+}
+
+// Given an AVP type, search an AVP for a child of this type. If one exists, return true
+// and set str to the string value of the child AVP. Otherwise return false.
+bool AVP::get_str_from_avp(const Dictionary::AVP& type, std::string& str) const
+{
+  AVP::iterator avps = begin(type);
+  if (avps != end())
+  {
+    str = avps->val_str();
+    return true;
+  }
+  else
+  {
+    return false;
+  }
+}
+
+// Given an AVP type, search an AVP for a child of this type. If one exists, return true
+// and set i32 to the integer value of the child AVP. Otherwise return false.
+bool AVP::get_i32_from_avp(const Dictionary::AVP& type, int32_t& i32) const
+{
+  AVP::iterator avps = begin(type);
+  if (avps != end())
+  {
+    i32 = avps->val_i32();
+    return true;
+  }
+  else
+  {
+    return false;
+  }
 }
 
 AVP& AVP::val_json(const std::vector<std::string>& vendors,


### PR DESCRIPTION
Graeme,

Please can you review this fix to add methods to set the Auth-Application-Id and Acct-Application-Id.  This is needed to fix https://github.com/Metaswitch/homestead/issues/74.  As part of this, I've also
-   exposed the freeDiameter vendor, application, command and AVP data structures
-   moved the iterator to use these
-   added `get_str_from_avp` and `get_i32_from_avp` methods to the AVP class (to make UT easier) - these were already present on the Message class, and I think will be useful.

UT-ed through the homestead change (to follow shortly).

Matt
