### PR TITLE
Reviewer AMC: Expose Time AVP values

### DIFF
--- a/include/diameterstack.h
+++ b/include/diameterstack.h
@@ -234,6 +234,13 @@ public:
     len = hdr->avp_value->os.len;
     return hdr->avp_value->os.data;
   }
+  inline time_t val_time() const
+  {
+    time_t time;
+    struct avp_hdr* hdr = avp_hdr();
+    fd_dictfct_Time_interpret(hdr->avp_value, &time);
+    return time;
+  }
   inline int32_t val_i32() const {return avp_hdr()->avp_value->i32;}
   inline int32_t val_i64() const {return avp_hdr()->avp_value->i64;}
   inline int32_t val_u32() const {return avp_hdr()->avp_value->u32;}


### PR DESCRIPTION
Hi Andy,

Can you review this change to the diameter stack to expose freeDiameter's fd_dictfct_Time_interpret method for creating a time_t object from a Time AVP?

Thanks,
Graeme