### PR TITLE
[Reviewer: Ellie] Fix log to use correct variables

### DIFF
--- a/src/zmq_lvc.cpp
+++ b/src/zmq_lvc.cpp
@@ -282,7 +282,7 @@ void LastValueCache::replay_cache(void *entry)
     return;
   }
 
-  LOG_DEBUG("Replaying cache for entry %p (length: %d)", cache_record, entry, cache_record->size());
+  LOG_DEBUG("Replaying cache for entry %p (length: %d)", entry, cache_record->size());
   std::vector<zmq_msg_t *>::iterator it;
   for (std::vector<zmq_msg_t *>::iterator it = cache_record->begin();
        it != cache_record->end();


### PR DESCRIPTION
Spotted some logs like:

`09-04-2015 16:54:05.748 UTC Debug zmq_lvc.cpp:285: Replaying cache for entry 0x1ded608 (length: 31341008)`

I realised that the very high length was because we were passing a pointer rather than the vector size. This fixes that.