### PR TITLE
[Reviewer: Alex] ENT logs for memcached resize

### DIFF
--- a/include/cpp_common_pd_definitions.h
+++ b/include/cpp_common_pd_definitions.h
@@ -119,9 +119,8 @@ static const PDLog2<const char*, int> CL_MEMCACHED_CLUSTER_UPDATE_STABLE
 (
   PDLogBase::CL_CPP_COMMON_ID + 6,
   PDLOG_NOTICE,
-  "The memcached cluster configuration has been updated.",
-  "A change has been detected to the %s configuration file that has changed the memcached cluster. "
-  "There are now %d nodes in the cluster.",
+  "The memcached cluster configuration has been updated. There are now %d nodes in the cluster.",
+  "A change has been detected to the %s configuration file that has changed the memcached cluster.";
   "Normal.",
   "None."
 );
@@ -130,9 +129,8 @@ static const PDLog3<const char*, int, int> CL_MEMCACHED_CLUSTER_UPDATE_RESIZE
 (
   PDLogBase::CL_CPP_COMMON_ID + 7,
   PDLOG_NOTICE,
-  "The memcached cluster configuration has been updated.",
-  "A change has been detected to the %s configuration file that has changed the memcached cluster. "
-  "The cluster is resizing from %d nodes to %d nodes.",
+  "The memcached cluster configuration has been updated. The cluster is resizing from %d nodes to %d nodes.",
+  "A change has been detected to the %s configuration file that has changed the memcached cluster.",
   "Normal.",
   "None."
 );

--- a/include/cpp_common_pd_definitions.h
+++ b/include/cpp_common_pd_definitions.h
@@ -115,4 +115,28 @@ static const PDLog4<const char*, const char*, const char*, int> CL_HTTP_COMM_ERR
   "and/or Wireshark."
 );
 
+static const PDLog2<const char*, int> CL_MEMCACHED_CLUSTER_UPDATE_STABLE
+(
+  PDLogBase::CL_CPP_COMMON_ID + 6,
+  PDLOG_NOTICE,
+  "The memcached cluster configuration has been updated.",
+  "A change has been detected to the %s configuration file that has changed the memcached cluster. "
+  "There are now %d nodes in the cluster.",
+  "Normal.",
+  "None."
+);
+
+static const PDLog3<const char*, int, int> CL_MEMCACHED_CLUSTER_UPDATE_RESIZE
+(
+  PDLogBase::CL_CPP_COMMON_ID + 7,
+  PDLOG_NOTICE,
+  "The memcached cluster configuration has been updated.",
+  "A change has been detected to the %s configuration file that has changed the memcached cluster. "
+  "The cluster is resizing from %d nodes to %d nodes.",
+  "Normal.",
+  "None."
+);
+
+
+
 #endif

--- a/include/cpp_common_pd_definitions.h
+++ b/include/cpp_common_pd_definitions.h
@@ -115,7 +115,7 @@ static const PDLog4<const char*, const char*, const char*, int> CL_HTTP_COMM_ERR
   "and/or Wireshark."
 );
 
-static const PDLog2<const char*, int> CL_MEMCACHED_CLUSTER_UPDATE_STABLE
+static const PDLog2<int, const char*> CL_MEMCACHED_CLUSTER_UPDATE_STABLE
 (
   PDLogBase::CL_CPP_COMMON_ID + 6,
   PDLOG_NOTICE,
@@ -125,7 +125,7 @@ static const PDLog2<const char*, int> CL_MEMCACHED_CLUSTER_UPDATE_STABLE
   "None."
 );
 
