### PR TITLE
[Reviewer: Graeme] Allow the supported node types to be defined when creating a table

### DIFF
--- a/include/snmp_node_types.h
+++ b/include/snmp_node_types.h
@@ -61,13 +61,6 @@ enum NodeTypes
   PROXYFUNCTION = 16,
   EPDG = 17
 };
-
-static std::vector<int> node_types = { NodeTypes::SCSCF,
-                                       NodeTypes::PCSCF,
-                                       NodeTypes::ICSCF,
-                                       NodeTypes::BGCF,
-                                       NodeTypes::IBCF,
-                                       NodeTypes::ECSCF };
 }
 
 #endif

--- a/include/snmp_single_count_by_node_type_table.h
+++ b/include/snmp_single_count_by_node_type_table.h
@@ -59,7 +59,7 @@ public:
   SingleCountByNodeTypeTable() {};
   virtual ~SingleCountByNodeTypeTable() {};
 
-  static SingleCountByNodeTypeTable* create(std::string name, std::string oid);
+  static SingleCountByNodeTypeTable* create(std::string name, std::string oid, std::vector<int> node_types);
   virtual void increment(NodeTypes node_type) = 0;
 };
 

--- a/src/snmp_single_count_by_node_type_table.cpp
+++ b/src/snmp_single_count_by_node_type_table.cpp
@@ -75,7 +75,8 @@ class SingleCountByNodeTypeTableImpl: public CountsByOtherTypeTableImpl<SingleCo
 {
 public:
   SingleCountByNodeTypeTableImpl(std::string name,
-                                 std::string tbl_oid): CountsByOtherTypeTableImpl<SingleCountByNodeTypeRow>(name, tbl_oid, node_types)
+                                 std::string tbl_oid,
+                                 std::vector<int> node_types): CountsByOtherTypeTableImpl<SingleCountByNodeTypeRow>(name, tbl_oid, node_types)
   {}
  
   void increment(NodeTypes type)
@@ -86,9 +87,10 @@ public:
 };
 
 SingleCountByNodeTypeTable* SingleCountByNodeTypeTable::create(std::string name,
-                                                               std::string oid)
+                                                               std::string oid,
+                                                               std::vector<int> node_types)
 {
-  return new SingleCountByNodeTypeTableImpl(name, oid);
+  return new SingleCountByNodeTypeTableImpl(name, oid, node_types);
 }
 
 }


### PR DESCRIPTION
As discussed on Friday, this lets you define what node type rows should be in a table when you create it, rather than hardcoding a list in cpp-common.