### PR TITLE
[Reviewer: Ellie] Log net-snmp messages to the Clearwater log

### DIFF
--- a/src/snmp_agent.cpp
+++ b/src/snmp_agent.cpp
@@ -49,11 +49,56 @@ void* snmp_thread(void* data)
   return NULL;
 };
 
+int logging_callback(int majorID, int minorID, void *serverarg, void *clientarg)
+{
+  snmp_log_message *log_message = (snmp_log_message *) serverarg;
+  int snmp_prio = log_message->priority;
+  int clearwater_prio = Log::STATUS_LEVEL;
+
+  switch (snmp_prio) {
+    case LOG_EMERG:
+    case LOG_ALERT:
+    case LOG_CRIT:
+    case LOG_ERR:
+      clearwater_prio = Log::ERROR_LEVEL;
+      break;
+    case LOG_WARNING:
+      clearwater_prio = Log::WARNING_LEVEL;
+      break;
+    case LOG_NOTICE:
+      clearwater_prio = Log::STATUS_LEVEL;
+      break;
+    case LOG_INFO:
+      clearwater_prio = Log::INFO_LEVEL;
+      break;
+    case LOG_DEBUG:
+      clearwater_prio = Log::DEBUG_LEVEL;
+      break;
+  }
+
+  if (clearwater_prio <= Log::loggingLevel)
+  {
+    char* orig_msg = strdup(log_message->msg);
+    char* msg = orig_msg;
+    // Remove the trailing newline
+    msg[strlen(msg) - 1] = '\0';
+    Log::write(clearwater_prio, "(Net-SNMP)", 0, msg);
+    free(orig_msg);
+  }
+
+  return 0;
+}
+
+
 // Set up the SNMP agent and handler thread. Returns 0 if and only if both succeed.
 int snmp_setup(const char* name)
 {
   // Make sure we start as a subagent, not a master agent.
   netsnmp_ds_set_boolean(NETSNMP_DS_APPLICATION_ID, NETSNMP_DS_AGENT_ROLE, 1);
+
+  // Use callback-based logging, and integrate it with the Clearwater logger
+  snmp_enable_calllog();
+  snmp_register_callback(SNMP_CALLBACK_LIBRARY, SNMP_CALLBACK_LOGGING, logging_callback, NULL);
 
   netsnmp_container_init_list();
   int rc = init_agent(name);

--- a/src/snmp_agent.cpp
+++ b/src/snmp_agent.cpp
@@ -49,40 +49,40 @@ void* snmp_thread(void* data)
   return NULL;
 };
 
-int logging_callback(int majorID, int minorID, void *serverarg, void *clientarg)
+int logging_callback(int majorID, int minorID, void* serverarg, void* clientarg)
 {
-  snmp_log_message *log_message = (snmp_log_message *) serverarg;
-  int snmp_prio = log_message->priority;
-  int clearwater_prio = Log::STATUS_LEVEL;
+  snmp_log_message* log_message = (snmp_log_message*)serverarg;
+  int snmp_priority = log_message->priority;
+  int clearwater_priority = Log::STATUS_LEVEL;
 
-  switch (snmp_prio) {
+  switch (snmp_priority) {
     case LOG_EMERG:
     case LOG_ALERT:
     case LOG_CRIT:
     case LOG_ERR:
-      clearwater_prio = Log::ERROR_LEVEL;
+      clearwater_priority = Log::ERROR_LEVEL;
       break;
     case LOG_WARNING:
-      clearwater_prio = Log::WARNING_LEVEL;
+      clearwater_priority = Log::WARNING_LEVEL;
       break;
     case LOG_NOTICE:
-      clearwater_prio = Log::STATUS_LEVEL;
+      clearwater_priority = Log::STATUS_LEVEL;
       break;
     case LOG_INFO:
-      clearwater_prio = Log::INFO_LEVEL;
+      clearwater_priority = Log::INFO_LEVEL;
       break;
     case LOG_DEBUG:
-      clearwater_prio = Log::DEBUG_LEVEL;
+      clearwater_priority = Log::DEBUG_LEVEL;
       break;
   }
 
-  if (clearwater_prio <= Log::loggingLevel)
+  if (clearwater_priority <= Log::loggingLevel)
   {
     char* orig_msg = strdup(log_message->msg);
     char* msg = orig_msg;
     // Remove the trailing newline
     msg[strlen(msg) - 1] = '\0';
-    Log::write(clearwater_prio, "(Net-SNMP)", 0, msg);
+    Log::write(clearwater_priority, "(Net-SNMP)", 0, msg);
     free(orig_msg);
   }
 


### PR DESCRIPTION
Hopefully reasonably self-explanatory - netsnmp lets you provide a callback for logging, so I've done that and written a callback that logs to our normal log. (Previously, it went to syslog.)