-static const PDLog3<const char*, int, int> CL_MEMCACHED_CLUSTER_UPDATE_RESIZE
+static const PDLog3<int, int, const char*> CL_MEMCACHED_CLUSTER_UPDATE_RESIZE
 (
   PDLogBase::CL_CPP_COMMON_ID + 7,
   PDLOG_NOTICE,

--- a/include/cpp_common_pd_definitions.h
+++ b/include/cpp_common_pd_definitions.h
@@ -120,7 +120,7 @@ static const PDLog2<const char*, int> CL_MEMCACHED_CLUSTER_UPDATE_STABLE
   PDLogBase::CL_CPP_COMMON_ID + 6,
   PDLOG_NOTICE,
   "The memcached cluster configuration has been updated. There are now %d nodes in the cluster.",
-  "A change has been detected to the %s configuration file that has changed the memcached cluster.";
+  "A change has been detected to the %s configuration file that has changed the memcached cluster.",
   "Normal.",
   "None."
 );

--- a/include/memcached_config.h
+++ b/include/memcached_config.h
@@ -62,6 +62,9 @@ struct MemcachedConfig
   /// 0 means that tombstones are not used. Deleted data is simply removed.
   int tombstone_lifetime;
 
+  /// The configuration file used for this memcached cluster. Used for logging.
+  std::string filename;
+
   /// Default constructor.
   MemcachedConfig();
 };

--- a/include/pdlog.h
+++ b/include/pdlog.h
@@ -93,18 +93,21 @@ public:
     CL_ASTAIRE_ID = 7000,
   };
 
-  PDLogBase(int log_id, int severity, const std::string& msg, 
-            const std::string& cause,
-            const std::string& effect, const std::string& action) 
-    : _log_id(log_id), _severity(severity), _msg(msg),
-    _cause(cause), _effect(effect), _action(action) {};
+  PDLogBase(int log_id,
+            int severity,
+            const std::string& desc,    // Description of the condition
+            const std::string& cause,   // The cause of the condition
+            const std::string& effect,  // The effect the condiiton has on the system
+            const std::string& action)  // A list of actions to be taken for the condition
+    : _log_id(log_id), _severity(severity)
+  {
+    _msg = ("Description: " + desc + " @@Cause: " + cause + " @@Effect: " + effect + " @@Action: " + action) ;
+  }
 
   // Writes the description. cause, effect, and actions to syslog
   virtual void dcealog(const char* buf) const
   {
-    syslog(_severity, "%d - Description: %s @@Cause: %s @@Effect: "
-	   "%s @@Action: %s", 
-	   _log_id, buf, _cause.c_str(), _effect.c_str(), _action.c_str());
+    syslog(_severity, "%d - %s", _log_id, buf);
   }
 protected:
   // Unique identity for a PDLog, e.g. CL_CPP_COMMON + 1
@@ -113,17 +116,7 @@ protected:
   // Log severity, usually PDLOG_ERR or PDLOG_NOTICE
   int         _severity;
 
-  // Description of the condition
   std::string _msg;
-
-  // The cause of the condition
-  std::string _cause;
-
-  // The effect the condiiton has on the system
-  std::string _effect;
-
-  // A list of actions to be taken for the condition
-  std::string _action;
 };
 
 // PDLog - For logs with no log() arguments

--- a/include/pdlog.h
+++ b/include/pdlog.h
@@ -91,6 +91,8 @@ public:
     CL_RALF_ID = 5000,
     CL_SCRIPT_ID = 6000,
     CL_ASTAIRE_ID = 7000,
