### PR TITLE
[Reviewer: Andy] Fix memory leak failures in UT

### DIFF
--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -138,11 +138,16 @@ void DnsCachedResolver::init(const std::vector<IP46Address>& dns_servers)
 void DnsCachedResolver::init_from_server_ips(const std::vector<std::string>& dns_servers)
 {
   std::vector<IP46Address> dns_server_ips;
-  dns_server_ips.reserve(dns_servers.size());
 
   TRC_STATUS("Creating Cached Resolver using servers:");
   for (size_t i = 0; i < dns_servers.size(); i++)
   {
+    if (dns_servers[i] == "0.0.0.0")
+    {
+      // Skip this DNS server
+      continue;
+    }
+
     IP46Address addr;
     TRC_STATUS("    %s", dns_servers[i].c_str());
     // Parse the DNS server's IP address.
@@ -887,5 +892,6 @@ void DnsCachedResolver::DnsTsx::ares_callback(int status, int timeouts, unsigned
 {
   _channel->resolver->dns_response(_domain, _dnstype, status, abuf, alen);
   --_channel->pending_queries;
+  delete this;
 }
 


### PR DESCRIPTION
Two fixes:

* DnsCachedResolver previously ignored 0.0.0.0 as an IP. I've restored this behaviour.
* We never delete DnsTsx objects (and didn't notice previously, because 0.0.0.0 was our IP address in UT...). They now self-destruct at the end of their useful life.

I'm going to throw together a test in clearwater-fv-test to query Google Public DNS and ensure that there are no other DnsCachedResolver leaks.

I might also fake out ares_query() so that the Sprout UTs can hit all of DnsCachedResolver.