### PR TITLE
[Reviewer: Ellie] Further CNAME work

### DIFF
--- a/include/dnsrrecords.h
+++ b/include/dnsrrecords.h
@@ -306,4 +306,31 @@ private:
   const std::string _replacement;
 };
 
+class DnsCNAMERecord : public DnsRRecord
+{
+public:
+DnsCNAMERecord(const std::string& rrname, int ttl, const std::string& target) :
+    DnsRRecord(rrname, ns_t_cname, ns_c_in, ttl),
+    _target(target)
+  {
+  }
+
+  const std::string& target() const { return _target; }
+
+  virtual DnsCNAMERecord* clone()
+  {
+    return new DnsCNAMERecord(*this);
+  }
+
+  virtual std::string to_string() const
+  {
+    std::ostringstream oss;
+    oss << DnsRRecord::to_string() << " " << _target;
+    return oss.str();
+  }
+
+private:
+  const std::string _target;
+};
+
 #endif

--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -432,8 +432,20 @@ void DnsCachedResolver::dns_response(const std::string& domain,
         }
         else if (rr->rrtype() == ns_t_cname)
         {
+          // Store off the CNAME value, so that if we see subsequent A
+          // records for the pointed-to name, we'll recognise them.
+          //
+          // This only works for responses that contain a CNAME
+          // followed by other valid records, e.g.
+          // example.net CNAME example.com
+          // example.com A 10.0.0.1
+          //
+          // RFC 1034 mandates this format, so this should be fine.
+          
           canonical_domain = ((DnsCNAMERecord*)rr)->target();
-          LOG_DEBUG("CNAME record pointing at %s - treating this as equivalent to %s", canonical_domain.c_str(), domain.c_str());
+          LOG_DEBUG("CNAME record pointing at %s - treating this as equivalent to %s",
+                    canonical_domain.c_str(),
+                    domain.c_str());
         }
         else
         {

--- a/src/dnsparser.cpp
+++ b/src/dnsparser.cpp
@@ -350,10 +350,10 @@ int DnsParser::parse_rr(unsigned char* rptr, DnsRRecord*& rr)
   {
     LOG_DEBUG("Parse CNAME record RDATA");
     std::string target;
-    int target_len = parse_domain_name(rdata, target);
+    parse_domain_name(rdata, target);
     rr = new DnsCNAMERecord(rrname, ttl, target);
   }
-    else
+  else
   {
     rr = new DnsRRecord(rrname, rrtype, rrclass, ttl);
   }

--- a/src/dnsparser.cpp
+++ b/src/dnsparser.cpp
@@ -346,7 +346,14 @@ int DnsParser::parse_rr(unsigned char* rptr, DnsRRecord*& rr)
     }
     rr = (DnsRRecord*)new DnsNaptrRecord(rrname, ttl, order, preference, flags, services, regexp, replacement);
   }
-  else
+  else if ((rrclass == ns_c_in) && (rrtype == ns_t_cname))
+  {
+    LOG_DEBUG("Parse CNAME record RDATA");
+    std::string target;
+    int target_len = parse_domain_name(rdata, target);
+    rr = new DnsCNAMERecord(rrname, ttl, target);
+  }
+    else
   {
     rr = new DnsRRecord(rrname, rrtype, rrclass, ttl);
   }


### PR DESCRIPTION
Builds on #225 to fix #224 more fully (but I think it's a bit more controversial which is why I pulled #225 out separately). With this change, if we get a DNS answer that contains a CNAME pointing at Y, and then some A/AAAA records for Y, we'll use them. For example, this will work:

```
news.bbc.co.uk          599     IN      CNAME   newswww.bbc.net.uk
newswww.bbc.net.uk      300     IN      A       212.58.246.130
newswww.bbc.net.uk      300     IN      A       212.58.246.129
```

but 

```
newswww.bbc.net.uk      300     IN      A       212.58.246.130
newswww.bbc.net.uk      300     IN      A       212.58.246.129
news.bbc.co.uk          599     IN      CNAME   newswww.bbc.net.uk
```

will result in the two A records being thrown away with a LOG_WARNING. And if we just get:

`news.bbc.co.uk          599     IN      CNAME   newswww.bbc.net.uk`

we won't go away and do further A record lookups on the record pointed to by CNAME, we'll just report finding 0 A/AAAA records. Fortunately, the first style of answer is the only one I've seen, and I think RFC 1034 mandates it:

```
If recursive service is requested and available, the recursive response
to a query will be one of the following:

   - The answer to the query, possibly preface by one or more CNAME
     RRs that specify aliases encountered on the way to an answer.
```

so I think this is a good enough fix for the real world, and even in weird edge cases the behaviour will be reasonable (but not perfect).