### PR TITLE
Reviewer Mike - Handle DNS errors sensibly

### DIFF
--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -473,6 +473,12 @@ void DnsCachedResolver::dns_response(const std::string& domain,
       }
     }
   }
+  else
+  {
+    // If we can't contact the DNS server, keep using the old record's value until we can reconnect.
+    LOG_ERROR("Failed to retrieve record for %s: %s", domain.c_str(), ares_strerror(status));
+    ce->expires = 30;
+  }
 
   // If there were no records set cache a negative entry to prevent 
   // immediate retries.


### PR DESCRIPTION
If this is the first time we've requested a domain from DNS, we don't fully populate the cache record (in particular we don't set the expiry), if we then fail to contact the DNS server we jump over a load of processing then store the (empty) cache record for the time specified in the expiry (which is normally massive).

This fix ensures we'll continue to use the last seen value for a record for 30 more seconds if the DNS server fails to respond.  Note that `NXDOMAIN` counts as a successful response so doesn't trigger this branch, errors indicate incorrect DNS configuration or death of the DNS server.
