### PR TITLE
[Reviewer: Matt] Don't count ping handler responses

### DIFF
--- a/include/httpstack.h
+++ b/include/httpstack.h
@@ -148,7 +148,7 @@ public:
       }
     }
 
-    void send_reply(int rc, SAS::TrailId trail);
+    void send_reply(int rc, SAS::TrailId trail, bool use_latency=true);
     inline evhtp_request_t* req() { return _req; }
 
     void record_penalty() { _stack->record_penalty(); }
@@ -409,7 +409,7 @@ public:
   virtual void start(evhtp_thread_init_cb init_cb = NULL);
   virtual void stop();
   virtual void wait_stopped();
-  virtual void send_reply(Request& req, int rc, SAS::TrailId trail);
+  virtual void send_reply(Request& req, int rc, bool use_latency, SAS::TrailId trail);
   virtual void record_penalty();
 
   void log(const std::string uri, std::string method, int rc, unsigned long latency_us)

--- a/include/httpstack.h
+++ b/include/httpstack.h
@@ -66,7 +66,12 @@ public:
   {
   public:
     Request(HttpStack* stack, evhtp_request_t* req) :
-    _method(htp_method_UNKNOWN), _rx_body_set(false), _stack(stack), _req(req), _stopwatch()
+      _method(htp_method_UNKNOWN), 
+      _rx_body_set(false), 
+      _stack(stack), 
+      _req(req), 
+      _stopwatch(),
+      _track_latency(true)
     {
       _stopwatch.start();
     }
@@ -113,6 +118,11 @@ public:
       evhtp_headers_add_header(_req->headers_out, new_header);
     }
 
+    inline void set_track_latency(bool track_latency)
+    {
+      _track_latency = track_latency;
+    }
+
     htp_method method()
     {
       if (_method == htp_method_UNKNOWN)
@@ -148,7 +158,7 @@ public:
       }
     }
 
-    void send_reply(int rc, SAS::TrailId trail, bool use_latency=true);
+    void send_reply(int rc, SAS::TrailId trail);
     inline evhtp_request_t* req() { return _req; }
 
     void record_penalty() { _stack->record_penalty(); }
@@ -213,6 +223,7 @@ public:
     evhtp_request_t* _req;
     Utils::StopWatch _stopwatch;
     SasLogger* _sas_logger;
+    bool _track_latency;
 
     std::string url_unescape(const std::string& s)
     {
@@ -409,7 +420,7 @@ public:
   virtual void start(evhtp_thread_init_cb init_cb = NULL);
   virtual void stop();
   virtual void wait_stopped();
-  virtual void send_reply(Request& req, int rc, bool use_latency, SAS::TrailId trail);
+  virtual void send_reply(Request& req, int rc, SAS::TrailId trail);
   virtual void record_penalty();
 
   void log(const std::string uri, std::string method, int rc, unsigned long latency_us)

--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -51,10 +51,10 @@ HttpStack::HttpStack() :
   _load_monitor(NULL)
 {}
 
-void HttpStack::Request::send_reply(int rc, SAS::TrailId trail)
+void HttpStack::Request::send_reply(int rc, SAS::TrailId trail, bool use_latency)
 {
   _stopwatch.stop();
-  _stack->send_reply(*this, rc, trail);
+  _stack->send_reply(*this, rc, use_latency, trail);
 }
 
 bool HttpStack::Request::get_latency(unsigned long& latency_us)
@@ -76,7 +76,10 @@ void HttpStack::send_reply_internal(Request& req, int rc, SAS::TrailId trail)
 }
 
 
-void HttpStack::send_reply(Request& req, int rc, SAS::TrailId trail)
+void HttpStack::send_reply(Request& req, 
+                           int rc, 
+                           bool use_latency, 
+                           SAS::TrailId trail)
 {
   send_reply_internal(req, rc, trail);
   // Resume the request to actually send it.  This matches the function to pause the request in
@@ -85,7 +88,7 @@ void HttpStack::send_reply(Request& req, int rc, SAS::TrailId trail)
 
   // Update the latency stats and throttling algorithm.
   unsigned long latency_us = 0;
-  if (req.get_latency(latency_us))
+  if ((use_latency) && (req.get_latency(latency_us)))
   {
     if (_load_monitor != NULL)
     {

--- a/src/httpstack_utils.cpp
+++ b/src/httpstack_utils.cpp
@@ -46,7 +46,8 @@ namespace HttpStackUtils
                                     SAS::TrailId trail)
   {
     req.add_content("OK");
-    req.send_reply(200, trail, false);
+    req.set_track_latency(false);
+    req.send_reply(200, trail);
   }
 
   //

--- a/src/httpstack_utils.cpp
+++ b/src/httpstack_utils.cpp
@@ -46,7 +46,7 @@ namespace HttpStackUtils
                                     SAS::TrailId trail)
   {
     req.add_content("OK");
-    req.send_reply(200, trail);
+    req.send_reply(200, trail, false);
   }
 
   //

--- a/test_utils/mockhttpstack.hpp
+++ b/test_utils/mockhttpstack.hpp
@@ -98,7 +98,7 @@ public:
   MOCK_METHOD0(start, void());
   MOCK_METHOD0(stop, void());
   MOCK_METHOD0(wait_stopped, void());
-  MOCK_METHOD4(send_reply, void(HttpStack::Request&, int, bool, SAS::TrailId));
+  MOCK_METHOD3(send_reply, void(HttpStack::Request&, int, SAS::TrailId));
   MOCK_METHOD0(record_penalty, void());
 };
 

--- a/test_utils/mockhttpstack.hpp
+++ b/test_utils/mockhttpstack.hpp
@@ -98,7 +98,7 @@ public:
   MOCK_METHOD0(start, void());
   MOCK_METHOD0(stop, void());
   MOCK_METHOD0(wait_stopped, void());
-  MOCK_METHOD3(send_reply, void(HttpStack::Request&, int, SAS::TrailId));
+  MOCK_METHOD4(send_reply, void(HttpStack::Request&, int, bool, SAS::TrailId));
   MOCK_METHOD0(record_penalty, void());
 };
 


### PR DESCRIPTION
This stops us from including any response from the Ping Handler in our latencies
Fixes #306 