### PR TITLE
Reviewer Andy: Add latency to access logs

### DIFF
--- a/include/accesslogger.h
+++ b/include/accesslogger.h
@@ -34,9 +34,6 @@
  * as those licenses appear in the file LICENSE-OPENSSL.
  */
 
-///
-///
-
 #ifndef ACCESSLOGGER_H__
 #define ACCESSLOGGER_H__
 
@@ -52,7 +49,8 @@ public:
 
   void log(const std::string& url,
            const std::string& method,
-           int rc);
+           int rc,
+           unsigned long latency_us);
 
 private:
   static const int BUFFER_SIZE = 1000;

--- a/include/httpstack.h
+++ b/include/httpstack.h
@@ -63,9 +63,9 @@ public:
   {
   public:
     Request(HttpStack* stack, evhtp_request_t* req) :
-    _method(htp_method_UNKNOWN), _body_set(false), _stack(stack), _req(req), stopwatch()
+    _method(htp_method_UNKNOWN), _body_set(false), _stack(stack), _req(req), _stopwatch()
     {
-      stopwatch.start();
+      _stopwatch.start();
     }
     virtual ~Request() {};
 
@@ -164,7 +164,7 @@ public:
   private:
     HttpStack* _stack;
     evhtp_request_t* _req;
-    Utils::StopWatch stopwatch;
+    Utils::StopWatch _stopwatch;
     SASEvent::HttpLogLevel _sas_log_level;
 
     std::string url_unescape(const std::string& s)
@@ -279,11 +279,11 @@ public:
   virtual void send_reply(Request& req, int rc, SAS::TrailId trail);
   virtual void record_penalty();
 
-  void log(const std::string uri, std::string method, int rc)
+  void log(const std::string uri, std::string method, int rc, unsigned long latency_us)
   {
     if (_access_logger)
     {
-      _access_logger->log(uri, method, rc);
+      _access_logger->log(uri, method, rc, latency_us);
     }
   };
 

--- a/src/accesslogger.cpp
+++ b/src/accesslogger.cpp
@@ -51,13 +51,16 @@ AccessLogger::~AccessLogger()
 
 void AccessLogger::log(const std::string& uri,
                        const std::string& method,
-                       int rc)
+                       int rc,
+                       unsigned long latency_us)
 {
   char buf[BUFFER_SIZE];
   snprintf(buf, sizeof(buf),
-           "%d %s %s\n",
+           "%d %s %s %ld.%6.6ld seconds\n",
            rc,
            method.c_str(),
-           uri.c_str());
+           uri.c_str(),
+           latency_us / 1000000,
+           latency_us % 1000000);
   _logger->write(buf);
 }

--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -50,13 +50,13 @@ HttpStack::HttpStack() :
 
 void HttpStack::Request::send_reply(int rc, SAS::TrailId trail)
 {
-  stopwatch.stop();
+  _stopwatch.stop();
   _stack->send_reply(*this, rc, trail);
 }
 
 bool HttpStack::Request::get_latency(unsigned long& latency_us)
 {
-  return stopwatch.read(latency_us);
+  return _stopwatch.read(latency_us);
 }
 
 // Wrapper around evhtp_send_reply to ensure that all responses are
@@ -64,8 +64,9 @@ bool HttpStack::Request::get_latency(unsigned long& latency_us)
 void HttpStack::send_reply_internal(Request& req, int rc, SAS::TrailId trail)
 {
   LOG_VERBOSE("Sending response %d to request for URL %s, args %s", rc, req.req()->uri->path->full, req.req()->uri->query_raw);
-
-  log(std::string(req.req()->uri->path->full), req.method_as_str(), rc);
+  unsigned long latency_us = 0;
+  req.get_latency(latency_us);
+  log(std::string(req.req()->uri->path->full), req.method_as_str(), rc, latency_us);
   sas_log_tx_http_rsp(trail, req, rc, 0);
 
   evhtp_send_reply(req.req(), rc);


### PR DESCRIPTION
Andy

Can you review my change to add request latency to the access logs generated by the HttpStack class.  I've tested by building a Homestead image with the change, where an example of the output is as follows.

22-05-2014 09:57:02.067 200 GET /impi/2010021254%40me2.cw-ngv.com/registration-status 0.000027 seconds

(I also fixed up a minor coding standards violation - a member variable was missing the _ prefix, which confused me while I was trying to work out the change.)

I'd raised cpp-common issue #102 to cover this.

I'll pull into sprout, homestead and ralf later as I suspect I am going to have some memcachedstore fixes as well.

Mike
