### PR TITLE
[Reviewer: Mike] Use relative expiry except when we want a record to expire immediately

### DIFF
--- a/include/memcachedstore.h
+++ b/include/memcachedstore.h
@@ -155,6 +155,11 @@ private:
   // each vector index into the list of servers.
   std::vector<std::vector<int> > _read_replicas;
   std::vector<std::vector<int> > _write_replicas;
+
+  // The maximum expiration delta that memcached expects.  Any expiration
+  // value larger than this is assumed to be an absolute rather than relative
+  // value.  This matches the REALTIME_MAXDELTA constant defined by memcached.
+  static const int MEMCACHED_EXPIRATION_MAXDELTA = 60 * 60 * 24 * 30;
 };
 
 #endif


### PR DESCRIPTION
Mike,

Please can you review this fix to #160?  The issue was that using absolute time to trigger expiry is great as long as the memcached daemon has the same concept of absolute time.  Unfortunately, it doesn't cope with time stepchanges very well.  Rather than fixing memcached, I suggest just using relative time, except where we have to use absolute time to force expiry - in that case, we can use the earliest absolute time.

I've live-tested by
- registering and checking that memcached has the correct expiry time
- logging out while sprout is stopped (so it can't erase the entry from memcached) and checking the entry expires from memcached at the right time
- registering in and unregistering and confirming that the entry is removed from memcached immediately.

Matt

(fixes #160)
