### PR TITLE
Remove the need for a relationship between servers and new_servers in MemcachedStoreView

### DIFF
--- a/include/memcachedstore.h
+++ b/include/memcachedstore.h
@@ -165,8 +165,7 @@ private:
   // The list of servers in this view.
   std::vector<std::string> _servers;
 
-  // The set of read and write replicas for each vbucket.  The integers in
-  // each vector index into the list of servers.
+  // The set of read and write replicas for each vbucket.
   std::vector<std::vector<std::string> > _read_replicas;
   std::vector<std::vector<std::string> > _write_replicas;
 

--- a/include/memcachedstore.h
+++ b/include/memcachedstore.h
@@ -110,7 +110,7 @@ private:
     uint64_t view_number;
 
     // Contains the memcached_st's for each server.
-    std::vector<memcached_st*> st;
+    std::map<std::string, memcached_st*> st;
 
     // Contains the set of read and write replicas for each vbucket.
     std::vector<std::vector<memcached_st*> > write_replicas;
@@ -167,8 +167,8 @@ private:
 
   // The set of read and write replicas for each vbucket.  The integers in
   // each vector index into the list of servers.
-  std::vector<std::vector<int> > _read_replicas;
-  std::vector<std::vector<int> > _write_replicas;
+  std::vector<std::vector<std::string> > _read_replicas;
+  std::vector<std::vector<std::string> > _write_replicas;
 
   // The maximum expiration delta that memcached expects.  Any expiration
   // value larger than this is assumed to be an absolute rather than relative

--- a/include/memcachedstoreview.h
+++ b/include/memcachedstoreview.h
@@ -58,15 +58,18 @@ public:
   const std::vector<std::string>& servers() const { return _servers; };
 
   /// Returns the current read and write replica sets for each vbucket.
-  const std::vector<int>& read_replicas(int vbucket) const { return _read_set[vbucket]; };
-  const std::vector<int>& write_replicas(int vbucket) const { return _write_set[vbucket]; };
+  const std::vector<std::string>& read_replicas(int vbucket) const { return _read_set[vbucket]; };
+  const std::vector<std::string>& write_replicas(int vbucket) const { return _write_set[vbucket]; };
 
 private:
   /// Converts the view into a string suitable for logging.
   std::string view_to_string();
 
   /// Converts a set of replicas into an ordered string suitable for logging.
-  std::string replicas_to_string(const std::vector<int>& replicas);
+  std::string replicas_to_string(const std::vector<std::string>& replicas);
+
+  std::vector<std::string> merge_servers(const std::vector<std::string>& list1,
+                                         const std::vector<std::string>& list2);
 
   /// Calculates the ring used to generate the vbucket configurations.  The
   /// ring essentially maps each vbucket slot to a particular node which is
@@ -124,8 +127,8 @@ private:
   // vbucket will be the same and have exactly _replicas entries in each.  In
   // unstable configurations (scale-up/scale-down) additional read and write
   // replicas are enabled to maintain redundancy.
-  std::vector<std::vector<int> > _read_set;
-  std::vector<std::vector<int> > _write_set;
+  std::vector<std::vector<std::string> > _read_set;
+  std::vector<std::vector<std::string> > _write_set;
 };
 
 #endif

