### PR TITLE
[Reviewer: Ellie] sto1264 changes

### DIFF
--- a/include/sasevent.h
+++ b/include/sasevent.h
@@ -42,7 +42,10 @@
 
 namespace SASEvent {
 
-  const std::string CURRENT_RESOURCE_BUNDLE = "org.projectclearwater.20150401";
+  const std::string CURRENT_RESOURCE_BUNDLE_DATESTAMP = "20150401";
+  const std::string RESOURCE_BUNDLE_NAME = "org.projectclearwater";
+  const std::string CURRENT_RESOURCE_BUNDLE =
+                 RESOURCE_BUNDLE_NAME + "." + CURRENT_RESOURCE_BUNDLE_DATESTAMP;
 
   // Name of the HTTP header we use to correlate the client and server in SAS.
   const std::string HTTP_BRANCH_HEADER_NAME = "X-SAS-HTTP-Branch-ID";

--- a/include/sasevent.h
+++ b/include/sasevent.h
@@ -84,6 +84,7 @@ namespace SASEvent {
   const int GEMINI_BASE = 0x850000;
   const int MMTEL_BASE = 0x860000;
   const int MANGELWURZEL_BASE = 0x870000;
+  const int CEDAR_BASE = 0x880000;
 
   //----------------------------------------------------------------------------
   // Common events and protocol flows.

--- a/src/diameterstack.cpp
+++ b/src/diameterstack.cpp
@@ -828,9 +828,9 @@ void Stack::fd_sas_log_diameter_message(enum fd_hook_type type,
 
   // Now construct a correlating marker based on the diameter session ID.
   struct session* sess;
-  int is_new;
+  int dummy_is_new;
 
-  if (fd_msg_sess_get(fd_g_config->cnf_dict, msg, &sess, &is_new) == 0)
+  if (fd_msg_sess_get(fd_g_config->cnf_dict, msg, &sess, &dummy_is_new) == 0)
   {
     os0_t session_id;
     size_t session_id_len;

--- a/src/diameterstack.cpp
+++ b/src/diameterstack.cpp
@@ -45,9 +45,9 @@ Stack* Stack::INSTANCE = &DEFAULT_INSTANCE;
 Stack Stack::DEFAULT_INSTANCE;
 struct fd_hook_data_hdl* Stack::_sas_cb_data_hdl = NULL;
 
-Stack::Stack() : _initialized(false), 
-                 _callback_handler(NULL), 
-                 _callback_fallback_handler(NULL), 
+Stack::Stack() : _initialized(false),
+                 _callback_handler(NULL),
+                 _callback_fallback_handler(NULL),
                  _exception_handler(NULL),
                  _comm_monitor(NULL),
                  _realm_counter(NULL),
@@ -231,7 +231,7 @@ void Stack::fd_error_hook_cb(enum fd_hook_type type,
            dest_realm.c_str());
 
   // Increment routing error stats if they're supported
-  if ((_realm_counter != NULL) && 
+  if ((_realm_counter != NULL) &&
       (strcmp(fd_g_config->cnf_diamrlm, dest_realm.c_str()) != 0))
   {
     _realm_counter->increment();
@@ -454,7 +454,7 @@ int Stack::request_callback_fn(struct msg** req,
   }
   CW_END
 
-  // The handler will turn the message associated with the task into an 
+  // The handler will turn the message associated with the task into an
   // answer.
   // Return 0 to indicate no errors with the callback.
   *req = NULL;
@@ -841,7 +841,11 @@ void Stack::fd_sas_log_diameter_message(enum fd_hook_type type,
                 session_id_len, session_id);
       SAS::Marker corr(trail, MARKED_ID_GENERIC_CORRELATOR, 0);
       corr.add_var_param(session_id_len, session_id);
-      SAS::report_marker(corr);
+
+      // The marker should be trace-scoped, and should not reactivate any trail
+      // groups (this means that diameter flows occurring after the end of the
+      // call will not delay it from appearing in SAS).
+      SAS::report_marker(corr, SAS::Marker::Scope::Trace, false);
     }
   }
 }


### PR DESCRIPTION
This PR contains two main changes:

* Add SAS correlation to the diameter stack based on diameter session ID. 
* Split out the datestamp from the resource bundle name (to allow us to define other resource bundles in future.