### PR TITLE
Reviewer Rob - Update SAS bundle version

### DIFF
--- a/include/sasevent.h
+++ b/include/sasevent.h
@@ -41,7 +41,7 @@
 
 namespace SASEvent {
 
-  const std::string CURRENT_RESOURCE_BUNDLE = "org.projectclearwater.20140407";
+  const std::string CURRENT_RESOURCE_BUNDLE = "org.projectclearwater.20140612";
 
   // Name of the HTTP header we use to correlate the client and server in SAS.
   const std::string HTTP_BRANCH_HEADER_NAME = "X-SAS-HTTP-Branch-ID";


### PR DESCRIPTION
This is the cpp-common fix I mentioned in SCRUM this morning.  We are moving up to a new SAS bundle version (see https://github.com/Metaswitch/clearwater-sas-resources/pull/2) and need to specify that on the SAS API.
