### PR TITLE
[Reviewer: Ellie] Attempt to shrink the per-node stats boilerplate

### DIFF
--- a/include/snmp_internal/snmp_table.h
+++ b/include/snmp_internal/snmp_table.h
@@ -218,16 +218,21 @@ public:
     }
   }
 
+  void add(TRowKey key, TRow* row)
+  {
+    std::pair<TRowKey, TRow*> new_entry(key, row);
+    _map.insert(new_entry);
+
+    Table<TRow>::add(row);
+  }
+
   // Creates the row keyed off `key`.
   void add(TRowKey key)
   {
     TRow* row = new_row(key);
     if (row != NULL)
     {
-      std::pair<TRowKey, TRow*> new_entry(key, row);
-      _map.insert(new_entry);
-
-      Table<TRow>::add(row);
+      add(key, row);
     }
     else
     {

--- a/include/snmp_node_types.h
+++ b/include/snmp_node_types.h
@@ -1,5 +1,5 @@
 /**
- * @file snmp_time_period_and_node_type_table.h
+ * @file snmp_node_types.h
  *
  * Project Clearwater - IMS in the Cloud
  * Copyright (C) 2015 Metaswitch Networks Ltd
@@ -34,38 +34,17 @@
  * as those licenses appear in the file LICENSE-OPENSSL.
  */
 
-#include "snmp_time_period_table.h"
-#include "snmp_node_types.h"
+#ifndef SNMP_NODE_TYPES_H
+#define SNMP_NODE_TYPES_H
 
-#ifndef SNMP_TIME_PERIOD_AND_NODE_TYPE_TABLE_H
-#define SNMP_TIME_PERIOD_AND_NODE_TYPE_TABLE_H
-
-// This file contains the base infrastructure for SNMP tables 
-// which are indexed by time period and node type.
 namespace SNMP
 {
 
-template <class T> class TimeAndNodeTypeBasedRow : public TimeBasedRow<T>
+enum NodeTypes
 {
-public:
-  // Constructor, takes ownership of the View*.
-  TimeAndNodeTypeBasedRow(int time_index, int type_index, typename TimeBasedRow<T>::View* view) :
-    TimeBasedRow<T>(time_index, view),
-    _type_index(type_index)
-  {
-    // Add index for the node type
-    netsnmp_tdata_row_add_index(this->_row,
-                                ASN_INTEGER,
-                                &_type_index,
-                                sizeof(int));
-  };
-
-  virtual ~TimeAndNodeTypeBasedRow()
-  {
-  };
-
-protected:
-  uint32_t _type_index;
+  SCSCF = 0,
+  ICSCF = 2,
+  BGCF = 5,
 };
 
 }

--- a/include/snmp_single_count_by_node_type_table.h
+++ b/include/snmp_single_count_by_node_type_table.h
@@ -37,6 +37,7 @@
 #include <vector>
 #include <map>
 #include <string>
+#include "snmp_node_types.h"
 
 #ifndef SINGLE_COUNT_BY_NODE_TYPE_H
 #define SINGLE_COUNT_BY_NODE_TYPE_H
@@ -59,7 +60,7 @@ public:
   virtual ~SingleCountByNodeTypeTable() {};
 
   static SingleCountByNodeTypeTable* create(std::string name, std::string oid);
-  virtual void increment(int node_type) = 0;
+  virtual void increment(NodeTypes node_type) = 0;
 };
 
 }

--- a/src/snmp_single_count_by_node_type_table.cpp
+++ b/src/snmp_single_count_by_node_type_table.cpp
@@ -76,24 +76,10 @@ public:
     CountsByNodeTypeTableImpl<SingleCountByNodeTypeRow, 0>(name, tbl_oid)
   {}
  
-  void increment(int type)
+  void increment(NodeTypes type)
   {
-    // Increment each underlying set of data.
-    switch (type)
-    {
-      case NodeTypes::ICSCF:
-        five_second_i.get_current()->count++;
-        five_minute_i.get_current()->count++;
-        break;
-      case NodeTypes::SCSCF:
-        five_second_s.get_current()->count++;
-        five_minute_s.get_current()->count++;
-        break;
-      case NodeTypes::BGCF:
-        five_second_b.get_current()->count++;
-        five_minute_b.get_current()->count++;
-        break;
-    }
+    five_second[type]->get_current()->count++;
+    five_minute[type]->get_current()->count++;
   }
 };
 


### PR DESCRIPTION
The big change here is the addition of an `add` method to SNMP::ManagedTable where you can provide the row directly, instead of having it constructed by new_row. This makes more sense for tables where all the rows are constructed up front.

I've also used NodeTypes a bit more widely - I'm not sure if this is sensible (I'm happy to back it out and use ints and a cast).