### PR TITLE
[Reviewer: Andy] Use HTTP SAS compression profile when logging HTTP requests

### DIFF
--- a/src/httpconnection.cpp
+++ b/src/httpconnection.cpp
@@ -987,7 +987,7 @@ void HttpConnection::sas_log_http_req(SAS::TrailId trail,
     SAS::Event event(trail, event_id, instance_id);
 
     sas_add_ip_addrs_and_ports(event, curl);
-    event.add_compressed_param(request_bytes);
+    event.add_compressed_param(request_bytes, &SASEvent::PROFILE_HTTP);
     event.add_var_param(method_str);
     event.add_var_param(Utils::url_unescape(url));
 
@@ -1012,7 +1012,7 @@ void HttpConnection::sas_log_http_rsp(SAS::TrailId trail,
 
     sas_add_ip_addrs_and_ports(event, curl);
     event.add_static_param(http_rc);
-    event.add_compressed_param(response_bytes);
+    event.add_compressed_param(response_bytes, &SASEvent::PROFILE_HTTP);
     event.add_var_param(method_str);
     event.add_var_param(Utils::url_unescape(url));
 


### PR DESCRIPTION
Andy,

Please can you review this (pretty self-explanatory) change to fix #335?  Note that clearwater_sas_resource_bundle.yaml already tries to decompress these using the HTTP SAS compression profile.

Thanks,

Matt