### PR TITLE
[Reviewer: Ellie] Discard DNS responses other than A/AAAA/SRV/NAPTR with a warning

### DIFF
--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -415,7 +415,8 @@ void DnsCachedResolver::dns_response(const std::string& domain,
           }
           else
           {
-            LOG_WARNING("Ignoring A/AAAA record for %s (expecting domain %s)", rr->rrname().c_str(), domain.c_str());
+            LOG_DEBUG("Ignoring A/AAAA record for %s (expecting domain %s)",
+                      rr->rrname().c_str(), domain.c_str());
             delete rr;
           }
         }
@@ -427,7 +428,8 @@ void DnsCachedResolver::dns_response(const std::string& domain,
         }
         else
         {
-          LOG_WARNING("Ignoring %s record in DNS answer - only A, AAAA, NAPTR and SRV are supported", DnsRRecord::rrtype_to_string(rr->rrtype()).c_str());
+          LOG_WARNING("Ignoring %s record in DNS answer - only A, AAAA, NAPTR and SRV are supported",
+                      DnsRRecord::rrtype_to_string(rr->rrtype()).c_str());
           delete rr;
         }
       }

--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -415,13 +415,20 @@ void DnsCachedResolver::dns_response(const std::string& domain,
           }
           else
           {
+            LOG_WARNING("Ignoring A/AAAA record for %s (expecting domain %s)", rr->rrname().c_str(), domain.c_str());
             delete rr;
           }
         }
-        else
+        else if ((rr->rrtype() == ns_t_srv) ||
+                 (rr->rrtype() == ns_t_naptr))
         {
           // SRV or NAPTR record, so add it to the cache entry.
           add_record_to_cache(ce, rr);
+        }
+        else
+        {
+          LOG_WARNING("Ignoring %s record in DNS answer - only A, AAAA, NAPTR and SRV are supported", DnsRRecord::rrtype_to_string(rr->rrtype()).c_str());
+          delete rr;
         }
       }
 
@@ -480,7 +487,7 @@ void DnsCachedResolver::dns_response(const std::string& domain,
     ce->expires = 30;
   }
 
-  // If there were no records set cache a negative entry to prevent 
+  // If there were no records set cache a negative entry to prevent
   // immediate retries.
   if ((ce->records.empty()) &&
       (ce->expires == 0))


### PR DESCRIPTION
Improves the behaviour of #224. Tested by setting my Bono node's upstream_hostname to news.bbc.co.uk and checking the logs:

