### PR TITLE
[No reviewer] Undefine ACTION after including snmp headers

### DIFF
--- a/include/snmp_includes.h
+++ b/include/snmp_includes.h
@@ -41,4 +41,8 @@
 #include <net-snmp/net-snmp-includes.h>
 #include <net-snmp/agent/net-snmp-agent-includes.h>
 
+// net-snmp defines conflicting things, so undef them here
+
+#undef ACTION
+
 #endif


### PR DESCRIPTION
(This conflicts with a #define in gmock.)