### PR TITLE
[Reviewer: Andy] Make alarms optional on MemcachedStore - default to NULL pointers

### DIFF
--- a/include/memcachedstore.h
+++ b/include/memcachedstore.h
@@ -63,8 +63,8 @@ class MemcachedStore : public Store
 public:
   MemcachedStore(bool binary,
                  const std::string& config_file,
-                 CommunicationMonitor* comm_monitor,
-                 Alarm* vbucket_alarm);
+                 CommunicationMonitor* comm_monitor = NULL,
+                 Alarm* vbucket_alarm = NULL);
   ~MemcachedStore();
 
   /// Flags that the store should use a new view of the memcached cluster to


### PR DESCRIPTION
Andy,

Please can you review this change to make alarms optional?  NULL is a valid value and it seems unnecessary to require it to be specified if you don't need/want alarm function.

Thanks,

Matt
