### PR TITLE
[Reviewer: Alex] Speculative fix to stop logs being truncated

### DIFF
--- a/include/log.h
+++ b/include/log.h
@@ -47,6 +47,7 @@
 #define LOG_VERBOSE(...) if (Log::enabled(Log::VERBOSE_LEVEL)) Log::write(Log::VERBOSE_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
 #define LOG_DEBUG(...) if (Log::enabled(Log::DEBUG_LEVEL)) Log::write(Log::DEBUG_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
 #define LOG_BACKTRACE(...) Log::backtrace(__VA_ARGS__)
+#define LOG_COMMIT(...) Log::commit()
 
 namespace Log
 {
@@ -73,6 +74,7 @@ namespace Log
   void write(int level, const char *module, int line_number, const char *fmt, ...);
   void _write(int level, const char *module, int line_number, const char *fmt, va_list args);
   void backtrace(const char *fmt, ...);
+  void commit();
 }
 
 #endif

--- a/include/logger.h
+++ b/include/logger.h
@@ -59,6 +59,7 @@ public:
 
   virtual void write(const char* data);
   virtual void flush();
+  virtual void commit();
 
   // Dumps a backtrace.  Note that this is not thread-safe and should only be
   // called when no other threads are running - generally from a signal
@@ -75,7 +76,7 @@ private:
     int hour;
     int min;
     int sec;
-    int msec;      
+    int msec;
     int yday;
   } timestamp_t;
 
@@ -97,7 +98,7 @@ private:
   int _saved_errno;
   pthread_mutex_t _lock;
 
-  /// Defines how frequently (in terms of log attempts) we will try to 
+  /// Defines how frequently (in terms of log attempts) we will try to
   /// open the log file if we failed to open it previously.
   static const int LOGFILE_CHECK_FREQUENCY = 1000;
 };

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -145,4 +145,14 @@ void Log::backtrace(const char *fmt, ...)
   Log::logger->backtrace(logline);
 }
 
+void Log::commit()
+{
+  if (!Log::logger)
+  {
+    return;
+  }
+
+  Log::logger->commit();
+}
+
 // LCOV_EXCL_STOP

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -275,12 +275,19 @@ void Logger::backtrace(const char *data)
     dup2(fd2, 2);
     close(fd2);
     fprintf(_fd, "\n");
+
     if (rc != 0)
     {
       fprintf(_fd, "gdb failed with return code %d\n", rc);
     }
+
     fflush(_fd);
   }
+}
+
+void Logger::commit()
+{
+  fsync(fileno(_fd));
 }
 
 // LCOV_EXCL_STOP


### PR DESCRIPTION
Alex, can you review this speculative fix to stop the logs being truncated during diags collection. 

This is for [clearwater-infrastructure #61](https://github.com/Metaswitch/clearwater-infrastructure/issues/61)
