### PR TITLE
[Reviewer: Matt] - Made the update time function in time period table more consistent

### DIFF
--- a/include/snmp_internal/snmp_time_period_table.h
+++ b/include/snmp_internal/snmp_time_period_table.h
@@ -86,11 +86,8 @@ public:
     }
 
     // Rolls the current period over into the previous period if necessary.
-    void update_time()
+    void update_time(timespec now)
     {
-      struct timespec now;
-      clock_gettime(CLOCK_REALTIME_COARSE, &now);
-
       // Count of how many _interval periods have passed since the epoch
       uint64_t new_tick = (now.tv_sec / (_interval_ms / 1000));
 
@@ -113,8 +110,8 @@ public:
       }
     }
 
-    T* get_current() { update_time(); return current.load(); }
-    T* get_previous() { update_time(); return previous.load(); }
+    T* get_current(timespec now) { update_time(now); return current.load(); }
+    T* get_previous(timespec now) { update_time(now); return previous.load(); }
     uint32_t get_interval_ms() { return _interval_ms; }
 
   protected:
@@ -133,7 +130,7 @@ public:
   public:
     View(CurrentAndPrevious* data): _data(data) {};
     virtual ~View() {};
-    virtual T* get_data() = 0;
+    virtual T* get_data(timespec now) = 0;
     // Return interval in ms
     uint32_t get_interval_ms() { return (this->_data->get_interval_ms()); }
   protected:
@@ -145,7 +142,7 @@ public:
   {
   public:
     CurrentView(CurrentAndPrevious* data): View(data) {};
-    T* get_data() { return this->_data->get_current(); };
+    T* get_data(timespec now) { return this->_data->get_current(now); };
   };
 
   // A view into the previous part of a CurrentAndPrevious set of data.
@@ -153,7 +150,7 @@ public:
   {
   public:
     PreviousView(CurrentAndPrevious* data): View(data) {};
-    T* get_data() { return this->_data->get_previous(); };
+    T* get_data(timespec now) { return this->_data->get_previous(now); };
   };
 
 

--- a/include/snmp_internal/snmp_time_period_table.h
+++ b/include/snmp_internal/snmp_time_period_table.h
@@ -86,7 +86,7 @@ public:
     }
 
     // Rolls the current period over into the previous period if necessary.
-    void update_time(timespec now)
+    void update_time(struct timespec now)
     {
       // Count of how many _interval periods have passed since the epoch
       uint64_t new_tick = (now.tv_sec / (_interval_ms / 1000));
@@ -142,7 +142,7 @@ public:
   public:
     View(CurrentAndPrevious* data): _data(data) {};
     virtual ~View() {};
-    virtual T* get_data(timespec now) = 0;
+    virtual T* get_data(struct timespec now) = 0;
     // Return interval in ms
     uint32_t get_interval_ms() { return (this->_data->get_interval_ms()); }
   protected:
@@ -154,7 +154,7 @@ public:
   {
   public:
     CurrentView(CurrentAndPrevious* data): View(data) {};
-    T* get_data(timespec now) { return this->_data->get_current(now); };
+    T* get_data(struct timespec now) { return this->_data->get_current(now); };
   };
 
   // A view into the previous part of a CurrentAndPrevious set of data.
@@ -162,7 +162,7 @@ public:
   {
   public:
     PreviousView(CurrentAndPrevious* data): View(data) {};
-    T* get_data(timespec now) { return this->_data->get_previous(now); };
+    T* get_data(struct timespec now) { return this->_data->get_previous(now); };
   };
 
 

--- a/include/snmp_internal/snmp_time_period_table.h
+++ b/include/snmp_internal/snmp_time_period_table.h
@@ -110,8 +110,20 @@ public:
       }
     }
 
-    T* get_current(timespec now) { update_time(now); return current.load(); }
-    T* get_previous(timespec now) { update_time(now); return previous.load(); }
+    T* get_current() {
+      struct timespec now;
+      clock_gettime(CLOCK_REALTIME_COARSE, &now);
+      return get_current(now);
+    }
+
+    T* get_previous() {
+      struct timespec now;
+      clock_gettime(CLOCK_REALTIME_COARSE, &now);
+      return get_previous(now);
+    }
+
+    T* get_current(struct timespec now) { update_time(now); return current.load(); }
+    T* get_previous(struct timespec now) { update_time(now); return previous.load(); }
     uint32_t get_interval_ms() { return _interval_ms; }
 
   protected:

