### PR TITLE
[Reviewer: Andy] Interface for MemcachedConfig code

### DIFF
--- a/include/memcached_config.h
+++ b/include/memcached_config.h
@@ -38,6 +38,9 @@
 #ifndef MEMCACHED_CONFIG_H_
 #define MEMCACHED_CONFIG_H_
 
+#include <vector>
+#include <string>
+
 
 /// Structure holding memcached configuration parameters.
 struct MemcachedConfig
@@ -77,12 +80,12 @@ public:
   virtual bool read_config(MemcachedConfig& config) = 0;
 
   /// Virtual destructor.
-  virtual ~MemcachedConfigReader();
+  virtual ~MemcachedConfigReader() {};
 };
 
 
 /// Class that reads the memcached config from a file on disk.
-class MemcachedConfigFileReader
+class MemcachedConfigFileReader : public MemcachedConfigReader
 {
 public:
   /// Constructor

--- a/include/memcached_config.h
+++ b/include/memcached_config.h
@@ -1,0 +1,103 @@
+/**
+ * @file memcached_config.h Classes to handle reading and parsing memcached
+ * configuration.
+ *
+ * Project Clearwater - IMS in the cloud.
+ * Copyright (C) 2015  Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#ifndef MEMCACHED_CONFIG_H_
+#define MEMCACHED_CONFIG_H_
+
+
+/// Structure holding memcached configuration parameters.
+struct MemcachedConfig
+{
+  /// The servers in the cluster. Each entry is an IP address and port
+  /// combination (e.g.  "192.168.0.1:11211" or "[1111:2222::]:55555").
+  std::vector<std::string> servers;
+
+  /// During a scale-up or scale-down operation, the servers that will be in
+  /// the cluster once the operation has completed. Empty if no scale-up/down
+  /// is in progress.
+  ///
+  /// Each entry is an IP address and port combination.
+  std::vector<std::string> new_servers;
+
+  /// The expiry time (in seconds) of tombstone records that are written when
+  /// data is deleted from memcached.
+  ///
+  /// 0 means that tombstones are not used. Deleted data is simply removed.
+  int tombstone_lifetime;
+
+  /// Default constructor.
+  MemcachedConfig();
+};
+
+
+/// Interface that all memcached config readers must implement.
+class MemcachedConfigReader
+{
+public:
+  /// Read the current memcached config.
+  ///
+  /// @return       - True if the config was read successfully. False otherwise.
+  ///
+  /// @param config - (out) The config that was read.  This is only valid if
+  ///                 the function returns true.
+  virtual bool read_config(MemcachedConfig& config) = 0;
+
+  /// Virtual destructor.
+  virtual ~MemcachedConfigReader();
+};
+
+
+/// Class that reads the memcached config from a file on disk.
+class MemcachedConfigFileReader
+{
+public:
+  /// Constructor
+  ///
+  /// @param filename - The full filename (path and name) to read the config
+  /// from.
+  MemcachedConfigFileReader(const std::string& filename);
+
+  ~MemcachedConfigFileReader();
+
+  bool read_config(MemcachedConfig& config);
+
+private:
+  std::string _filename;
+};
+
+#endif
+

--- a/include/memcachedstore.h
+++ b/include/memcachedstore.h
@@ -49,6 +49,7 @@ extern "C" {
 }
 
 #include "store.h"
+#include "memcached_config.h"
 #include "memcachedstoreview.h"
 #include "updater.h"
 #include "sas.h"
@@ -71,8 +72,7 @@ public:
   /// Flags that the store should use a new view of the memcached cluster to
   /// distribute data.  Note that this is public because it is called from
   /// the MemcachedStoreUpdater class and from UT classes.
-  void new_view(const std::vector<std::string>& servers,
-                const std::vector<std::string>& new_servers);
+  void new_view(const MemcachedConfig& config);
 
   bool has_servers() { return (_servers.size() > 0); };
 
@@ -207,7 +207,7 @@ private:
   // (This is only used during normal running - at start-of-day we use
   // a fixed 10ms time, to start up as quickly as possible).
   unsigned int _max_connect_latency_ms;
-  
+
   // The set of read and write replicas for each vbucket.
   std::vector<std::vector<std::string> > _read_replicas;
   std::vector<std::vector<std::string> > _write_replicas;
@@ -244,6 +244,9 @@ private:
   //
   // Atomic as it is set by the updater thread and read by application threads.
   std::atomic<int> _tombstone_lifetime;
+
+  // Object used to read the memcached config.
+  MemcachedConfigReader* _config_reader;
 };
 
 #endif

--- a/include/memcachedstore.h
+++ b/include/memcachedstore.h
@@ -107,14 +107,15 @@ public:
   /// Updates the cluster settings
   void update_config();
 
-private:
-  // Constructor. This is private to prevent the BaseMemcachedStore from being
+protected:
+  // Constructor. This is protected to prevent the BaseMemcachedStore from being
   // instantiated directly.
   BaseMemcachedStore(bool binary,
                      MemcachedConfigReader* config_reader,
                      CommunicationMonitor* comm_monitor,
                      Alarm* vbucket_alarm);
 
+private:
   // A copy of this structure is maintained for each worker thread, as
   // thread local data.
   typedef struct connection

--- a/include/memcachedstoreview.h
+++ b/include/memcachedstoreview.h
@@ -50,9 +50,8 @@ public:
   MemcachedStoreView(int vbuckets, int replicas);
   ~MemcachedStoreView();
 
-  /// Updates the view for new current and target server lists.
-  void update(const std::vector<std::string>& servers,
-              const std::vector<std::string>& new_servers);
+  /// Updates the view based on new configuration.
+  void update(const MemcachedConfig& config);
 
   /// Returns the current server list.
   const std::vector<std::string>& servers() const { return _servers; };

--- a/include/memcachedstoreview.h
+++ b/include/memcachedstoreview.h
@@ -42,6 +42,8 @@
 #include <string>
 #include <vector>
 
+#include "memcached_config.h"
+
 /// Tracks the current view of the underlying memcached cluster, including
 /// calculating the server list and the replica configurations.
 class MemcachedStoreView

--- a/src/memcached_config.cpp
+++ b/src/memcached_config.cpp
@@ -1,0 +1,130 @@
+/**
+ * @file memcached_config.cpp Classes to handle reading and parsing memcached
+ * config.
+ *
+ * Project Clearwater - IMS in the cloud.
+ * Copyright (C) 2015  Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include <fstream>
+
+#include "log.h"
+#include "utils.h"
+#include "memcached_config.h"
+
+/// The default lifetime (in seconds) of tombstones written to memcached.
+static const int DEFAULT_TOMBSTONE_LIFETIME = 0;
+
+MemcachedConfig::MemcachedConfig() :
+  servers(), new_servers(), tombstone_lifetime(DEFAULT_TOMBSTONE_LIFETIME)
+{}
+
+
+MemcachedConfigFileReader::MemcachedConfigFileReader(const std::string& filename) :
+  _filename(filename)
+{}
+
+MemcachedConfigFileReader::~MemcachedConfigFileReader() {}
+
+bool MemcachedConfigFileReader::read_config(MemcachedConfig& config)
+{
+  config.servers.clear();
+  config.new_servers.clear();
+  config.tombstone_lifetime = DEFAULT_TOMBSTONE_LIFETIME;
+
+  std::ifstream f(_filename);
+
+  if (f.is_open())
+  {
+    LOG_STATUS("Reloading memcached configuration from '%s'", _filename.c_str());
+
+    while (f.good())
+    {
+      std::string line;
+      getline(f, line);
+
+      if (line.length() > 0)
+      {
+        // Read a non-blank line.
+        std::vector<std::string> tokens;
+        Utils::split_string(line, '=', tokens, 0, true);
+
+        if (tokens.size() != 2)
+        {
+          LOG_ERROR("Malformed config file (got bad line: '%s')",
+                    line.c_str());
+          return false;
+        }
+
+        LOG_STATUS(" %s=%s", tokens[0].c_str(), tokens[1].c_str());
+
+        if (tokens[0] == "servers")
+        {
+          // Found line defining servers.
+          Utils::split_string(tokens[1], ',', config.servers, 0, true);
+        }
+        else if (tokens[0] == "new_servers")
+        {
+          // Found line defining new servers.
+          Utils::split_string(tokens[1], ',', config.new_servers, 0, true);
+        }
+        else if (tokens[0] == "tombstone_lifetime")
+        {
+          // Read the tombstone lifetime from the config file. Check it is
+          // actually a valid integer before committing to the member variable
+          // (atoi stops when it reaches non-numeric characters).
+          config.tombstone_lifetime = atoi(tokens[1].c_str());
+
+          if (std::to_string(config.tombstone_lifetime) != tokens[1])
+          {
+            LOG_ERROR("Config contained an invalid tombstone_lifetime line:\n%s",
+                      line.c_str());
+            return false;
+          }
+        }
+      }
+    }
+  }
+  else
+  {
+    LOG_ERROR("Failed to open '%s'", _filename.c_str());
+    return false;
+  }
+
+  if (config.servers.size() < 0)
+  {
+    LOG_ERROR("'%s' does not contain a valid set of servers", _filename.c_str());
+    return false;
+  }
+
+  return true;
+}

--- a/src/memcached_config.cpp
+++ b/src/memcached_config.cpp
@@ -63,7 +63,7 @@ bool MemcachedConfigFileReader::read_config(MemcachedConfig& config)
 
   std::ifstream f(_filename);
 
-  if (f.is_open())
+  if (f.is_open() && f.good())
   {
     LOG_STATUS("Reloading memcached configuration from '%s'", _filename.c_str());
 
@@ -71,6 +71,8 @@ bool MemcachedConfigFileReader::read_config(MemcachedConfig& config)
     {
       std::string line;
       getline(f, line);
+
+      LOG_DEBUG("Got line: %s", line.c_str());
 
       if (line.length() > 0)
       {
@@ -120,7 +122,7 @@ bool MemcachedConfigFileReader::read_config(MemcachedConfig& config)
     return false;
   }
 
-  if (config.servers.size() < 0)
+  if (config.servers.size() == 0)
   {
     LOG_ERROR("'%s' does not contain a valid set of servers", _filename.c_str());
     return false;

--- a/src/memcachedstoreview.cpp
+++ b/src/memcachedstoreview.cpp
@@ -68,21 +68,20 @@ std::vector<std::string> MemcachedStoreView::merge_servers(const std::vector<std
   std::set<std::string> merged_servers;
   merged_servers.insert(list1.begin(), list1.end());
   merged_servers.insert(list2.begin(), list2.end());
-  
+
   std::vector<std::string> ret(merged_servers.begin(), merged_servers.end());
   return ret;
 }
 
 /// Updates the view for new current and target server lists.
-void MemcachedStoreView::update(const std::vector<std::string>& servers,
-                                const std::vector<std::string>& new_servers)
+void MemcachedStoreView::update(const MemcachedConfig& config)
 {
   // Generate the appropriate rings and the resulting vbuckets arrays.
-  if (new_servers.empty())
+  if (config.new_servers.empty())
   {
     // Stable configuration.
-    LOG_DEBUG("View is stable with %d nodes", servers.size());
-    _servers = servers;
+    LOG_DEBUG("View is stable with %d nodes", config.servers.size());
+    _servers = config.servers;
 
     // Only need to generate a single ring.
     Ring ring(_vbuckets);
@@ -103,24 +102,26 @@ void MemcachedStoreView::update(const std::vector<std::string>& servers,
       for (size_t jj = 0; jj < server_indexes.size(); jj++)
       {
         int idx = server_indexes[jj];
-        _read_set[ii].push_back(servers[idx]);
+        _read_set[ii].push_back(config.servers[idx]);
       }
       _write_set[ii] = _read_set[ii];
     }
   }
   else
   {
-    LOG_DEBUG("Cluster is moving from %d nodes to %d nodes", servers.size(), new_servers.size());
+    LOG_DEBUG("Cluster is moving from %d nodes to %d nodes",
+              config.servers.size(),
+              config.new_servers.size());
 
     // _servers should contain all the servers we might want to store
     // data on, so combine the old and new server lists, removing any overlap.
-    _servers = merge_servers(servers, new_servers);
+    _servers = merge_servers(config.servers, config.new_servers);
 
     // Calculate the two rings needed to generate the vbucket replica sets
     Ring c_ring(_vbuckets);
-    c_ring.update(servers.size());
+    c_ring.update(config.servers.size());
     Ring n_ring(_vbuckets);
-    n_ring.update(new_servers.size());
+    n_ring.update(config.new_servers.size());
 
     for (int ii = 0; ii < _vbuckets; ++ii)
     {
@@ -138,7 +139,7 @@ void MemcachedStoreView::update(const std::vector<std::string>& servers,
       _read_set[ii].clear();
       _write_set[ii].clear();
 
-      std::string initial_server = servers[c_nodes[0]];
+      std::string initial_server = config.servers[c_nodes[0]];
       _read_set[ii].push_back(initial_server);
       _write_set[ii].push_back(initial_server);
       in_set[initial_server] = true;
@@ -150,7 +151,7 @@ void MemcachedStoreView::update(const std::vector<std::string>& servers,
       // all nodes in the new replica set will have the full set of data.
       for (int jj = 0; jj < _replicas; ++jj)
       {
-        std::string server = new_servers[n_nodes[jj]];
+        std::string server = config.new_servers[n_nodes[jj]];
         if (!in_set[server])
         {
           _read_set[ii].push_back(server);
@@ -165,7 +166,7 @@ void MemcachedStoreView::update(const std::vector<std::string>& servers,
       // not already in the set.
       for (int jj = 1; jj < _replicas; ++jj)
       {
-        std::string server = servers[c_nodes[jj]];
+        std::string server = config.servers[c_nodes[jj]];
         if (!in_set[server])
         {
           _read_set[ii].push_back(server);


### PR DESCRIPTION
This change defines the interface to the memcached config reading code I am writing. Please could you take a look at it and let me know if this works for you? 

Note that I have defined separate classed for `MemcachedConfigReader` (the interface) and `MemcachedConfigFileReader` (the implementation). I think this is cleaner and encourages looser coupling between the classes that use the config. For the same reason, I have also taken your suggestion of changing `MemcachedStoreView::update` to take a config object. 