### PR TITLE
Reviewer Matt - Session leak fix

### DIFF
--- a/src/diameterstack.cpp
+++ b/src/diameterstack.cpp
@@ -661,24 +661,9 @@ int32_t Message::vendor_id() const
 
 Message& Message::add_session_id(const std::string& session_id)
 {
-  struct session* session;
-
-  // Horrible casting to get round freeDiameter's poor use of types to
-  // represent SIDs.  Although the function doesn't modify the supplied string
-  // it's not marked as const so we aren't allowed to pass session_id.data()
-  // in.
-  //
-  // For bonus points, the session_id is specified as an unsigned char, despite
-  // being ASCII only, so we also have to do a sign-cast.
-  fd_sess_fromsid((uint8_t*)const_cast<char*>(session_id.data()),
-                  session_id.length(),
-                  &session,
-                  NULL);
-  fd_msg_sess_set(_fd_msg, session);
   Diameter::AVP session_id_avp(dict()->SESSION_ID);
   session_id_avp.val_str(session_id);
   add(session_id_avp);
-  fd_sess_reclaim(&session);
   return *this;
 }
 


### PR DESCRIPTION
The old code here was totally bogus, we'd create an `fd_session`, never properly reference it (the call to `fd_msg_sess_set` does pretty much nothing), and leak it and the end of the day...  Given that we don't use the session anywhere, we don't need to bother building one.
