### PR TITLE
[Reviewer: Ellie] Prevent double free on SNMP shutdown

### DIFF
--- a/src/snmp_agent.cpp
+++ b/src/snmp_agent.cpp
@@ -77,7 +77,6 @@ int snmp_setup(const char* name)
 void snmp_terminate(const char* name)
 {
   pthread_cancel(snmp_thread_var);
-  shutdown_agent();
   snmp_shutdown(name);
   netsnmp_container_free_list();
 }


### PR DESCRIPTION
We shouldn't be calling `shutdown_agent()` ourselves (and don't in clearwater-fv-test). Tested live, fixes a crash I was seeing.