### PR TITLE
[No review required] Fix unused variable warning

### DIFF
--- a/src/httpconnection.cpp
+++ b/src/httpconnection.cpp
@@ -239,7 +239,7 @@ HTTPCode HttpConnection::curl_code_to_http_code(CURL* curl, CURLcode code)
   case CURLE_OK:
   {
     long http_code = 0;
-    CURLcode rc = curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
     return http_code;
   // LCOV_EXCL_START
   }


### PR DESCRIPTION
Leaving as a pull request until I next do a cpp-common merge.