### PR TITLE
[Reviewer: Andy] Preserve old DNS records if the server doesn't respond

### DIFF
--- a/include/dnscachedresolver.h
+++ b/include/dnscachedresolver.h
@@ -173,6 +173,11 @@ private:
   void add_record_to_cache(DnsCacheEntryPtr ce, DnsRRecord* rr);
   void clear_cache_entry(DnsCacheEntryPtr ce);
 
+  DnsCacheEntryPtr common_query_logic(DnsChannel** channel,
+                                      const std::string& domain,
+                                      int dnstype);
+
+  
   DnsChannel* get_dns_channel();
   void wait_for_replies(DnsChannel* channel);
   static void destroy_dns_channel(DnsChannel* channel);

--- a/include/dnscachedresolver.h
+++ b/include/dnscachedresolver.h
@@ -195,6 +195,11 @@ private:
   /// @TODO - may make sense for this to be configured, or even different for
   /// each record type.
   static const int DEFAULT_NEGATIVE_CACHE_TTL = 300;
+
+  /// The time to keep records after they expire before freeing them.
+  /// This provides a grace period if a DNS server becomes temporarily
+  /// unresponsive, but doesn't risk leaking memory.
+  static const int EXTRA_INVALID_TIME = 300;
 };
 
 #endif

--- a/include/dnscachedresolver.h
+++ b/include/dnscachedresolver.h
@@ -173,10 +173,6 @@ private:
   void add_record_to_cache(DnsCacheEntryPtr ce, DnsRRecord* rr);
   void clear_cache_entry(DnsCacheEntryPtr ce);
 
-  DnsCacheEntryPtr common_query_logic(DnsChannel** channel,
-                                      const std::string& domain,
-                                      int dnstype);
-
   
   DnsChannel* get_dns_channel();
   void wait_for_replies(DnsChannel* channel);

--- a/include/dnscachedresolver.h
+++ b/include/dnscachedresolver.h
@@ -57,6 +57,7 @@ public:
   DnsResult(const std::string& domain, int dnstype, const std::vector<DnsRRecord*>& records, int ttl);
   DnsResult(const std::string& domain, int dnstype, int ttl);
   DnsResult(const DnsResult &obj);
+  DnsResult(DnsResult &&obj);
   ~DnsResult();
 
   const std::string& domain() const { return _domain; }

--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -118,6 +118,54 @@ DnsCachedResolver::~DnsCachedResolver()
   clear();
 }
 
