### PR TITLE
[Reviewer: Alex] Fixes to the load monitor for UTability

### DIFF
--- a/src/load_monitor.cpp
+++ b/src/load_monitor.cpp
@@ -111,7 +111,7 @@ LoadMonitor::LoadMonitor(int init_target_latency, int max_bucket_size,
   pending_count = 0;
   max_pending_count = 0;
   target_latency = init_target_latency;
-  smoothed_latency = 0;
+  smoothed_latency = init_target_latency;
   adjust_count = 0;
   clock_gettime(CLOCK_MONOTONIC_COARSE, &last_adjustment_time);
   min_token_rate = init_min_token_rate;
@@ -204,7 +204,7 @@ void LoadMonitor::request_complete(int latency)
           new_rate = min_token_rate;
         }
         bucket.update_rate(new_rate);
-        LOG_STATUS("Maximum incoming request rate/second is now %f "
+        LOG_STATUS("Maximum incoming request rate/second decreased to %f "
                    "(based on a smoothed mean latency of %d and %d upstream overload responses)",
                    bucket.rate,
                    smoothed_latency,
@@ -214,7 +214,7 @@ void LoadMonitor::request_complete(int latency)
       {
         float new_rate = bucket.rate + (-1 * err * bucket.max_size * INCREASE_FACTOR);
         bucket.update_rate(new_rate);
-        LOG_STATUS("Maximum incoming request rate/second is now %f "
+        LOG_STATUS("Maximum incoming request rate/second increased to %f "
                    "(based on a smoothed mean latency of %d and %d upstream overload responses)",
                    bucket.rate,
                    smoothed_latency,

--- a/test_utils/test_interposer.cpp
+++ b/test_utils/test_interposer.cpp
@@ -62,7 +62,7 @@ static bool completely_control_time = false;
 
 /// When completely controlling time, these store the time at which the test
 /// scripts took control. Protected by time_lock.
-static const clockid_t supported_clock_ids[] = {CLOCK_REALTIME, CLOCK_MONOTONIC};
+static const clockid_t supported_clock_ids[] = {CLOCK_REALTIME, CLOCK_MONOTONIC, CLOCK_MONOTONIC_COARSE};
 static std::map<clockid_t, struct timespec> abs_timespecs;
 static time_t abs_time;
 


### PR DESCRIPTION
Follow-on to https://github.com/Metaswitch/cpp-common/pull/281.

Trivial changes - allowed CLOCK_MONOTONIC_COARSE to be controlled by the UT time controls, clarified some logs.

More interesting change - smoothed_latency started at 0. This meant that if your first 20 requests are all dead-on your target latency of 100ms, the smoothed latency is actually about 92ms, and your bucket rate increases. I think that's wrong, so I've defaulted it to target_latency.