### PR TITLE
[Reviewer: Alex] Fix HttpConnection segfault (and other potential ones)

### DIFF
--- a/src/cassandra_store.cpp
+++ b/src/cassandra_store.cpp
@@ -261,6 +261,8 @@ Store::~Store()
   // (as the pool stores a pointer to the store). Make sure this is the case.
   stop();
   wait_stopped();
+  
+  pthread_key_delete(_thread_local);
 }
 
 

--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -187,6 +187,7 @@ DnsCachedResolver::~DnsCachedResolver()
     pthread_setspecific(_thread_local, NULL);
     destroy_dns_channel(channel);
   }
+  pthread_key_delete(_thread_local);
 
   // Clear the cache.
   clear();

--- a/src/exception_handler.cpp
+++ b/src/exception_handler.cpp
@@ -57,6 +57,7 @@ ExceptionHandler::ExceptionHandler(int ttl,
 
 ExceptionHandler::~ExceptionHandler()
 {
+  pthread_key_delete(_jmp_buf);
 }
 
 void ExceptionHandler::handle_exception()

--- a/src/httpconnection.cpp
+++ b/src/httpconnection.cpp
@@ -179,6 +179,9 @@ HttpConnection::~HttpConnection()
     delete _statistic;
     _statistic = NULL;
   }
+
+  pthread_key_delete(_curl_thread_local);
+  pthread_key_delete(_uuid_thread_local);
 }
 
 /// Get the thread-local curl handle if it exists, and create it if not.

--- a/src/memcachedstore.cpp
+++ b/src/memcachedstore.cpp
@@ -127,6 +127,8 @@ BaseMemcachedStore::~BaseMemcachedStore()
   pthread_mutex_destroy(&_vbucket_comm_lock);
 
   pthread_rwlock_destroy(&_view_lock);
+  
+  pthread_key_delete(_thread_local);
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/Metaswitch/sprout/issues/621. See my comment in there for why.

I've grepped cpp-common, sprout, chronos, ralf and homestead for pthread_key_create calls - only cpp-common and sprout had any (sprout just had one in enumservice.cpp, which I'll fix up without review once this is OKed).