### PR TITLE
Reviewer Matt - Turbo boost DIAMETER stack performance

### DIFF
--- a/include/diameterstack.h
+++ b/include/diameterstack.h
@@ -672,6 +672,8 @@ private:
   std::map<std::string, std::map<std::string, struct dict_object*>> _avp_map;
 
   void populate_avp_map();
+  void populate_vendor_map(const std::string& vendor_name,
+                           struct dict_object* vendor_dict);
 
   void remove_int(Peer* peer);
 };


### PR DESCRIPTION
- Overwrite the built in message send hooks (so we don't waste time dumping out messages on every send).
- Load a map of Vendor->AVP->Dictionary at configuration time and use that for AVP lookups later.

Tested in Ralf UTs.
