### PR TITLE
[Review: Mike] peek() is not const because it must take/release a lock

### DIFF
--- a/include/eventq.h
+++ b/include/eventq.h
@@ -364,7 +364,7 @@ public:
   }
 
   /// Peek at the item at the front of the event queue.
-  T peek() const
+  T peek()
   {
     T item;
     pthread_mutex_lock(&_m);


### PR DESCRIPTION
Mike,

Please can you review this fix.  `peek()` can't be const because it now takes/releases a lock.  I'm going to merge this anyway to fix the chronos build but please let me know if you have any questions/comments.

Thanks,

Matt
