### PR TITLE
[Reviewer: Alex] UTs run much faster if we don't pause for 1s every time we destroy a Sig...

### DIFF
--- a/include/updater.h
+++ b/include/updater.h
@@ -64,11 +64,12 @@ public:
       // LCOV_EXCL_STOP
     }
   }
- 
+
   ~Updater()
   {
     // Destroy the updater thread.
     _terminate = true;
+    _sighup_handler.cancel();
     pthread_join(_updater, NULL);
   }
 
@@ -78,7 +79,7 @@ private:
     ((Updater*)p)->updater();
     return NULL;
   }
- 
+
   void updater()
   {
     LOG_DEBUG("Started updater thread");


### PR DESCRIPTION
...nalHandler

More fixes addressing https://github.com/Metaswitch/sprout/issues/588. This brings it down from 24s to 10s, and I have another change in Sprout bringing it down to 6s.

Tested by running the UTs, but not live - I don't think that's worthwhile as we only destroy the updaters on program termination.
