### PR TITLE
[Reviewer: Andy] Fix deadlock seen when two threads look up the same nam...

### DIFF
--- a/include/dnscachedresolver.h
+++ b/include/dnscachedresolver.h
@@ -125,7 +125,6 @@ private:
 
   struct DnsCacheEntry
   {
-    pthread_mutex_t lock;
     bool pending_query;
     std::string domain;
     int dnstype;
@@ -190,6 +189,7 @@ private:
   /// The cache itself is held in a map indexed on RRTYPE and RRNAME, and a
   /// multimap indexed on expiry time.
   pthread_mutex_t _cache_lock;
+  pthread_cond_t _got_reply_cond;
   DnsCache _cache;
 
   // Expiry is done efficiently by storing pointers to cache entries in a

--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -116,7 +116,8 @@ DnsResult::~DnsResult()
 }
 
 DnsCachedResolver::DnsCachedResolver(const std::vector<std::string>& dns_servers) :
-  _cache_lock(PTHREAD_MUTEX_INITIALIZER),
+  _cache_lock(PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP),
+  _got_reply_cond(PTHREAD_COND_INITIALIZER),
   _cache()
 {
   // Initialize the ares library.  This might have already been done by curl
@@ -145,6 +146,7 @@ DnsCachedResolver::DnsCachedResolver(const std::vector<std::string>& dns_servers
 
 DnsCachedResolver::DnsCachedResolver(const std::string& dns_server) :
   _cache_lock(PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP),
+  _got_reply_cond(PTHREAD_COND_INITIALIZER),
   _cache()
 {
   LOG_STATUS("Creating Cached Resolver using server %s", dns_server.c_str());
@@ -245,7 +247,6 @@ void DnsCachedResolver::dns_query(const std::vector<std::string>& domains,
         // same query.
         LOG_DEBUG("Create and execute DNS query transaction");
         ce->pending_query = true;
-        pthread_mutex_lock(&ce->lock);
         DnsTsx* tsx = new DnsTsx(channel, *domain, dnstype);
         tsx->execute();
       }
@@ -271,21 +272,17 @@ void DnsCachedResolver::dns_query(const std::vector<std::string>& domains,
   {
     DnsCacheEntryPtr ce = get_cache_entry(*i, dnstype);
 
+    // If we found the cache entry, check whether it is still pending a query.
+    while ((ce != NULL) && (ce->pending_query))
+    {
+      // We must release the global lock and let the other thread finish
+      // the query.
+      pthread_cond_wait(&_got_reply_cond, &_cache_lock);
+      ce = get_cache_entry(*i, dnstype);
+    }
+
     if (ce != NULL)
     {
-      // Found the cache entry, so check whether it is still pending a query.
-      if (ce->pending_query)
-      {
-        // We must release the global lock and let the other thread finish
-        // the query.
-        // @TODO - may need to do something with reference counting of the
-        // DnsCacheEntry to make this watertight.
-        pthread_mutex_unlock(&_cache_lock);
-        pthread_mutex_lock(&ce->lock);
-        pthread_mutex_unlock(&ce->lock);
-        pthread_mutex_lock(&_cache_lock);
-      }
-
       // Can now pull the information from the cache entry in to the results.
       LOG_DEBUG("Pulling %d records from cache for %s %s",
                 ce->records.size(),
@@ -561,7 +558,10 @@ void DnsCachedResolver::dns_response(const std::string& domain,
   // Flag that the cache entry is no longer pending a query, and release
   // the lock on the cache entry.
   ce->pending_query = false;
-  pthread_mutex_unlock(&ce->lock);
+
+  // Another thread may be waiting for our query to finish, so
+  // broadcast a signal to wake it up.
+  pthread_cond_signal(&_got_reply_cond);
 
   pthread_mutex_unlock(&_cache_lock);
 }
@@ -589,7 +589,6 @@ DnsCachedResolver::DnsCacheEntryPtr DnsCachedResolver::get_cache_entry(const std
 DnsCachedResolver::DnsCacheEntryPtr DnsCachedResolver::create_cache_entry(const std::string& domain, int dnstype)
 {
   DnsCacheEntryPtr ce = DnsCacheEntryPtr(new DnsCacheEntry());
-  pthread_mutex_init(&ce->lock, NULL);
   ce->domain = domain;
   ce->dnstype = dnstype;
   ce->expires = 0;
@@ -821,7 +820,7 @@ void DnsCachedResolver::DnsTsx::ares_callback(void* arg,
 
 void DnsCachedResolver::DnsTsx::ares_callback(int status, int timeouts, unsigned char* abuf, int alen)
 {
-  --_channel->pending_queries;
   _channel->resolver->dns_response(_domain, _dnstype, status, abuf, alen);
+  --_channel->pending_queries;
 }
 


### PR DESCRIPTION
...e and take _cache_lock and ce->lock in different orders

There's a deadlock in DnsCacheResolver, introduced/worsened by https://github.com/Metaswitch/cpp-common/pull/231/files, which is reasonably easy to reproduce when two threads are trying to look up the same name at the same time (e.g. if a DNS server is being slow).

I’ve fixed this by removing the per-DnsCacheEntryPtr lock and just relying on the cache lock. To ensure this is safe, I've:
* tried to make sure that `get_cache_entry` and `create_cache_entry` are only called when the cache lock is held
* tried to make sure that any DnsCacheEntryPtrs I get while holding the lock are not used after releasing that lock
 
(as a corollary of those two, all modifications to a DnsCacheEntryPtr happen while the cache lock is held)

There was one bit where we released the cache lock, and relied on being able to take the DnsCacheEntryPtr lock as a way to check that another thread had finished doing work. I’ve replaced that with a condition variable (and recognised that waiting on a condition variable implicitly releases and re-takes the lock, so treated any previously-owned DnsCacheEntryPtrs as invalid and looked them up again).

I've tested by pointing a Sprout node at a nonexistent DNS server (so that it always times out) and sending 50 simultaneous REGISTERs into Sprout (so that 50 threads try and look up hs.homedomain at once). That reliably deadlocks on master, but doesn't do so with this fix.

(I also spotted that I changed one constructor to initialize a recursive mutex but not the other - I've corrected that while in the area.)