### PR TITLE
[Reviewer: Alex] Speed up unit tests that need to wait for a signal

### DIFF
--- a/include/signalhandler.h
+++ b/include/signalhandler.h
@@ -124,7 +124,8 @@ public:
     // expense of being less efficient.
     ts.tv_nsec += 1000000;
     if (ts.tv_nsec >= 1000000000) {
-          ts.tv_nsec = 999999999;
+        ts.tv_sec += 1;
+        ts.tv_nsec -= 1000000000;
     }
 #endif
 


### PR DESCRIPTION
I closed my previous pull request here and took an approach similar to https://github.com/Metaswitch/sprout/pull/620. Brings Sprout UTs on my machine from ~15s to ~3.5s.
