### PR TITLE
[Reviewer: Alex] Allow overriding the SAS logger

### DIFF
--- a/include/httpstack_utils.h
+++ b/include/httpstack_utils.h
@@ -76,7 +76,7 @@ namespace HttpStackUtils
       task->run();
     }
 
-    HttpStack::SasLogger* sas_logger(HttpStack::Request& req)
+    virtual HttpStack::SasLogger* sas_logger(HttpStack::Request& req)
     {
       if (_sas_logger != NULL)
       {


### PR DESCRIPTION
Tested by using the new function, and also building Homestead to verify that old usage isn't broken. Not tested live.
