### PR TITLE
[Reviewer: Andy] Don't log while destroying a logger

### DIFF
--- a/src/fakelogger.cpp
+++ b/src/fakelogger.cpp
@@ -56,7 +56,6 @@ PrintingTestLogger::PrintingTestLogger() : _last_logger(NULL)
 
 PrintingTestLogger::~PrintingTestLogger()
 {
-  LOG_DEBUG("Logger destruction");
   Logger* replaced = Log::setLogger(_last_logger);
 
   // Ensure that loggers are destroyed in the reverse order of creation.


### PR DESCRIPTION
I hit a couple of random crashes in UT on this log. As logging that we're destroying the logger we're logging to seemed unwise, I removed the log.
