### PR TITLE
Reviewer AMC: SRV priority and Diameter routing

### DIFF
--- a/include/baseresolver.h
+++ b/include/baseresolver.h
@@ -54,6 +54,8 @@ struct AddrInfo
   IP46Address address;
   int port;
   int transport;
+  int priority;
+  int weight;
 
   bool operator<(const AddrInfo& rhs) const
   {

--- a/include/diameterstack.h
+++ b/include/diameterstack.h
@@ -584,6 +584,11 @@ public:
   inline const bool& connected() const {return _connected;}
   inline void set_connected() {_connected = true;}
 
+  inline void set_srv_priority(int priority)
+  {
+    _addr_info.priority = priority;
+  }
+
 private:
   AddrInfo _addr_info;
   bool _addr_info_specified;

--- a/include/realmmanager.h
+++ b/include/realmmanager.h
@@ -81,7 +81,7 @@ private:
   pthread_mutex_t _lock;
   pthread_cond_t _cond;
   DiameterResolver* _resolver;
-  std::vector<Diameter::Peer*> _peers;
+  std::map<std::string, Diameter::Peer*> _peers;
   volatile bool _terminating;
 };
 

--- a/include/realmmanager.h
+++ b/include/realmmanager.h
@@ -42,7 +42,13 @@
 #include "diameterstack.h"
 #include "diameterresolver.h"
 
-class RealmManager : public Diameter::PeerListener
+namespace Diameter
+{
+class Stack;
+class Peer;
+}
+
+class RealmManager
 {
 public:
   RealmManager(Diameter::Stack* stack,
@@ -55,8 +61,9 @@ public:
   void start();
   void stop();
 
-  void connection_succeeded(Diameter::Peer* peer);
-  void connection_failed(Diameter::Peer* peer);
+  void peer_connection_cb(bool connection_success,
+                          const std::string& host,
+                          const std::string& realm);
 
   static const int DEFAULT_BLACKLIST_DURATION;
 
@@ -75,7 +82,6 @@ private:
   pthread_cond_t _cond;
   DiameterResolver* _resolver;
   std::vector<Diameter::Peer*> _peers;
-  std::vector<Diameter::Peer*> _connected_peers;
   volatile bool _terminating;
 };
 

--- a/include/realmmanager.h
+++ b/include/realmmanager.h
@@ -65,6 +65,8 @@ public:
                           const std::string& host,
                           const std::string& realm);
 
+  void srv_priority_cb(struct fd_list* candidates);
+
   static const int DEFAULT_BLACKLIST_DURATION;
 
 private:

--- a/include/realmmanager.h
+++ b/include/realmmanager.h
@@ -42,12 +42,6 @@
 #include "diameterstack.h"
 #include "diameterresolver.h"
 
