### PR TITLE
[Reviewer Ellie] Use shared_ptr to manage references to DNS cache entries

### DIFF
--- a/include/dnscachedresolver.h
+++ b/include/dnscachedresolver.h
@@ -151,10 +151,11 @@ private:
     }
   };
 
+  typedef std::shared_ptr<DnsCacheEntry> DnsCacheEntryPtr;
   typedef std::pair<int, std::string> DnsCacheKey;
   typedef std::multimap<int, DnsCacheKey> DnsCacheExpiryList;
   typedef std::map<DnsCacheKey,
-                   std::shared_ptr<DnsCacheEntry>,
+                   DnsCacheEntryPtr,
                    DnsCacheKeyCompare> DnsCache;
 
   void dns_response(const std::string& domain,
@@ -165,12 +166,12 @@ private:
 
   bool caching_enabled(int rrtype);
 
-  DnsCacheEntry* get_cache_entry(const std::string& domain, int dnstype);
-  DnsCacheEntry* create_cache_entry(const std::string& domain, int dnstype);
-  void add_to_expiry_list(DnsCacheEntry* ce);
+  DnsCacheEntryPtr get_cache_entry(const std::string& domain, int dnstype);
+  DnsCacheEntryPtr create_cache_entry(const std::string& domain, int dnstype);
+  void add_to_expiry_list(DnsCacheEntryPtr ce);
   void expire_cache();
-  void add_record_to_cache(DnsCacheEntry* ce, DnsRRecord* rr);
-  void clear_cache_entry(DnsCacheEntry* ce);
+  void add_record_to_cache(DnsCacheEntryPtr ce, DnsRRecord* rr);
+  void clear_cache_entry(DnsCacheEntryPtr ce);
 
   DnsChannel* get_dns_channel();
   void wait_for_replies(DnsChannel* channel);


### PR DESCRIPTION
Ellie

Can you review my fix to https://github.com/Metaswitch/sprout/issues/541.  The fix is basically to use shared_ptr<DnsCacheEntry> everywhere instead of DnsCacheEntry\* in some places - and not to use the get() operation on the shared pointer as this is potentially unsafe without some alternate locking on the object.

I've tested it live - the stress tests no longer hit the scribbler I've been reliably hitting (although they now seem to run in to some Chronos timer-related issues).

Mike