--- a/src/snmp_counter_table.cpp
+++ b/src/snmp_counter_table.cpp
@@ -94,8 +94,8 @@ public:
   void increment()
   {
     // Increment each underlying set of data.
-    five_second.get_current(now)->count++;
-    five_minute.get_current(now)->count++;
+    five_second.get_current()->count++;
+    five_minute.get_current()->count++;
   }
 
 private:

--- a/src/snmp_counter_table.cpp
+++ b/src/snmp_counter_table.cpp
@@ -59,7 +59,10 @@ public:
     TimeBasedRow<SingleCount>(index, view) {};
   ColumnData get_columns()
   {
-    SingleCount accumulated = *(this->_view->get_data());
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME_COARSE, &now);
+
+    SingleCount accumulated = *(this->_view->get_data(now));
 
     // Construct and return a ColumnData with the appropriate values
     ColumnData ret;
@@ -91,8 +94,11 @@ public:
   void increment()
   {
     // Increment each underlying set of data.
-    five_second.get_current()->count++;
-    five_minute.get_current()->count++;
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME_COARSE, &now);
+
+    five_second.get_current(now)->count++;
+    five_minute.get_current(now)->count++;
   }
 
 private:

--- a/src/snmp_counter_table.cpp
+++ b/src/snmp_counter_table.cpp
@@ -94,9 +94,6 @@ public:
   void increment()
   {
     // Increment each underlying set of data.
-    struct timespec now;
-    clock_gettime(CLOCK_REALTIME_COARSE, &now);
-
     five_second.get_current(now)->count++;
     five_minute.get_current(now)->count++;
   }

--- a/src/snmp_event_accumulator_table.cpp
+++ b/src/snmp_event_accumulator_table.cpp
@@ -110,7 +110,10 @@ private:
 
   void accumulate_internal(EventAccumulatorRow::CurrentAndPrevious& data, uint32_t sample)
   {
-    EventStatistics* current = data.get_current();
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME_COARSE, &now);
+
+    EventStatistics* current = data.get_current(now);
 
     current->count++;
 
@@ -155,7 +158,10 @@ void EventStatistics::reset(uint64_t periodstart, EventStatistics* previous)
 
 ColumnData EventAccumulatorRow::get_columns()
 {
-  EventStatistics* accumulated = _view->get_data();
+  struct timespec now;
+  clock_gettime(CLOCK_REALTIME_COARSE, &now);
+
+  EventStatistics* accumulated = _view->get_data(now);
   uint_fast32_t count = accumulated->count.load();
 
   uint_fast32_t avg = 0;

--- a/src/snmp_success_fail_count_by_request_type_table.cpp
+++ b/src/snmp_success_fail_count_by_request_type_table.cpp
@@ -104,29 +104,20 @@ public:
 
   void increment_attempts(SIPRequestTypes type)
   {
-    struct timespec now;
-    clock_gettime(CLOCK_REALTIME_COARSE, &now);
-
-    five_second[type]->get_current(now)->attempts++;
-    five_minute[type]->get_current(now)->attempts++;
+    five_second[type]->get_current()->attempts++;
+    five_minute[type]->get_current()->attempts++;
   }
 
   void increment_successes(SIPRequestTypes type)
   {
-    struct timespec now;
-    clock_gettime(CLOCK_REALTIME_COARSE, &now);
-
-    five_second[type]->get_current(now)->successes++;
-    five_minute[type]->get_current(now)->successes++;
+    five_second[type]->get_current()->successes++;
+    five_minute[type]->get_current()->successes++;
   }
 
   void increment_failures(SIPRequestTypes type)
   {
-    struct timespec now;
-    clock_gettime(CLOCK_REALTIME_COARSE, &now);
-
-    five_second[type]->get_current(now)->failures++;
-    five_minute[type]->get_current(now)->failures++;
+    five_second[type]->get_current()->failures++;
+    five_minute[type]->get_current()->failures++;
   }
 };
 

--- a/src/snmp_success_fail_count_by_request_type_table.cpp
+++ b/src/snmp_success_fail_count_by_request_type_table.cpp
@@ -52,7 +52,10 @@ public:
     TimeAndOtherTypeBasedRow<SuccessFailCount>(time_index, type_index, view) {};
   ColumnData get_columns()
   {
-    SuccessFailCount* counts = _view->get_data();
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME_COARSE, &now);
+
+    SuccessFailCount* counts = _view->get_data(now);
     uint_fast32_t attempts = counts->attempts.load();
     uint_fast32_t successes = counts->successes.load();
     uint_fast32_t failures = counts->failures.load();
