### PR TITLE
Reviewer MIRW: Add a NONE level for HTTP SAS Logging

### DIFF
--- a/include/sasevent.h
+++ b/include/sasevent.h
@@ -53,6 +53,7 @@ namespace SASEvent {
   // The levels at which clearwater nodes may log HTTP messages.
   enum struct HttpLogLevel
   {
+    NONE = 0,
     DETAIL = 40,
     PROTOCOL = 60
   };


### PR DESCRIPTION
Hi Matt,

This change adds a NONE level to the set of SAS HTTP log levels, and implements it in httpconnection.

Along with a corresponding Chronos change, this stops Chronos from creating (and just dropping) SAS events. Tested by running stress with and without these changes - CPU usage was 50% higher without these changes.

Thanks,
Graeme