### PR TITLE
Fixes for port to Ubuntu 14.04's tools chain (gcc 4.8.2)

### DIFF
--- a/include/dnscachedresolver.h
+++ b/include/dnscachedresolver.h
@@ -56,6 +56,7 @@ class DnsResult
 public:
   DnsResult(const std::string& domain, int dnstype, const std::vector<DnsRRecord*>& records, int ttl);
   DnsResult(const std::string& domain, int dnstype, int ttl);
+  DnsResult(const DnsResult &obj);
   ~DnsResult();
 
   const std::string& domain() const { return _domain; }

--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -55,13 +55,36 @@ DnsResult::DnsResult(const std::string& domain,
   _records(),
   _ttl(ttl)
 {
+  LOG_DEBUG("%x::DnsResult - records.size()=%d", this, records.size());
   // Clone the records to the result.
   for (std::vector<DnsRRecord*>::const_iterator i = records.begin();
        i != records.end();
        ++i)
   {
-    _records.push_back((*i)->clone());
+    DnsRRecord* clone=(*i)->clone();
+    LOG_DEBUG("%x::DnsResult - i=%x, clone=%x", this, i, clone);
+    _records.push_back(clone);
   }
+  LOG_DEBUG("%x::DnsResult - _records.size()=%d", this, _records.size());
+}
+
+DnsResult::DnsResult(const DnsResult &res) :
+  _domain(res._domain),
+  _dnstype(res._dnstype),
+  _records(),
+  _ttl(res._ttl)
+{
+  LOG_DEBUG("%x::DnsResult (copy) - res._records.size()=%d", this, res._records.size());
+  // Clone the records to the result.
+  for (std::vector<DnsRRecord*>::const_iterator i = res._records.begin();
+       i != res._records.end();
+       ++i)
+  {
+    DnsRRecord* clone=(*i)->clone();
+    LOG_DEBUG("%x::DnsResult (copy) - i=%x, clone=%x", this, i, clone);
+    _records.push_back(clone);
+  }
+  LOG_DEBUG("%x::DnsResult (copy) - _records.size()=%d", this, _records.size());
 }
 
 DnsResult::DnsResult(const std::string& domain,
@@ -72,15 +95,18 @@ DnsResult::DnsResult(const std::string& domain,
   _records(),
   _ttl(ttl)
 {
+    LOG_DEBUG("%x::DnsResult - no records", this);
 }
 
 DnsResult::~DnsResult()
 {
-  while (!_records.empty())
+  LOG_DEBUG("%x::~DnsResult - _records.size()=%d", this, _records.size());
+  for (int i=0; i < (int)_records.size(); i++ )
   {
-    delete _records.back();
-    _records.pop_back();
+    LOG_DEBUG("%x::~DnsResult - _records[%d]=%x", this, i, _records[i]);
+    delete _records[i];
   }
+  _records.clear();
 }
 
 DnsCachedResolver::DnsCachedResolver(const std::string& dns_server) :

--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -55,17 +55,13 @@ DnsResult::DnsResult(const std::string& domain,
   _records(),
   _ttl(ttl)
 {
-  LOG_DEBUG("%x::DnsResult - records.size()=%d", this, records.size());
   // Clone the records to the result.
   for (std::vector<DnsRRecord*>::const_iterator i = records.begin();
        i != records.end();
        ++i)
   {
-    DnsRRecord* clone=(*i)->clone();
-    LOG_DEBUG("%x::DnsResult - i=%x, clone=%x", this, i, clone);
-    _records.push_back(clone);
+    _records.push_back((*i)->clone());
   }
-  LOG_DEBUG("%x::DnsResult - _records.size()=%d", this, _records.size());
 }
 
 DnsResult::DnsResult(const DnsResult &res) :
@@ -74,17 +70,13 @@ DnsResult::DnsResult(const DnsResult &res) :
   _records(),
   _ttl(res._ttl)
 {
-  LOG_DEBUG("%x::DnsResult (copy) - res._records.size()=%d", this, res._records.size());
   // Clone the records to the result.
   for (std::vector<DnsRRecord*>::const_iterator i = res._records.begin();
        i != res._records.end();
        ++i)
   {
-    DnsRRecord* clone=(*i)->clone();
-    LOG_DEBUG("%x::DnsResult (copy) - i=%x, clone=%x", this, i, clone);
-    _records.push_back(clone);
+    _records.push_back((*i)->clone());
   }
-  LOG_DEBUG("%x::DnsResult (copy) - _records.size()=%d", this, _records.size());
 }
 
 DnsResult::DnsResult(const std::string& domain,
@@ -95,18 +87,15 @@ DnsResult::DnsResult(const std::string& domain,
   _records(),
   _ttl(ttl)
 {
-    LOG_DEBUG("%x::DnsResult - no records", this);
 }
 
 DnsResult::~DnsResult()
 {
-  LOG_DEBUG("%x::~DnsResult - _records.size()=%d", this, _records.size());
-  for (int i=0; i < (int)_records.size(); i++ )
+  while (!_records.empty())
   {
-    LOG_DEBUG("%x::~DnsResult - _records[%d]=%x", this, i, _records[i]);
-    delete _records[i];
+    delete _records.back();
+    _records.pop_back();
   }
-  _records.clear();
 }
 
 DnsCachedResolver::DnsCachedResolver(const std::string& dns_server) :

--- a/test_utils/test_interposer.cpp
+++ b/test_utils/test_interposer.cpp
@@ -305,6 +305,10 @@ int pthread_cond_timedwait(pthread_cond_t* cond,
   if (!real_pthread_cond_timedwait)
   {
     real_pthread_cond_timedwait = (pthread_cond_timedwait_func_t)(intptr_t)dlvsym(RTLD_NEXT, "pthread_cond_timedwait", "GLIBC_2.3.2");
+    if (!real_pthread_cond_timedwait)
+    {
+      real_pthread_cond_timedwait = (pthread_cond_timedwait_func_t)(intptr_t)dlvsym(RTLD_NEXT, "pthread_cond_timedwait", "GLIBC_2.4.0");
+    }
   }
 
   // Subtract our fake time and add the real time, this means the


### PR DESCRIPTION
I'm guessing that it was just luck that the code generated by Ubuntu 12.04's tools chain (gcc 4.6.3) got away without having a copy constructor for DnsResult, since the shallow copy performed by the default copy constructor for DnsResult causes a double delete of the pointers stored in the _records vector. Regardless, the double delete causes a crash (sig 11) on loads built with Ubuntu 14.0.4's gcc tool chain. This error prevents an Ubuntu 14.04 built sprout from ever completing its initialization causing an endless crash loop.

Also, I had to add support in the test_iterposer for glibc 2.4.0.