--- a/src/memcachedstoreview.cpp
+++ b/src/memcachedstoreview.cpp
@@ -118,6 +118,9 @@ void MemcachedStoreView::update(const std::vector<std::string>& servers,
   else
   {
     LOG_DEBUG("Cluster is moving from %d nodes to %d nodes", servers.size(), new_servers.size());
+
+    // _servers should contain all the servers we might want to store
+    // data on, so combine the old and new server lists, removing any overlap.
     _servers = merge_servers(servers, new_servers);
 
     // Calculate the two rings needed to generate the vbucket replica sets
@@ -196,7 +199,8 @@ std::string MemcachedStoreView::view_to_string()
   for (int ii = 0; ii < _vbuckets; ++ii)
   {
     oss << std::left << std::setw(8) << std::setfill(' ') << std::to_string(ii);
-    oss << std::left << std::setw(30) << std::setfill(' ') << replicas_to_string(_write_set[ii]);
+    oss << std::left << std::setw(28) << std::setfill(' ') << replicas_to_string(_write_set[ii]);
+    oss << "||";
     oss << replicas_to_string(_read_set[ii]) << std::endl;
   }
   return oss.str();
@@ -210,7 +214,7 @@ std::string MemcachedStoreView::replicas_to_string(const std::vector<std::string
   {
     s += replicas[ii] + "/";
   }
-  s += replicas[replicas.size()-1] ;
+  s += replicas[replicas.size()-1];
 
   return s;
 }

--- a/src/memcachedstoreview.cpp
+++ b/src/memcachedstoreview.cpp
@@ -66,11 +66,11 @@ std::vector<std::string> MemcachedStoreView::merge_servers(const std::vector<std
                                                            const std::vector<std::string>& list2)
 {
   std::set<std::string> merged_servers;
-  for (int ii = 0; ii < list1.size(); ii++)
+  for (size_t ii = 0; ii < list1.size(); ii++)
   {
     merged_servers.insert(list1[ii]);
   }
-  for (int ii = 0; ii < list2.size(); ii++)
+  for (size_t ii = 0; ii < list2.size(); ii++)
   {
     merged_servers.insert(list2[ii]);
   }
@@ -107,7 +107,7 @@ void MemcachedStoreView::update(const std::vector<std::string>& servers,
     {
       std::vector<int> server_indexes = ring.get_nodes(ii, replicas);
       _read_set[ii].clear();
-      for (int jj = 0; jj < server_indexes.size(); jj++)
+      for (size_t jj = 0; jj < server_indexes.size(); jj++)
       {
         int idx = server_indexes[jj];
         _read_set[ii].push_back(servers[idx]);

--- a/src/memcachedstoreview.cpp
+++ b/src/memcachedstoreview.cpp
@@ -66,17 +66,10 @@ std::vector<std::string> MemcachedStoreView::merge_servers(const std::vector<std
                                                            const std::vector<std::string>& list2)
 {
   std::set<std::string> merged_servers;
-  for (size_t ii = 0; ii < list1.size(); ii++)
-  {
-    merged_servers.insert(list1[ii]);
-  }
-  for (size_t ii = 0; ii < list2.size(); ii++)
-  {
-    merged_servers.insert(list2[ii]);
-  }
-
-  std::vector<std::string> ret;
-  std::copy(merged_servers.begin(), merged_servers.end(), std::back_inserter(ret));
+  merged_servers.insert(list1.begin(), list1.end());
+  merged_servers.insert(list2.begin(), list2.end());
+  
+  std::vector<std::string> ret(merged_servers.begin(), merged_servers.end());
   return ret;
 }
 


### PR DESCRIPTION
Previously, servers and new_servers had to share a prefix, because MemcachedStoreView returned indexes into an array of memcached connections (so if your servers[0] didn't match new_servers[0], read attempts would go to a different memcached and fail).

This change makes MemcachedStoreView return the address of the relevant memcached server directly, rather than an index, allowing for new_servers to have any (or no) overlap with servers. This mostly just makes use of information it already has - it's not a very big change.

This substantially mitigates https://github.com/Metaswitch/sprout/issues/852 - it doesn't do hinted-handoff-style rebalancing but it is now possible to do a "create new VMs" upgrade with no risk of an outage by adding new memcacheds to the end and then removing the old ones from the start.

I've tested by writing a script that creates a MemcachedStore and starts off with four servers, writes a series of keys in, starts scaling (in five different ways noted below), checks that the keys are still readable, writes a different series of keys, finishes scaling, and checks that the second series of keys are still readable.

It scales:
1) up, by adding new servers to the end of the list
2) down, by removing servers from the end of the list
3) up, by adding new servers to the start of the list
4) down, by removing servers from the start of the list
5) "across", by making the new_servers a different pair of servers (i.e. there's no overlap at all between the old and the new servers)

Against the master branch, that test script passes cases 1 and 2 and fails the rest (as expected). Against this branch, all five cases pass.

(That testing was live, in that it linked in the real MemcachedStore object and I had six memcached processes running on my machine for it to use. I haven't tested live in the sense of doing it within Sprout, but I think my test script replicates what would really happen on scale up/down and gives me enough confidence that it works.)

The test script is at https://github.com/rkday/sprout/blob/memstore_tester/sprout/memcachedstore_tester.cpp if you want to see it, but I'm not proposing to merge it - it requires some work to run (i.e. running six memcacheds locally) so will probably just get stale.

(We should probably have some UT of MemcachedStoreView - I'll add some to Sprout in a separate pull request.)