### PR TITLE
Easier tailing of log files

### DIFF
--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -223,6 +223,13 @@ void Logger::cycle_log_file(const timestamp_t& ts)
           ts.hour);
   _fd = fopen(fname, "a");
 
+  // Set up /var/log/<component>/<component>_current.txt as a symlink
+  char cfname[100];
+  sprintf(cfname, "%s_current.txt",
+          _prefix.c_str());
+  unlink(cfname);
+  symlink(fname, cfname);
+
   if (_fd == NULL)
   {
     // Failed to open logfile, so save errno until we can log it.


### PR DESCRIPTION
This creates a `/var/log/<component>/<component>_current.txt` symlink pointing at the current log file (and updates it on every log rotation). This gets the key benefit of https://github.com/Metaswitch/clearwater-infrastructure/issues/63, without all the upheaval of actually moving to logrotate.

Tested by running `tail -F /var/log/sprout/sprout_current.txt` and seeing continued output across the hour boundary.