+DnsCachedResolver::DnsCacheEntryPtr DnsCachedResolver::common_query_logic(DnsChannel** channel,
+                                                       const std::string& domain,
+                                                       int dnstype)
+{
+  LOG_VERBOSE("Check cache for %s type %d", domain.c_str(), dnstype);
+  DnsCacheEntryPtr ce = get_cache_entry(domain, dnstype);
+  time_t now = time(NULL);
+  bool do_query = false;
+  if (ce == NULL)
+  {
+    LOG_DEBUG("No entry found in cache");
+
+    // Create an empty record for this cache entry.
+    LOG_DEBUG("Create cache entry pending query");
+    ce = create_cache_entry(domain, dnstype);
+    do_query = true;
+  }
+  else if (ce->expires < now)
+  {
+    LOG_DEBUG("Expired entry found in cache");
+    do_query = true;
+  }
+  
+  if (do_query)
+  {
+    if (*channel == NULL)
+    {
+      // Get a DNS channel to issue any queries.
+      *channel = get_dns_channel();
+    }
+
+    if (*channel != NULL)
+    {
+      // DNS server is configured, so create a Transaction for the query
+      // and execute it.  Mark the entry as pending and take the lock on
+      // it before doing this to prevent any other threads sending the
+      // same query.
+      LOG_DEBUG("Create and execute DNS query transaction");
+      ce->pending_query = true;
+      pthread_mutex_lock(&ce->lock);
+      DnsTsx* tsx = new DnsTsx(*channel, domain, dnstype);
+      tsx->execute();
+    }
+  }
+
+  return ce;
+}
+
 DnsResult DnsCachedResolver::dns_query(const std::string& domain,
                                        int dnstype)
 {
@@ -128,35 +176,15 @@ DnsResult DnsCachedResolver::dns_query(const std::string& domain,
   // Expire any cache entries that have passed their TTL.
   expire_cache();
 
-  DnsCacheEntryPtr ce = get_cache_entry(domain, dnstype);
-
-  if (ce == NULL)
+  DnsCacheEntryPtr ce = common_query_logic(&channel, domain, dnstype);
+  
+  if (channel != NULL)
   {
-    // Create an empty record for this cache entry.
-    LOG_DEBUG("Create cache entry pending query");
-    ce = create_cache_entry(domain, dnstype);
-
-    // Get a DNS channel to issue any queries.
-    channel = get_dns_channel();
-
-    if (channel != NULL)
-    {
-      // DNS server is configured, so create a Transaction for the query and
-      // execute it.  Mark the entry as pending and take the lock on it
-      // before doing this to prevent any other threads sending the same
-      // query.
-      LOG_DEBUG("Create and execute DNS query transaction");
-      ce->pending_query = true;
-      pthread_mutex_lock(&ce->lock);
-      DnsTsx* tsx = new DnsTsx(channel, domain, dnstype);
-      tsx->execute();
-
-      LOG_DEBUG("Wait for query responses");
-      pthread_mutex_unlock(&_cache_lock);
-      wait_for_replies(channel);
-      pthread_mutex_lock(&_cache_lock);
-      LOG_DEBUG("Received all query responses");
-    }
+    LOG_DEBUG("Wait for query responses");
+    pthread_mutex_unlock(&_cache_lock);
+    wait_for_replies(channel);
+    pthread_mutex_lock(&_cache_lock);
+    LOG_DEBUG("Received all query responses");
   }
 
   // We should now have responses for everything (unless another thread was
@@ -173,10 +201,12 @@ DnsResult DnsCachedResolver::dns_query(const std::string& domain,
     pthread_mutex_lock(&_cache_lock);
   }
 
-  LOG_DEBUG("Pulling %d records from cache for %s %s",
+  LOG_DEBUG("Pulling %d records from cache for %s %s - expiring at %d (now %d)",
             ce->records.size(),
             ce->domain.c_str(),
-            DnsRRecord::rrtype_to_string(ce->dnstype).c_str());
+            DnsRRecord::rrtype_to_string(ce->dnstype).c_str(),
+            ce->expires,
+            time(NULL));
 
   DnsResult result(ce->domain,
                    ce->dnstype,
@@ -204,44 +234,7 @@ void DnsCachedResolver::dns_query(const std::vector<std::string>& domains,
        i != domains.end();
        ++i)
   {
-    LOG_VERBOSE("Check cache for %s type %d", (*i).c_str(), dnstype);
-    bool do_query = false;
-    if (get_cache_entry(*i, dnstype) == NULL)
-    {
-      LOG_DEBUG("No entry found in cache");
-
-      // Create an empty record for this cache entry.
-      LOG_DEBUG("Create cache entry pending query");
-      DnsCacheEntryPtr ce = create_cache_entry(*i, dnstype);
-      do_query = true;
-    }
-    else if (get_cache_entry(*i, dnstype)->expires < now)
-    {
-      LOG_DEBUG("Expired entry found in cache");
-      do_query = true;
-    }
-
-    if (do_query)
-    {
-      if (channel == NULL)
-      {
-        // Get a DNS channel to issue any queries.
-        channel = get_dns_channel();
-      }
-
-      if (channel != NULL)
-      {
-        // DNS server is configured, so create a Transaction for the query
-        // and execute it.  Mark the entry as pending and take the lock on
-        // it before doing this to prevent any other threads sending the
-        // same query.
-        LOG_DEBUG("Create and execute DNS query transaction");
-        ce->pending_query = true;
-        pthread_mutex_lock(&ce->lock);
-        DnsTsx* tsx = new DnsTsx(channel, *i, dnstype);
-        tsx->execute();
-      }
-    }
+      common_query_logic(&channel, *i, dnstype);
   }
 
   if (channel != NULL)
@@ -503,7 +496,17 @@ void DnsCachedResolver::dns_response(const std::string& domain,
     // that will return NXDOMAIN and not be cached.
     LOG_ERROR("Failed to retrieve record for %s: %s", domain.c_str(), ares_strerror(status));
 
-    ce->expires = 30 + time(NULL);
+    if (status == ARES_ENOTFOUND)
+    {
+      // NXDOMAIN, indicating that the DNS entry has been definitively removed
+      // (rather than a DNS server failure). Clear the cache for this
+      // entry.
+      clear_cache_entry(ce);
+    }
+    else
+    {
+      ce->expires = 30 + time(NULL);
+    }    
   }
 
   // If there were no records set cache a negative entry to prevent

--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -562,6 +562,14 @@ DnsCachedResolver::DnsCacheEntryPtr DnsCachedResolver::create_cache_entry(const 
 /// Adds the cache entry to the expiry list.
 void DnsCachedResolver::add_to_expiry_list(DnsCacheEntryPtr ce)
 {
+  int sensible_minimum = 1420070400;  // 1st January 2015
+  if ((ce->expires != 0) && (ce->expires < sensible_minimum))
+  {
+    LOG_WARNING("Cache expiry time is %d - expecting either 0 or an epoch timestamp (> %d)",
+                ce->expires,
+                sensible_minimum);
+  }
+  
   LOG_DEBUG("Adding %s to cache expiry list with deletion time of %d",
             ce->domain.c_str(),
             ce->expires + EXTRA_INVALID_TIME);

--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -79,6 +79,23 @@ DnsResult::DnsResult(const DnsResult &res) :
   }
 }
 
+DnsResult::DnsResult(DnsResult &&res) :
+  _domain(res._domain),
+  _dnstype(res._dnstype),
+  _records(),
+  _ttl(res._ttl)
+{
+  // Copy the records, then remove them from the source.
+  for (std::vector<DnsRRecord*>::const_iterator i = res._records.begin();
+       i != res._records.end();
+       ++i)
+  {
+    _records.push_back(*i);
+  }
+
+  res._records.clear();
+}
+
 DnsResult::DnsResult(const std::string& domain,
                      int dnstype,
                      int ttl) :
@@ -245,10 +262,10 @@ void DnsCachedResolver::dns_query(const std::vector<std::string>& domains,
                 ce->domain.c_str(),
                 DnsRRecord::rrtype_to_string(ce->dnstype).c_str());
 
-      results.push_back(DnsResult(ce->domain,
-                                  ce->dnstype,
-                                  ce->records,
-                                  ce->expires - time(NULL)));
+      results.push_back(std::move(DnsResult(ce->domain,
+                                            ce->dnstype,
+                                            ce->records,
+                                            ce->expires - time(NULL))));
     }
     else
     {


### PR DESCRIPTION
We discussed earlier how the existing code probably doesn't behave how it's meant to (because records expire on schedule, so by the time we've realised that the DNS server hasn't responded, we've deleted the old records). This should improve that.

The basic change is that we add 5 minutes to the expiry time when working out when to free records, so there's a period where it has expired (and we'll re-query the DNS server) but is still in memory (and so we can re-use it if the server is down).

I also spotted that the existing code sets `ce->expires = 30` but I think it should be an epoch timestamp - I added a check to `add_to_expiry_list` to ensure this.

I haven't tested this yet (or even compiled it), but wanted to get it out for review to check the approach. In particular, this is meant to preserve existing records indefinitely if the server stays down - do you think that's right?

I'll test by:
* checking that my new warning isn't triggered during normal operation
* checking that DNS records are re-queried and updated during normal operation
* checking that if a DNS server goes down, the DNS record is preserved in the cache
* checking that if the server comes back with a different DNS record, that's picked up
* checking that NXDOMAIN responses don't preserve the existing cached record
* checking that if a record doesn't exist at start-of-day, everything still works