### PR TITLE
[Reviewer Andy] Add locking to deadlock detection

### DIFF
--- a/include/eventq.h
+++ b/include/eventq.h
@@ -156,7 +156,7 @@ public:
             ((now_time - service_time) > _deadlock_threshold))
         {
           LOG_ERROR("Queue is deadlocked - service delay %ld > threshold %ld",
-                    service_delay_ms, _deadlock_threshold);
+                    service_time - now_time, _deadlock_threshold);
           LOG_DEBUG("  Last service time = %d.%ld", _service_time.tv_sec, _service_time.tv_nsec);
           LOG_DEBUG("  Now = %d.%ld", now.tv_sec, now.tv_nsec);
           deadlocked = true;


### PR DESCRIPTION
Andy

As discussed, this fix adds locking to the deadlock detection code to avoid the issues we've seen with it triggering incorrectly.  This avoids us having to allow a grace period for the detection to allow for case where we only read a partially updated service time.  As we discussed, the locking isn't a problem because the intent of the function is to detect deadlocks in code servicing an event queue, not deadlocks in the event queue code itself.

I should have said - I tested this live by merging in to the svc_api branch and running stress tests over it.

Mike
