### PR TITLE
[Reviewer: Mike] Apply a penalty on a downsteam overload response

### DIFF
--- a/include/httpconnection.h
+++ b/include/httpconnection.h
@@ -62,6 +62,7 @@ static const long HTTP_TEMP_UNAVAILABLE = 480;
 static const long HTTP_SERVER_ERROR = 500;
 static const long HTTP_NOT_IMPLEMENTED = 501;
 static const long HTTP_SERVER_UNAVAILABLE = 503;
+static const long HTTP_GATEWAY_TIMEOUT = 504;
 
 /// Provides managed access to data on a single HTTP server. Properly
 /// supports round-robin DNS load balancing.


### PR DESCRIPTION
Mike, can you review this change to apply a penalty when a downsteam node is overloaded. 