+    CL_CLUSTER_MGR_ID = 8000,
+    CL_CONFIG_MGR_ID = 9000
   };
 
   PDLogBase(int log_id,

--- a/src/memcached_config.cpp
+++ b/src/memcached_config.cpp
@@ -61,6 +61,7 @@ bool MemcachedConfigFileReader::read_config(MemcachedConfig& config)
   config.servers.clear();
   config.new_servers.clear();
   config.tombstone_lifetime = DEFAULT_TOMBSTONE_LIFETIME;
+  config.filename = _filename;
 
   std::ifstream f(_filename);
 

--- a/src/memcachedstoreview.cpp
+++ b/src/memcachedstoreview.cpp
@@ -141,8 +141,8 @@ void MemcachedStoreView::update(const MemcachedConfig& config)
   {
     // Stable configuration.
     LOG_DEBUG("View is stable with %d nodes", config.servers.size());
-    CL_MEMCACHED_CLUSTER_UPDATE_STABLE.log(config.filename.c_str(),
-                                           config.servers.size());
+    CL_MEMCACHED_CLUSTER_UPDATE_STABLE.log(config.servers.size(),
+                                           config.filename.c_str());
     _servers = config.servers;
     generate_ring_from_stable_servers();
   }
@@ -150,9 +150,9 @@ void MemcachedStoreView::update(const MemcachedConfig& config)
   {
     // Stable configuration.
     LOG_DEBUG("Cluster is moving from 0 nodes to %d nodes", config.new_servers.size());
-    CL_MEMCACHED_CLUSTER_UPDATE_RESIZE.log(config.filename.c_str(),
-                                           0,
-                                           config.new_servers.size());
+    CL_MEMCACHED_CLUSTER_UPDATE_RESIZE.log(0,
+                                           config.new_servers.size(),
+                                           config.filename.c_str());
     _servers = config.new_servers;
     generate_ring_from_stable_servers();
   }
@@ -161,9 +161,9 @@ void MemcachedStoreView::update(const MemcachedConfig& config)
     LOG_DEBUG("Cluster is moving from %d nodes to %d nodes",
               config.servers.size(),
               config.new_servers.size());
-    CL_MEMCACHED_CLUSTER_UPDATE_RESIZE.log(config.filename.c_str(),
-                                           config.servers.size(),
-                                           config.new_servers.size());
+    CL_MEMCACHED_CLUSTER_UPDATE_RESIZE.log(config.servers.size(),
+                                           config.new_servers.size(),
+                                           config.filename.c_str());
 
     // _servers should contain all the servers we might want to store
     // data on, so combine the old and new server lists, removing any overlap.

--- a/src/memcachedstoreview.cpp
+++ b/src/memcachedstoreview.cpp
@@ -48,6 +48,7 @@
 
 #include "log.h"
 #include "memcachedstoreview.h"
+#include "cpp_common_pd_definitions.h"
 
 
 MemcachedStoreView::MemcachedStoreView(int vbuckets, int replicas) :
@@ -140,6 +141,8 @@ void MemcachedStoreView::update(const MemcachedConfig& config)
   {
     // Stable configuration.
     LOG_DEBUG("View is stable with %d nodes", config.servers.size());
+    CL_MEMCACHED_CLUSTER_UPDATE_STABLE.log(config.filename.c_str(),
+                                           config.servers.size());
     _servers = config.servers;
     generate_ring_from_stable_servers();
   }
@@ -147,6 +150,9 @@ void MemcachedStoreView::update(const MemcachedConfig& config)
   {
     // Stable configuration.
     LOG_DEBUG("Cluster is moving from 0 nodes to %d nodes", config.new_servers.size());
+    CL_MEMCACHED_CLUSTER_UPDATE_RESIZE.log(config.filename.c_str(),
+                                           0,
+                                           config.new_servers.size());
     _servers = config.new_servers;
     generate_ring_from_stable_servers();
   }
@@ -155,6 +161,9 @@ void MemcachedStoreView::update(const MemcachedConfig& config)
     LOG_DEBUG("Cluster is moving from %d nodes to %d nodes",
               config.servers.size(),
               config.new_servers.size());
+    CL_MEMCACHED_CLUSTER_UPDATE_RESIZE.log(config.filename.c_str(),
+                                           config.servers.size(),
+                                           config.new_servers.size());
 
     // _servers should contain all the servers we might want to store
     // data on, so combine the old and new server lists, removing any overlap.


### PR DESCRIPTION
This adds ENT logs for memcached resize. I've also allowed variable interpolation in the cause/effect/action sections of PD logs, just in the message.

Example text below (though note that I moved 'There are now %d nodes in the cluster.' into the log description after testing this).