@@ -69,7 +72,7 @@ public:
   static int get_count_size() { return 3; }
 };
 
-static std::vector<int> request_types = 
+static std::vector<int> request_types =
 {
   SIPRequestTypes::INVITE,
   SIPRequestTypes::ACK,
@@ -97,24 +100,33 @@ public:
     CountsByOtherTypeTableImpl<SuccessFailCountByRequestTypeRow>(name,
                                                                  tbl_oid,
                                                                  request_types)
-  {} 
-  
+  {}
+
   void increment_attempts(SIPRequestTypes type)
   {
-    five_second[type]->get_current()->attempts++;
-    five_minute[type]->get_current()->attempts++;
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME_COARSE, &now);
+
+    five_second[type]->get_current(now)->attempts++;
+    five_minute[type]->get_current(now)->attempts++;
   }
-  
+
   void increment_successes(SIPRequestTypes type)
   {
-    five_second[type]->get_current()->successes++;
-    five_minute[type]->get_current()->successes++;
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME_COARSE, &now);
+
+    five_second[type]->get_current(now)->successes++;
+    five_minute[type]->get_current(now)->successes++;
   }
-  
+
   void increment_failures(SIPRequestTypes type)
   {
-    five_second[type]->get_current()->failures++;
-    five_minute[type]->get_current()->failures++;
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME_COARSE, &now);
+
+    five_second[type]->get_current(now)->failures++;
+    five_minute[type]->get_current(now)->failures++;
   }
 };
 

--- a/src/snmp_success_fail_count_table.cpp
+++ b/src/snmp_success_fail_count_table.cpp
@@ -51,7 +51,10 @@ public:
     TimeBasedRow<SuccessFailCount>(index, view) {};
   ColumnData get_columns()
   {
-    SuccessFailCount* counts = _view->get_data();
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME_COARSE, &now);
+
+    SuccessFailCount* counts = _view->get_data(now);
     uint_fast32_t attempts = counts->attempts.load();
     uint_fast32_t successes = counts->successes.load();
     uint_fast32_t failures = counts->failures.load();
@@ -87,23 +90,32 @@ public:
 
   void increment_attempts()
   {
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME_COARSE, &now);
+
     // Increment each underlying set of data.
-    five_second.get_current()->attempts++;
-    five_minute.get_current()->attempts++;
+    five_second.get_current(now)->attempts++;
+    five_minute.get_current(now)->attempts++;
   }
 
   void increment_successes()
   {
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME_COARSE, &now);
+
     // Increment each underlying set of data.
-    five_second.get_current()->successes++;
-    five_minute.get_current()->successes++;
+    five_second.get_current(now)->successes++;
+    five_minute.get_current(now)->successes++;
   }
 
   void increment_failures()
   {
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME_COARSE, &now);
+
     // Increment each underlying set of data.
-    five_second.get_current()->failures++;
-    five_minute.get_current()->failures++;
+    five_second.get_current(now)->failures++;
+    five_minute.get_current(now)->failures++;
   }
 
 private:

--- a/src/snmp_success_fail_count_table.cpp
+++ b/src/snmp_success_fail_count_table.cpp
@@ -90,32 +90,23 @@ public:
 
   void increment_attempts()
   {
-    struct timespec now;
-    clock_gettime(CLOCK_REALTIME_COARSE, &now);
-
     // Increment each underlying set of data.
-    five_second.get_current(now)->attempts++;
-    five_minute.get_current(now)->attempts++;
+    five_second.get_current()->attempts++;
+    five_minute.get_current()->attempts++;
   }
 
   void increment_successes()
   {
-    struct timespec now;
-    clock_gettime(CLOCK_REALTIME_COARSE, &now);
-
     // Increment each underlying set of data.
-    five_second.get_current(now)->successes++;
-    five_minute.get_current(now)->successes++;
+    five_second.get_current()->successes++;
+    five_minute.get_current()->successes++;
   }
 
   void increment_failures()
   {
-    struct timespec now;
-    clock_gettime(CLOCK_REALTIME_COARSE, &now);
-
     // Increment each underlying set of data.
-    five_second.get_current(now)->failures++;
-    five_minute.get_current(now)->failures++;
+    five_second.get_current()->failures++;
+    five_minute.get_current()->failures++;
   }
 
 private:


### PR DESCRIPTION
Previously the update time function could be called and it would have a (slightly) different time to when the original function was called. 

It is now required to pass a timspec value into update time, which will generally be when the function will be called, to ensure consistency