### PR TITLE
[Reviewer: Graeme] Catch exception if there's no keysapce set up

### DIFF
--- a/src/cassandra_store.cpp
+++ b/src/cassandra_store.cpp
@@ -184,6 +184,11 @@ ResultCode Store::connection_test()
     TRC_ERROR("Store caught NotFoundException: %s", nfe.what());
     rc = NOT_FOUND;
   }
+  catch(InvalidRequestException ire)
+  {
+    TRC_ERROR("Store caught InvalidRequestException: %s", ire.why.c_str());
+    rc = INVALID_REQUEST;
+  }
   catch(...)
   {
     TRC_ERROR("Store caught unknown exception!");


### PR DESCRIPTION
Graeme, can you review this change to catch an exception if the schema hasn't been set up, and put the reason in the trace, e.g.:
```
Error cassandra_store.cpp:189: Store caught InvalidRequestException: Keyspace 'homestead_cache' does not exist)
```

Fixes #382 