### PR TITLE
[Reviewer: Alex] Add NullSASLogger to disable SAS logging from the PingHandler

### DIFF
--- a/include/httpstack.h
+++ b/include/httpstack.h
@@ -232,7 +232,7 @@ public:
     // @instance_id unique instance ID for the event.
     virtual void sas_log_rx_http_req(SAS::TrailId trail,
                                      Request& req,
-                                     uint32_t instance_id = 0);
+                                     uint32_t instance_id = 0) = 0;
 
     // Log a transmitted HTTP response.
     //
@@ -243,7 +243,7 @@ public:
     virtual void sas_log_tx_http_rsp(SAS::TrailId trail,
                                      Request& req,
                                      int rc,
-                                     uint32_t instance_id = 0);
+                                     uint32_t instance_id = 0) = 0;
 
     // Log when an HTTP request is rejected due to overload.
     //
@@ -254,7 +254,7 @@ public:
     virtual void sas_log_overload(SAS::TrailId trail,
                                   Request& req,
                                   int rc,
-                                  uint32_t instance_id = 0);
+                                  uint32_t instance_id = 0) = 0;
 
   protected:
     //
@@ -285,6 +285,41 @@ public:
                             int rc,
                             uint32_t instance_id,
                             SASEvent::HttpLogLevel level = SASEvent::HttpLogLevel::PROTOCOL);
+  };
+
+  /// Default implementation of SAS Logger.  Logs with default severity.
+  class DefaultSasLogger : public SasLogger
+  {
+  public:
+    void sas_log_rx_http_req(SAS::TrailId trail,
+                             Request& req,
+                             uint32_t instance_id = 0);
+    void sas_log_tx_http_rsp(SAS::TrailId trail,
+                             Request& req,
+                             int rc,
+                             uint32_t instance_id = 0);
+    void sas_log_overload(SAS::TrailId trail,
+                          Request& req,
+                          int rc,
+                          uint32_t instance_id = 0);
+  };
+
+  /// "Null" SAS Logger.  Does not log.
+  class NullSasLogger : public SasLogger
+  {
+  public:
+    // Implement the API but don't actually log.
+    void sas_log_rx_http_req(SAS::TrailId trail,
+                             Request& req,
+                             uint32_t instance_id = 0) {}
+    void sas_log_tx_http_rsp(SAS::TrailId trail,
+                             Request& req,
+                             int rc,
+                             uint32_t instance_id = 0) {}
+    void sas_log_overload(SAS::TrailId trail,
+                          Request& req,
+                          int rc,
+                          uint32_t instance_id = 0) {}
   };
 
   class HandlerInterface
@@ -344,7 +379,8 @@ public:
     }
   };
 
-  static SasLogger DEFAULT_SAS_LOGGER;
+  static DefaultSasLogger DEFAULT_SAS_LOGGER;
+  static NullSasLogger NULL_SAS_LOGGER;
 
 private:
   static HttpStack* INSTANCE;

--- a/include/httpstack_utils.h
+++ b/include/httpstack_utils.h
@@ -137,6 +137,12 @@ namespace HttpStackUtils
   class PingHandler : public HttpStack::HandlerInterface
   {
     void process_request(HttpStack::Request& req, SAS::TrailId trail);
+
+    HttpStack::SasLogger* sas_logger(HttpStack::Request& req)
+    {
+      // Don't log any SAS events.
+      return &HttpStack::NULL_SAS_LOGGER;
+    }
   };
 
   /// @class HandlerThreadPool

--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -41,7 +41,8 @@
 HttpStack* HttpStack::INSTANCE = &DEFAULT_INSTANCE;
 HttpStack HttpStack::DEFAULT_INSTANCE;
 bool HttpStack::_ev_using_pthreads = false;
-HttpStack::SasLogger HttpStack::DEFAULT_SAS_LOGGER;
+HttpStack::DefaultSasLogger HttpStack::DEFAULT_SAS_LOGGER;
+HttpStack::NullSasLogger HttpStack::NULL_SAS_LOGGER;
 
 HttpStack::HttpStack() :
   _access_logger(NULL),
@@ -309,31 +310,6 @@ std::string HttpStack::Request::body()
 // SasLogger methods.
 //
 
-void HttpStack::SasLogger::sas_log_rx_http_req(SAS::TrailId trail,
-                                               HttpStack::Request& req,
-                                               uint32_t instance_id)
-{
-  log_correlator(trail, req, instance_id);
-  log_req_event(trail, req, instance_id);
-}
-
-
-void HttpStack::SasLogger::sas_log_tx_http_rsp(SAS::TrailId trail,
-                                               HttpStack::Request& req,
-                                               int rc,
-                                               uint32_t instance_id)
-{
-  log_rsp_event(trail, req, rc, instance_id);
-}
-
-void HttpStack::SasLogger::sas_log_overload(SAS::TrailId trail,
-                                            HttpStack::Request& req,
-                                            int rc,
-                                            uint32_t instance_id)
-{
-  log_overload_event(trail, req, rc, instance_id);
-}
-
 void HttpStack::SasLogger::log_correlator(SAS::TrailId trail,
                                           Request& req,
                                           uint32_t instance_id)
@@ -419,3 +395,33 @@ void HttpStack::SasLogger::log_overload_event(SAS::TrailId trail,
   event.add_var_param(req.full_path());
   SAS::report_event(event);
 }
+
+//
+// DefaultSasLogger methods.
+//
+
+void HttpStack::DefaultSasLogger::sas_log_rx_http_req(SAS::TrailId trail,
+                                                      HttpStack::Request& req,
+                                                      uint32_t instance_id)
+{
+  log_correlator(trail, req, instance_id);
+  log_req_event(trail, req, instance_id);
+}
+
+
+void HttpStack::DefaultSasLogger::sas_log_tx_http_rsp(SAS::TrailId trail,
+                                                      HttpStack::Request& req,
+                                                      int rc,
+                                                      uint32_t instance_id)
+{
+  log_rsp_event(trail, req, rc, instance_id);
+}
+
+void HttpStack::DefaultSasLogger::sas_log_overload(SAS::TrailId trail,
+                                                   HttpStack::Request& req,
+                                                   int rc,
+                                                   uint32_t instance_id)
+{
+  log_overload_event(trail, req, rc, instance_id);
+}
+


### PR DESCRIPTION
Alex,

Please can you review this fix to add a NullSASLogger to disable SAS logging from PingHandler?  This was raised as part of Metaswitch/ralf#88.

I've updated UT (as part of homestead) but not live-tested yet.

Matt
