### PR TITLE
[Reviewer: Andy] Allow IPv6 DNS servers

### DIFF
--- a/include/dnscachedresolver.h
+++ b/include/dnscachedresolver.h
@@ -49,6 +49,7 @@
 #include <arpa/nameser.h>
 #include <ares.h>
 
+#include "utils.h"
 #include "dnsrrecords.h"
 
 class DnsResult
@@ -75,8 +76,9 @@ private:
 class DnsCachedResolver
 {
 public:
-  DnsCachedResolver(const std::string& dns_server);
-  DnsCachedResolver(const std::vector<std::string>& dns_server);
+  DnsCachedResolver(const std::vector<IP46Address>& dns_server);
+  static DnsCachedResolver* from_server_ip (const std::string& dns_server);
+  static DnsCachedResolver* from_server_ips (const std::vector<std::string>& dns_server);
   ~DnsCachedResolver();
 
   /// Queries a single DNS record.
@@ -180,8 +182,8 @@ private:
   void wait_for_replies(DnsChannel* channel);
   static void destroy_dns_channel(DnsChannel* channel);
 
-  struct in_addr _dns_servers[3];
-  size_t _dns_servers_count;
+  struct ares_addr_node _ares_addrs[3];
+  std::vector<IP46Address> _dns_servers;
 
   // The thread-local store - used for storing DnsChannels.
   pthread_key_t _thread_local;

--- a/include/dnscachedresolver.h
+++ b/include/dnscachedresolver.h
@@ -76,9 +76,9 @@ private:
 class DnsCachedResolver
 {
 public:
-  DnsCachedResolver(const std::vector<IP46Address>& dns_server);
-  static DnsCachedResolver* from_server_ip (const std::string& dns_server);
-  static DnsCachedResolver* from_server_ips (const std::vector<std::string>& dns_server);
+  DnsCachedResolver(const std::vector<IP46Address>& dns_servers);
+  DnsCachedResolver(const std::vector<std::string>& dns_servers);
+  DnsCachedResolver(const std::string& dns_server);
   ~DnsCachedResolver();
 
   /// Queries a single DNS record.
@@ -102,6 +102,8 @@ public:
   void clear();
 
 private:
+  void init(const std::vector<IP46Address>& dns_server);
+  void init_from_server_ips(const std::vector<std::string>& dns_server);
 
   struct DnsChannel
   {

--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -115,28 +115,14 @@ DnsResult::~DnsResult()
   }
 }
 
-DnsCachedResolver::DnsCachedResolver(const std::vector<std::string>& dns_servers) :
+DnsCachedResolver::DnsCachedResolver(const std::vector<IP46Address>& dns_servers) :
+  _dns_servers(dns_servers),
   _cache_lock(PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP),
   _cache()
 {
   // Initialize the ares library.  This might have already been done by curl
   // but it's safe to do it twice.
   ares_library_init(ARES_LIB_INIT_ALL);
-
-  size_t max_servers = 3;
-  _dns_servers_count = std::min(max_servers, dns_servers.size());
-
-  TRC_STATUS("Creating Cached Resolver using servers:");
-  for (size_t i = 0; i < _dns_servers_count; i++)
-  {
-    TRC_STATUS("    %s", dns_servers[i].c_str());
-    // Parse the DNS server's IP address.
-    if (!inet_aton(dns_servers[i].c_str(), &(_dns_servers[i])))
-    {
-      TRC_ERROR("Failed to parse '%s' as IP address - defaulting to 127.0.0.1", dns_servers[i].c_str());
-      (void)inet_aton("127.0.0.1", &(_dns_servers[i]));
-    }
-  }
 
   // We store a DNSResolver in thread-local data, so create the thread-local
   // store.
@@ -149,34 +135,39 @@ DnsCachedResolver::DnsCachedResolver(const std::vector<std::string>& dns_servers
   pthread_condattr_destroy(&cond_attr);
 }
 
-DnsCachedResolver::DnsCachedResolver(const std::string& dns_server) :
-  _cache_lock(PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP),
-  _cache()
+DnsCachedResolver* DnsCachedResolver::from_server_ips(const std::vector<std::string>& dns_servers)
 {
-  TRC_STATUS("Creating Cached Resolver using server %s", dns_server.c_str());
+  std::vector<IP46Address> dns_server_ips;
 
-  // Initialize the ares library.  This might have already been done by curl
-  // but it's safe to do it twice.
-  ares_library_init(ARES_LIB_INIT_ALL);
-
-  _dns_servers_count = 1;
-
-  // Parse the DNS server's IP address.
-  if (!inet_aton(dns_server.c_str(), &(_dns_servers[0])))
+  TRC_STATUS("Creating Cached Resolver using servers:");
+  for (size_t i = 0; i < dns_servers.size(); i++)
   {
-    TRC_ERROR("Failed to parse '%s' as IP address - defaulting to 127.0.0.1", dns_server.c_str());
-    (void)inet_aton("127.0.0.1", &(_dns_servers[0]));
+    IP46Address addr;
+    TRC_STATUS("    %s", dns_servers[i].c_str());
+    // Parse the DNS server's IP address.
+    if (inet_pton(AF_INET, dns_servers[i].c_str(), &(addr.addr.ipv4)))
+    {
+      addr.af = AF_INET;
+    }
+    else if (inet_pton(AF_INET6, dns_servers[i].c_str(), &(addr.addr.ipv6)))
+    {
+      addr.af = AF_INET6;
+    }
+    else
+    {
+      TRC_ERROR("Failed to parse '%s' as IP address - defaulting to 127.0.0.1", dns_servers[i].c_str());
+      addr.af = AF_INET;
+      (void)inet_aton("127.0.0.1", &(addr.addr.ipv4));
+    }
+    dns_server_ips.push_back(addr);
   }
 
-  // We store a DNSResolver in thread-local data, so create the thread-local
-  // store.
-  pthread_key_create(&_thread_local, (void(*)(void*))&destroy_dns_channel);
+  return new DnsCachedResolver(dns_server_ips);
+}
 
-  pthread_condattr_t cond_attr;
-  pthread_condattr_init(&cond_attr);
-  pthread_condattr_setclock(&cond_attr, CLOCK_MONOTONIC);
-  pthread_cond_init(&_got_reply_cond, &cond_attr);
-  pthread_condattr_destroy(&cond_attr);
+DnsCachedResolver* DnsCachedResolver::from_server_ip(const std::string& dns_server)
+{
+  return DnsCachedResolver::from_server_ips({ dns_server });
 }
 
 DnsCachedResolver::~DnsCachedResolver()
@@ -767,8 +758,9 @@ DnsCachedResolver::DnsChannel* DnsCachedResolver::get_dns_channel()
   // Get the channel from the thread-local data, or create a new one if none
   // found.
   DnsChannel* channel = (DnsChannel*)pthread_getspecific(_thread_local);
+  size_t server_count = std::min((size_t)3u, _dns_servers.size());
   if ((channel == NULL) &&
-      (_dns_servers[0].s_addr != 0))
+      (server_count > 0))
   {
     channel = new DnsChannel;
     channel->pending_queries = 0;
@@ -780,10 +772,11 @@ DnsCachedResolver::DnsChannel* DnsCachedResolver::get_dns_channel()
     // but it's what we've always tested with so not worth the risk of removing.
     options.flags = ARES_FLAG_STAYOPEN;
     options.timeout = 1000;
-    options.tries = _dns_servers_count;
+    options.tries = server_count;
     options.ndots = 0;
-    options.servers = (struct in_addr*)_dns_servers;
-    options.nservers = _dns_servers_count;
+    // We must use ares_set_servers rather than setting it in the options for IPv6 support.
+    options.servers = NULL;
+    options.nservers = 0;
     ares_init_options(&channel->channel,
                       &options,
                       ARES_OPT_FLAGS |
@@ -791,6 +784,35 @@ DnsCachedResolver::DnsChannel* DnsCachedResolver::get_dns_channel()
                       ARES_OPT_TRIES |
                       ARES_OPT_NDOTS |
                       ARES_OPT_SERVERS);
+
+    // Convert our vector of IP46Addresses into the linked list of
+    // ares_addr_nodes which ares_set_servers takes.
+    for (size_t ii = 0;
+         ii < server_count;
+         ii++)
+    {
+      IP46Address server = _dns_servers[ii];
+      struct ares_addr_node* ares_addr = &_ares_addrs[ii];
+      memset(ares_addr, 0, sizeof(struct ares_addr_node));
+      if (ii > 0)
+      {
+        int prev_idx = ii - 1;
+        _ares_addrs[prev_idx].next = ares_addr;
+      }
+
+      ares_addr->family = server.af;
+      if (server.af == AF_INET)
+      {
+        memcpy(&ares_addr->addr.addr4, &server.addr.ipv4, sizeof(ares_addr->addr.addr4));
+      }
+      else
+      {
+        memcpy(&ares_addr->addr.addr6, &server.addr.ipv6, sizeof(ares_addr->addr.addr6));
+      }
+    }
+    
+    ares_set_servers(channel->channel, &(_ares_addrs[0]));
+
     pthread_setspecific(_thread_local, channel);
   }
 


### PR DESCRIPTION
This fixes https://github.com/Metaswitch/cpp-common/issues/246, mostly by porting code from Sprout's ENUM code.

I've given the resolver three constructors - one with a single IP address as a string, one with multiple IP address as strings, and one taking IP46Addresses directly (so that the ENUM resolution code can plug into this).