-namespace Diameter
-{
-class Stack;
-class Peer;
-}
-
 class RealmManager
 {
 public:
@@ -75,12 +69,24 @@ private:
 
   void manage_connections(int& ttl);
 
+  // We use a read/write lock to read and update the _peers map (defined below).
+  // However, we read this map on every single Diameter message, so we want to
+  // minimise blocking. Therefore we only grab the write lock when we are ready
+  // to write to _peers. This means we may first grab the read lock (to work
+  // out what write we want to do). However, we can't upgrade a read lock to a
+  // write lock, and we don't want somebody else to write to the peers map
+  // whilst in between reading and writing. Therefore a function that wishes to
+  // write to the peers map MUST ALSO HAVE HOLD OF THE MAIN THREAD LOCK. This is
+  // not policed anywhere (in fact, we can't police it), but that's how these
+  // locks should be used.
+  pthread_mutex_t _main_thread_lock;
+  pthread_rwlock_t _peers_lock;
+
   Diameter::Stack* _stack;
   std::string _realm;
   std::string _host;
   int _max_peers;
   pthread_t _thread;
-  pthread_mutex_t _lock;
   pthread_cond_t _cond;
   DiameterResolver* _resolver;
   std::map<std::string, Diameter::Peer*> _peers;

--- a/include/sasevent.h
+++ b/include/sasevent.h
@@ -42,7 +42,7 @@
 
 namespace SASEvent {
 
-  const std::string CURRENT_RESOURCE_BUNDLE_DATESTAMP = "20150923";
+  const std::string CURRENT_RESOURCE_BUNDLE_DATESTAMP = "20150926";
   const std::string RESOURCE_BUNDLE_NAME = "org.projectclearwater";
   const std::string CURRENT_RESOURCE_BUNDLE =
                  RESOURCE_BUNDLE_NAME + "." + CURRENT_RESOURCE_BUNDLE_DATESTAMP;

--- a/src/baseresolver.cpp
+++ b/src/baseresolver.cpp
@@ -247,6 +247,8 @@ void BaseResolver::srv_resolve(const std::string& srv_name,
              ++ii)
         {
           ai.port = srvs[ii]->port;
+          ai.priority = srvs[ii]->priority;
+          ai.weight = srvs[ii]->weight;
 
           if (!active_addr[ii].empty())
           {

--- a/src/diameterstack.cpp
+++ b/src/diameterstack.cpp
@@ -371,14 +371,15 @@ void Stack::fd_peer_hook_cb(enum fd_hook_type type,
     TRC_DEBUG("Callback (type %d) from freeDiameter: %s", type, peer->info.pi_diamid);
 
     std::string host = peer->info.pi_diamid;
-    std::string realm = peer->info.runtime.pir_realm;
 
     pthread_rwlock_rdlock(&_peer_connection_cbs_lock);
     for (std::map<std::string, PeerConnectionCB>::const_iterator cb = _peer_connection_cbs.begin();
          cb != _peer_connection_cbs.end();
          ++cb)
     {
-      (cb->second)((type == HOOK_PEER_CONNECT_SUCCESS) ? true : false, host, realm);
+      (cb->second)((type == HOOK_PEER_CONNECT_SUCCESS) ? true : false,
+                   host,
+                   (type == HOOK_PEER_CONNECT_SUCCESS) ? peer->info.runtime.pir_realm : "");
     }
     pthread_rwlock_unlock(&_peer_connection_cbs_lock);
   }

--- a/src/realmmanager.cpp
+++ b/src/realmmanager.cpp
@@ -370,6 +370,10 @@ void RealmManager::manage_connections(int& ttl)
         zombies++;
       }
     }
+    else
+    {
+      jj->second->set_srv_priority(ii->priority);
+    }
   }
 
   // 6. Tell the stack the number of peers we're currently managing (including

--- a/test_utils/mockdiameterstack.hpp
+++ b/test_utils/mockdiameterstack.hpp
@@ -48,8 +48,10 @@ public:
   MOCK_METHOD1(advertize_application, void(const Diameter::Dictionary::Application&));
   MOCK_METHOD3(register_handler, void(const Diameter::Dictionary::Application&, const Diameter::Dictionary::Message&, HandlerInterface*));
   MOCK_METHOD1(register_fallback_handler, void(const Diameter::Dictionary::Application&));
-  MOCK_METHOD1(register_peer_hook_hdlr, void(PeerConnectionCB));
-  MOCK_METHOD0(unregister_peer_hook_hdlr, void());
+  MOCK_METHOD2(register_peer_hook_hdlr, void(std::string, PeerConnectionCB));
+  MOCK_METHOD1(unregister_peer_hook_hdlr, void(std::string));
+  MOCK_METHOD2(register_rt_out_cb, void(std::string, RtOutCB));
+  MOCK_METHOD1(unregister_rt_out_cb, void(std::string));
   MOCK_METHOD0(start, void());
   MOCK_METHOD0(stop, void());
   MOCK_METHOD0(wait_stopped, void());

--- a/test_utils/mockdiameterstack.hpp
+++ b/test_utils/mockdiameterstack.hpp
@@ -48,9 +48,9 @@ public:
   MOCK_METHOD1(advertize_application, void(const Diameter::Dictionary::Application&));
   MOCK_METHOD3(register_handler, void(const Diameter::Dictionary::Application&, const Diameter::Dictionary::Message&, HandlerInterface*));
   MOCK_METHOD1(register_fallback_handler, void(const Diameter::Dictionary::Application&));
-  MOCK_METHOD2(register_peer_hook_hdlr, void(std::string, PeerConnectionCB));
+  MOCK_METHOD2(register_peer_hook_hdlr, void(std::string, Diameter::PeerConnectionCB));
   MOCK_METHOD1(unregister_peer_hook_hdlr, void(std::string));
-  MOCK_METHOD2(register_rt_out_cb, void(std::string, RtOutCB));
+  MOCK_METHOD2(register_rt_out_cb, void(std::string, Diameter::RtOutCB));
   MOCK_METHOD1(unregister_rt_out_cb, void(std::string));
   MOCK_METHOD0(start, void());
   MOCK_METHOD0(stop, void());

--- a/test_utils/mockdiameterstack.hpp
+++ b/test_utils/mockdiameterstack.hpp
@@ -48,7 +48,7 @@ public:
   MOCK_METHOD1(advertize_application, void(const Diameter::Dictionary::Application&));
   MOCK_METHOD3(register_handler, void(const Diameter::Dictionary::Application&, const Diameter::Dictionary::Message&, HandlerInterface*));
   MOCK_METHOD1(register_fallback_handler, void(const Diameter::Dictionary::Application&));
-  MOCK_METHOD0(register_peer_hook_hdlr, void());
+  MOCK_METHOD1(register_peer_hook_hdlr, void(PeerConnectionCB));
   MOCK_METHOD0(unregister_peer_hook_hdlr, void());
   MOCK_METHOD0(start, void());
   MOCK_METHOD0(stop, void());
@@ -60,6 +60,7 @@ public:
   MOCK_METHOD1(remove, void(Diameter::Peer*));
   MOCK_METHOD0(set_allow_connections, void());
   MOCK_METHOD0(close_connections, void());
+  MOCK_METHOD2(peer_count, void(int, int));
 };
 
 #endif


### PR DESCRIPTION
Hi Andy,

Please can you review these cpp-common changes to allow us to take into account SRV priority when routing Diameter messages?

The bulk of the work here is to refactor the existing code to make it more usable. Specifically, I've made RealmManager the sole manager of Diameter peers (removing the Diameter Stack's list of them), and I've tried to keep freeDiameter out of the RealmManager (instead using the Diameter Stack as the interface to freeDiameter), and I've made RealmManager an application of the Diameter Stack, so that the Stack doesn't know anything about RealmManager.

In addition to this, RealmManager now keeps track of the peers as a map rather than a vector, so that we can easily look up the Peer object when we get a call back. This is important because we now need to do this on the call path (i.e. when taking into account the SRV priority on message routing).

There is an accompanying Homestead PR (https://github.com/Metaswitch/homestead/pull/261) because the RealmManager is UTed in Homestead. I've still got complete code coverage on the RealmManager. I've also verified that existing function still works live, and I'm intending to run through the rest of the test plan later in the week.

Let me know if you've got any questions. It would be great if you could review by **end of Wednesday**, but let me know if that's going to be a problem.

Thanks,
Graeme