```
30-12-2014 11:46:40.513 UTC Debug dnscachedresolver.cpp:154: Wait for query responses
30-12-2014 11:46:40.513 UTC Debug dnscachedresolver.cpp:384: Received DNS response for news.bbc.co.uk type A
30-12-2014 11:46:40.514 UTC Debug dnsparser.cpp:90: Parsing DNS message
000000: c7ff8180 00010003 00000000 046e6577 73036262 6302636f 02756b00 00010001    .... .... .... .new s.bb c.co .uk. ....
000020: c00c0005 00010000 02db0014 076e6577 73777777 03626263 036e6574 02756b00    .... .... .... .new swww .bbc .net .uk.
000040: c02c0001 00010000 00830004 d43af43b c02c0001 00010000 00830004 d43af43a    .,.. .... .... .:.; .,.. .... .... .:.:

30-12-2014 11:46:40.514 UTC Debug dnsparser.cpp:95: Parsing header at offset 0x0
30-12-2014 11:46:40.514 UTC Debug dnsparser.cpp:98: 1 questions, 3 answers, 0 authorities, 0 additional records
30-12-2014 11:46:40.514 UTC Debug dnsparser.cpp:103: Parsing question 1 at offset 0xc
30-12-2014 11:46:40.514 UTC Debug dnsparser.cpp:229: Parsed domain name = news.bbc.co.uk, encoded length = 16
30-12-2014 11:46:40.514 UTC Debug dnsparser.cpp:112: Parsing answer 1 at offset 0x20
30-12-2014 11:46:40.514 UTC Debug dnsparser.cpp:229: Parsed domain name = news.bbc.co.uk, encoded length = 2
30-12-2014 11:46:40.514 UTC Debug dnsparser.cpp:282: Resource Record NAME=news.bbc.co.uk TYPE=CNAME CLASS=IN TTL=731 RDLENGTH=20
30-12-2014 11:46:40.514 UTC Debug dnsparser.cpp:112: Parsing answer 2 at offset 0x40
30-12-2014 11:46:40.514 UTC Debug dnsparser.cpp:229: Parsed domain name = newswww.bbc.net.uk, encoded length = 2
30-12-2014 11:46:40.514 UTC Debug dnsparser.cpp:282: Resource Record NAME=newswww.bbc.net.uk TYPE=A CLASS=IN TTL=131 RDLENGTH=4
30-12-2014 11:46:40.514 UTC Debug dnsparser.cpp:287: Parse A record RDATA
30-12-2014 11:46:40.514 UTC Debug dnsparser.cpp:112: Parsing answer 3 at offset 0x50
30-12-2014 11:46:40.514 UTC Debug dnsparser.cpp:229: Parsed domain name = newswww.bbc.net.uk, encoded length = 2
30-12-2014 11:46:40.514 UTC Debug dnsparser.cpp:282: Resource Record NAME=newswww.bbc.net.uk TYPE=A CLASS=IN TTL=131 RDLENGTH=4
30-12-2014 11:46:40.514 UTC Debug dnsparser.cpp:287: Parse A record RDATA
30-12-2014 11:46:40.514 UTC Debug dnsparser.cpp:142: Answer records
news.bbc.co.uk          731     IN      CNAME
newswww.bbc.net.uk      131     IN      A       212.58.244.59
newswww.bbc.net.uk      131     IN      A       212.58.244.58

30-12-2014 11:46:40.514 UTC Debug dnsparser.cpp:143: Authority records

30-12-2014 11:46:40.514 UTC Debug dnsparser.cpp:144: Additional records

30-12-2014 11:46:40.514 UTC Debug dnscachedresolver.cpp:430: Ignoring CNAME record in DNS answer - only A, AAAA, NAPTR and SRV are supported
30-12-2014 11:46:40.514 UTC Debug dnscachedresolver.cpp:418: Ignoring A/AAAA record for newswww.bbc.net.uk (expecting domain news.bbc.co.uk)
30-12-2014 11:46:40.514 UTC Debug dnscachedresolver.cpp:418: Ignoring A/AAAA record for newswww.bbc.net.uk (expecting domain news.bbc.co.uk)
30-12-2014 11:46:40.514 UTC Debug dnscachedresolver.cpp:546: Adding news.bbc.co.uk to cache expiry list with expiry time of 1419940300
30-12-2014 11:46:40.514 UTC Debug dnscachedresolver.cpp:158: Received all query responses
30-12-2014 11:46:40.514 UTC Debug dnscachedresolver.cpp:179: Pulling 0 records from cache for news.bbc.co.uk A
30-12-2014 11:46:40.514 UTC Debug baseresolver.cpp:349: Found 0 A/AAAA records, randomizing
30-12-2014 11:46:40.514 UTC Debug baseresolver.cpp:408: Adding 0 servers from blacklist
30-12-2014 11:46:40.514 UTC Error connection_pool.cpp:217: Failed to resolve news.bbc.co.uk to an IP address - Not found (PJ_ENOTFOUND)
30-12-2014 11:46:40.514 UTC Debug sipresolver.cpp:85: SIPResolver::resolve for name news.bbc.co.uk, port 5052, transport 6, family 2
30-12-2014 11:46:40.514 UTC Debug baseresolver.cpp:501: Attempt to parse news.bbc.co.uk as IP address
30-12-2014 11:46:40.514 UTC Debug sipresolver.cpp:127: Port is specified
30-12-2014 11:46:40.514 UTC Debug sipresolver.cpp:295: Perform A/AAAA record lookup only, name = news.bbc.co.uk
30-12-2014 11:46:40.514 UTC Debug dnscachedresolver.cpp:179: Pulling 0 records from cache for news.bbc.co.uk A
30-12-2014 11:46:40.514 UTC Debug baseresolver.cpp:349: Found 0 A/AAAA records, randomizing
30-12-2014 11:46:40.514 UTC Debug baseresolver.cpp:408: Adding 0 servers from blacklist
30-12-2014 11:46:40.514 UTC Error connection_pool.cpp:217: Failed to resolve news.bbc.co.uk to an IP address - Not found (PJ_ENOTFOUND)
```