### PR TITLE
[Reviewer: Andy] Allow the ruby stats script to be passed a port (that it actually listens to)

### DIFF
--- a/scripts/stats-c/cw_stat.cpp
+++ b/scripts/stats-c/cw_stat.cpp
@@ -193,13 +193,13 @@ int main(int argc, char** argv)
   // Check arguments.
   if (argc != 4)
   {
-    fprintf(stderr, "Usage: %s <hostname> <statname> <port>\n", argv[0]);
+    fprintf(stderr, "Usage: %s <hostname> <port> <statname>\n", argv[0]);
     return 1;
   }
 
   // Get messages from the server.
   std::vector<std::string> msgs;
-  if (!get_msgs(argv[1], argv[3], argv[2], msgs))
+  if (!get_msgs(argv[1], argv[2], argv[3], msgs))
   {
     return 2;
   }

--- a/scripts/stats/bin/cw_stat
+++ b/scripts/stats/bin/cw_stat
@@ -20,11 +20,10 @@ def main
   options = {
     verbose: false,
     subscribe: false,
-    ports: [6666],
   }
 
   opts = OptionParser.new do |o|
-    o.banner = "Usage: cw_stat [options] <hostname> [statname]"
+    o.banner = "Usage: cw_stat [options] <hostname> <port> [statname]"
     o.on("-v", "--[no-]verbose", "Run verbosely") do |v|
       options[:verbose] = v
     end
@@ -49,24 +48,44 @@ def main
   end
   opts.parse!
 
-  if ARGV[0].nil?
-    puts "Error: You must specify a host to query"
-    puts
-    puts opts
+  # Extract and check positional arguments.
+  num_positional_args = 3
+  hostname = ARGV[0]
+  port = ARGV[1]
+  statname = ARGV[2]
+
+  if hostname.nil?
+    puts "Error: You must specify a host to query\n\n#{opts}"
+    exit 1
+  end
+
+  if port.nil?
+    puts "Error: You must specify a port to query\n\n#{opts}"
     exit 2
+  else
+    begin
+      port = Integer(port)
+    rescue ArgumentError
+      puts "Error: #{port} is not a valid port number\n\n#{opts}"
+      exit 3
+    end
   end
 
   begin
-    if ARGV[1].nil?
-      fail "Subscription is only supported for single stats" if options[:subscribe]
-      stat_collectors = CWStatCollector.all_collectors(ARGV[0], options)
+    if statname.nil?
+      if options[:subscribe]
+        puts "Subscription is only supported for single stats"
+        exit 5
+      end
+
+      stat_collectors = CWStatCollector.all_collectors(hostname, port, options)
     else
-      stat_collectors = [CWStatCollector.new(ARGV[0], ARGV[1], options)]
+      stat_collectors = [CWStatCollector.new(hostname, port, statname, options)]
     end
   rescue Exception => e
     puts "Error: #{e.message}"
     puts "Error: Terminating due to previous errors"
-    exit 2
+    exit 6
   end
 
   begin


### PR DESCRIPTION
This enhances the ruby stats gathering script to take a positional `port` parameter and use this when connecting to zmq. This replaces the old scheme where the port was inferred from the stat name (which no longer works now that bono and sprout use different zmq ports. 

I've also changed the usage of the c++ version to be consistent with the ruby version.
#### Testing

Ruby version:
- Retrieved all stats from a sprout node. 
- Retrieved all stats from a bono node. 
- Retrieved one stat from sprout node. 
- Retrieved one stat from bono node. 
- Subscribed to one stat from a sprout node. 
- Subscribed to one stat from a bono node. 
- Supplied various bad arguments. all caught by the script with a sensible error message.

C++ version:
- Retrieved a single stats from a sprout node.  
- Retrieved a single stats from a bono node. 
