### PR TITLE
Increment table Implementation - Reviewer EM

### DIFF
--- a/include/current_and_previous.h
+++ b/include/current_and_previous.h
@@ -42,6 +42,7 @@
 #include <string>
 #include <atomic>
 #include "logger.h"
+#include "log.h"
 
 template <class T> class CurrentAndPrevious
 {
@@ -69,11 +70,13 @@ public:
   // Rolls the current period over into the previous period if necessary.
   void update_time(struct timespec now)
   {
+    TRC_DEBUG("calling Current_and_Previous func update_time");
     // Count of how many _interval periods have passed since the epoch
     uint64_t new_tick = (now.tv_sec / (_interval_ms / 1000));
 
     // Count of how many _interval periods have passed since the last change
     uint32_t tick_difference = new_tick - _tick;
+    TRC_DEBUG("Tick difference = %u ", tick_difference);
     _tick = new_tick;
 
     if (tick_difference == 1)

--- a/include/current_and_previous.h
+++ b/include/current_and_previous.h
@@ -70,13 +70,11 @@ public:
   // Rolls the current period over into the previous period if necessary.
   void update_time(struct timespec now)
   {
-    TRC_DEBUG("calling Current_and_Previous func update_time");
     // Count of how many _interval periods have passed since the epoch
     uint64_t new_tick = (now.tv_sec / (_interval_ms / 1000));
 
     // Count of how many _interval periods have passed since the last change
     uint32_t tick_difference = new_tick - _tick;
-    TRC_DEBUG("Tick difference = %u ", tick_difference);
     _tick = new_tick;
 
     if (tick_difference == 1)

--- a/include/current_and_previous.h
+++ b/include/current_and_previous.h
@@ -42,7 +42,6 @@
 #include <string>
 #include <atomic>
 #include "logger.h"
-#include "log.h"
 
 template <class T> class CurrentAndPrevious
 {

--- a/include/snmp_continuous_increment_table.h
+++ b/include/snmp_continuous_increment_table.h
@@ -46,7 +46,7 @@
 
 // This file contains the interface for tables which:
 //   - are indexed by time period
-//   - accumulate data samples over time
+//   - adjust data by means of incrementing or decrementing the current running total
 //   - report a count of samples, high-water-mark and low-water-mark
 //   - report mean sample rate and variance as weighted by the proportion
 //         of time active within the time period
@@ -55,30 +55,25 @@
 // The thing sampled should be a continiuous data set, i.e. valued across a
 // time period.
 //
-// To create an accumulator table, simply create one, and call `accumulate` on it as data comes in,
+// To create an increment table, simply create one, and call `increment` or 
+// 'decrement' on it as data comes in,
 // e.g.:
 //
-// ContinuousAccumulatorTable* token_rate_table = ContinuousAccumulatorTable::create("token_rate", ".1.2.3");
-// token_rate_table->accumulate(2000);
+// ContinuousIncrementTable* token_rate_table = ContinuousIncrementTable::create("token_rate", ".1.2.3");
+// token_rate_table->increment(1);
 
 namespace SNMP
 {
-
 class ContinuousIncrementTable
 {
 public:
   ContinuousIncrementTable() {};
   virtual ~ContinuousIncrementTable() {};
-
   static ContinuousIncrementTable* create(std::string name, std::string oid);
 
-  // Accumulate a sample into the underlying statistics.
+  // Increment or decrement the underlying statistics.
   virtual void increment (uint32_t value) = 0;
   virtual void decrement (uint32_t value) = 0;
-
-
 };
-
 }
-
 #endif

--- a/include/snmp_continuous_increment_table.h
+++ b/include/snmp_continuous_increment_table.h
@@ -1,0 +1,84 @@
+/**
+ * @file snmp_continuous_increment_table.h
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2015 Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed und er the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include <vector>
+#include <map>
+#include <string>
+#include <atomic>
+
+#include "logger.h"
+
+#ifndef SNMP_CONTINUOUS_INCREMENT_TABLE_H
+#define SNMP_CONTINUOUS_INCREMENT_TABLE_H
+
+// This file contains the interface for tables which:
+//   - are indexed by time period
+//   - accumulate data samples over time
+//   - report a count of samples, high-water-mark and low-water-mark
+//   - report mean sample rate and variance as weighted by the proportion
+//         of time active within the time period
+//   - carry across final value as initial value for the next table
+//
+// The thing sampled should be a continiuous data set, i.e. valued across a
+// time period.
+//
+// To create an accumulator table, simply create one, and call `accumulate` on it as data comes in,
+// e.g.:
+//
+// ContinuousAccumulatorTable* token_rate_table = ContinuousAccumulatorTable::create("token_rate", ".1.2.3");
+// token_rate_table->accumulate(2000);
+
+namespace SNMP
+{
+
+class ContinuousIncrementTable
+{
+public:
+  ContinuousIncrementTable() {};
+  virtual ~ContinuousIncrementTable() {};
+
+  static ContinuousIncrementTable* create(std::string name, std::string oid);
+
+  // Accumulate a sample into the underlying statistics.
+  virtual void increment (uint32_t value) = 0;
+  virtual void decrement (uint32_t value) = 0;
+
+
+};
+
+}
+
+#endif

--- a/src/snmp_continuous_accumulator_table.cpp
+++ b/src/snmp_continuous_accumulator_table.cpp
@@ -41,7 +41,6 @@
 
 namespace SNMP
 {
-
 // Just a TimeBasedRow that maps the data from ContinuousStatistics into the right five columns.
 class ContinuousAccumulatorRow: public TimeBasedRow<ContinuousStatistics>
 {
@@ -50,16 +49,18 @@ public:
   ColumnData get_columns();
 };
 
-class ContinuousAccumulatorTableImpl: public ManagedTable<ContinuousAccumulatorRow, int>, public ContinuousAccumulatorTable
+class ContinuousAccumulatorTableImpl: public ManagedTable<ContinuousAccumulatorRow, int>,
+                                      public ContinuousAccumulatorTable
 {
 public:
   ContinuousAccumulatorTableImpl(std::string name,
-                       std::string tbl_oid):
-    ManagedTable<ContinuousAccumulatorRow, int>(name,
-                                      tbl_oid,
-                                      2,
-                                      6, // Columns 2-6 should be visible
-                                      { ASN_INTEGER }), // Type of the index column
+                                 std::string tbl_oid):
+                                 ManagedTable<ContinuousAccumulatorRow,int>
+                                       (name,
+                                        tbl_oid,
+                                        2,
+                                        6, // Columns 2-6 should be visible
+                                        { ASN_INTEGER }), // Type of the index column
     five_second(5000),
     five_minute(300000)
   {
@@ -191,7 +192,7 @@ ColumnData ContinuousAccumulatorRow::get_columns()
 
   if (period_count > 0)
   {
-    // Calculate the average and the variance from the stored average/time of last upadted
+    // Calculate the average and the variance from the stored average/time of last updated
     // and sum-of-squares.
     sum += time_since_last_update_ms * current_value;
     accumulated->sum.store(sum);
@@ -199,7 +200,6 @@ ColumnData ContinuousAccumulatorRow::get_columns()
     accumulated->sqsum.store(sqsum);
     avg = sum / period_count;
     variance = ((sqsum * period_count) - (sum * sum)) / (period_count * period_count);
-//    variance = sqsum / period_count - (sum * sum);
   }
 
   // Construct and return a ColumnData with the appropriate values
@@ -213,9 +213,9 @@ ColumnData ContinuousAccumulatorRow::get_columns()
   return ret;
 }
 
-ContinuousAccumulatorTable* ContinuousAccumulatorTable::create(std::string name, std::string oid)
+ContinuousAccumulatorTable* ContinuousAccumulatorTable::create(std::string name,
+                                                               std::string oid)
 {
   return new ContinuousAccumulatorTableImpl(name, oid);
-
 }
 }

--- a/src/snmp_continuous_increment_table.cpp
+++ b/src/snmp_continuous_increment_table.cpp
@@ -1,0 +1,261 @@
+/**
+ * @file snmp_continuous_increment_table.cpp
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2015 Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include "snmp_statistics_structures.h"
+#include "snmp_internal/snmp_time_period_table.h"
+#include "snmp_continuous_increment_table.h"
+#include "limits.h"
+
+namespace SNMP
+{
+
+// Just a TimeBasedRow that maps the data from ContinuousStatistics into the right five columns.
+class ContinuousAccumulatorRow: public TimeBasedRow<ContinuousStatistics>
+{
+public:
+  ContinuousAccumulatorRow(int index, View* view): TimeBasedRow<ContinuousStatistics>(index, view) {};
+  ColumnData get_columns();
+};
+
+class ContinuousIncrementTableImpl: public ManagedTable<ContinuousAccumulatorRow, int>, public ContinuousIncrementTable
+{
+public:
+  ContinuousIncrementTableImpl(std::string name,
+                       std::string tbl_oid):
+    ManagedTable<ContinuousAccumulatorRow, int>(name,
+                                      tbl_oid,
+                                      2,
+                                      6, // Columns 2-6 should be visible
+                                      { ASN_INTEGER }), // Type of the index column
+    five_second(5000),
+    five_minute(300000)
+  {
+    // We have a fixed number of rows, so create them in the constructor.
+    add(TimePeriodIndexes::scopePrevious5SecondPeriod);
+    add(TimePeriodIndexes::scopeCurrent5MinutePeriod);
+    add(TimePeriodIndexes::scopePrevious5MinutePeriod);
+  }
+
+  void increment(uint32_t value)
+  {
+    TRC_DEBUG("Received request to increment by %uui", value);
+    //pass value as increment through to value adjusting structure.
+    TRC_DEBUG("Passing to count_internal with CurrentAndPrevious = five_second");
+    count_internal(five_second, value, TRUE);
+    TRC_DEBUG("Passing to count_internal with CurrentAndPrevious = five_minute");
+    count_internal(five_minute, value, TRUE);
+  }
+
+  void decrement(uint32_t value)
+  {
+    TRC_DEBUG("Received request to decrement by %uui", value);
+    //pass value as decrement through to value adjusting structure.
+    TRC_DEBUG("Passing to count_internal with CurrentAndPrevious = five_second");
+    count_internal(five_second, value, FALSE);
+    TRC_DEBUG("Passing to count_internal with CurrentAndPrevious = five_minute");
+    count_internal(five_minute, value, FALSE);
+  }
+
+private:
+  // Map row indexes to the view of the underlying data they should expose
+  ContinuousAccumulatorRow* new_row(int index)
+  {
+    ContinuousAccumulatorRow::View* view = NULL;
+    switch (index)
+    {
+      case TimePeriodIndexes::scopePrevious5SecondPeriod:
+        view = new ContinuousAccumulatorRow::PreviousView(&five_second);
+        break;
+      case TimePeriodIndexes::scopeCurrent5MinutePeriod:
+        view = new ContinuousAccumulatorRow::CurrentView(&five_minute);
+        break;
+      case TimePeriodIndexes::scopePrevious5MinutePeriod:
+        view = new ContinuousAccumulatorRow::PreviousView(&five_minute);
+        break;
+    }
+    return new ContinuousAccumulatorRow(index, view);
+  }
+
+  void count_internal(CurrentAndPrevious<ContinuousStatistics>& data, uint32_t value, bool increment_total)
+  {
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME_COARSE, &now);
+
+    ContinuousStatistics* current_data = data.get_current(now);
+    uint32_t total = current_data->current_value;
+
+    if(increment_total)
+      {
+        TRC_DEBUG("Count_internal Incrementing value");
+        total+=value;
+      }
+    else
+      {
+        TRC_DEBUG("Count_internal decrementing value");
+        total-=value;
+        //check to ensure the value to accumulate is not negative
+        if(value<0)
+        {
+          value=0;
+        }
+      }
+      accumulate_internal(current_data, total, now);
+  }
+
+
+
+  void accumulate_internal(ContinuousStatistics* current_data, uint32_t sample, const struct timespec& now)
+  {
+
+    TRC_DEBUG("Accumulating sample %uui into continuous accumulator statistic", sample);
+
+    current_data->count++;
+
+    // Compute the updated sum and sqsum based on the previous values, dependent on
+    // how long since an update happened. Additionally update the sum of squares as a
+    // rolling total, and update the time of the last update. Also maintain a
+    // current value held, that can be used if the period ends.
+
+    uint64_t time_since_last_update = ((now.tv_sec * 1000) + (now.tv_nsec / 1000000))
+                                     - (current_data->time_last_update_ms.load());
+    uint32_t current_value = current_data->current_value.load();
+
+    current_data->time_last_update_ms = (now.tv_sec * 1000) + (now.tv_nsec / 1000000);
+    current_data->sum += current_value * time_since_last_update;
+    current_data->sqsum += current_value * current_value * time_since_last_update;
+    current_data->current_value = sample;
+    TRC_DEBUG("Setting time since last update, sum, sqsum and current value");
+
+    // Update the low- and high-water marks.  In each case, we get the current
+    // value, decide whether a change is required and then atomically swap it
+    // if so, repeating if it was changed in the meantime.  Note that
+    // compare_exchange_weak loads the current value into the expected value
+    // parameter (lwm or hwm below) if the compare fails.
+    uint_fast64_t lwm = current_data->lwm.load();
+    TRC_DEBUG("comparing recorded LWM %u to the passed in sample %u", lwm, sample);
+    while ((sample < lwm) &&
+           (!current_data->lwm.compare_exchange_weak(lwm, sample)))
+    {
+      // Do nothing.
+    }
+    uint_fast64_t hwm = current_data->hwm.load();
+    TRC_DEBUG("comparing recorded HWM %u to the passed in sample %u", hwm, sample);
+    while ((sample > hwm) &&
+           (!current_data->hwm.compare_exchange_weak(hwm, sample)))
+    {
+      // Do nothing.
+    }
+  };
+
+
+  CurrentAndPrevious<ContinuousStatistics> five_second;
+  CurrentAndPrevious<ContinuousStatistics> five_minute;
+};
+
+ColumnData ContinuousAccumulatorRow::get_columns()
+{
+  struct timespec now;
+  clock_gettime(CLOCK_REALTIME_COARSE, &now);
+
+  TRC_DEBUG("calling ColumnData ContinuousAccumulatorRow::get_columns()");
+  ContinuousStatistics* accumulated = _view->get_data(now);
+  uint32_t interval_ms = _view->get_interval_ms();
+
+  uint_fast32_t count = accumulated->count.load();
+  uint_fast32_t current_value = accumulated->current_value.load();
+
+  uint_fast64_t avg = current_value;
+  uint_fast64_t variance = 0;
+  uint_fast32_t lwm = accumulated->lwm.load();
+  // If LWM is still ULONG_MAX, then report as 0, as no results
+  // have been entered (and HWM will be reported as 0)
+  if (lwm == ULONG_MAX)
+  {
+    lwm = 0;
+  }
+  uint_fast32_t hwm = accumulated->hwm.load();
+  uint_fast64_t time_last_update_ms = accumulated->time_last_update_ms.load();
+  uint_fast64_t time_period_start_ms = accumulated->time_period_start_ms.load();
+  uint_fast64_t sum = accumulated->sum.load();
+  uint_fast64_t sqsum = accumulated->sqsum.load();
+
+  // We need to know how long it has been since we've last updated.
+  // We must distinguish between the case that we have moved onto the
+  // next period though, which we do by comparing the calculated end of period
+  // with the current time. We should use the smaller value to accumulate with,
+  // to stop us from updating periods that are now out of date.
+  uint64_t time_now_ms = (now.tv_sec * 1000) + (now.tv_nsec / 1000000);
+
+  // As a time period might not begin on a boundary, we must synchronize
+  // the end of the period with a boundary which is why the following line
+  // requires so many interval_ms!
+  uint64_t time_period_end_ms = ((time_period_start_ms + interval_ms) / interval_ms) * interval_ms;
+  uint64_t time_comes_first_ms = std::min(time_period_end_ms, time_now_ms);
+
+  uint64_t time_since_last_update_ms = time_comes_first_ms - time_last_update_ms;
+  accumulated->time_last_update_ms.store(time_comes_first_ms);
+  uint64_t period_count = (time_comes_first_ms - time_period_start_ms);
+
+  if (period_count > 0)
+  {
+    // Calculate the average and the variance from the stored average/time of last upadted
+    // and sum-of-squares.
+    sum += time_since_last_update_ms * current_value;
+    accumulated->sum.store(sum);
+    sqsum += time_since_last_update_ms * current_value * current_value;
+    accumulated->sqsum.store(sqsum);
+    avg = sum / period_count;
+    variance = ((sqsum * period_count) - (sum * sum)) / (period_count * period_count);
+//    variance = sqsum / period_count - (sum * sum);
+  }
+
+  // Construct and return a ColumnData with the appropriate values
+  ColumnData ret;
+  ret[1] = Value::integer(_index);
+  ret[2] = Value::uint(avg);
+  ret[3] = Value::uint(variance);
+  ret[4] = Value::uint(hwm);
+  ret[5] = Value::uint(lwm);
+  ret[6] = Value::uint(count);
+  return ret;
+}
+
+ContinuousIncrementTable* ContinuousIncrementTable::create(std::string name, std::string oid)
+{
+  return new ContinuousIncrementTableImpl(name, oid);
+
+}
+}

--- a/src/snmp_continuous_increment_table.cpp
+++ b/src/snmp_continuous_increment_table.cpp
@@ -131,11 +131,8 @@ private:
     accumulate_internal(current_data, total, now);
   }
 
-
-
   void accumulate_internal(ContinuousStatistics* current_data, uint32_t sample, const struct timespec& now)
   {
-
 
     current_data->count++;
 
@@ -171,7 +168,6 @@ private:
       // Do nothing.
     }
   };
-
 
   CurrentAndPrevious<ContinuousStatistics> five_second;
   CurrentAndPrevious<ContinuousStatistics> five_minute;
@@ -247,6 +243,5 @@ ColumnData ContinuousAccumulatorRow::get_columns()
 ContinuousIncrementTable* ContinuousIncrementTable::create(std::string name, std::string oid)
 {
   return new ContinuousIncrementTableImpl(name, oid);
-
 }
 }

--- a/src/snmp_continuous_increment_table.cpp
+++ b/src/snmp_continuous_increment_table.cpp
@@ -41,7 +41,6 @@
 
 namespace SNMP
 {
-
 // Just a TimeBasedRow that maps the data from ContinuousStatistics into the right five columns.
 class ContinuousAccumulatorRow: public TimeBasedRow<ContinuousStatistics>
 {
@@ -50,12 +49,14 @@ public:
   ColumnData get_columns();
 };
 
-class ContinuousIncrementTableImpl: public ManagedTable<ContinuousAccumulatorRow, int>, public ContinuousIncrementTable
+class ContinuousIncrementTableImpl: public ManagedTable<ContinuousAccumulatorRow, int>,
+                                    public ContinuousIncrementTable
 {
 public:
   ContinuousIncrementTableImpl(std::string name,
-                       std::string tbl_oid):
-    ManagedTable<ContinuousAccumulatorRow, int>(name,
+                               std::string tbl_oid):
+                               ManagedTable<ContinuousAccumulatorRow, int>
+                                     (name,
                                       tbl_oid,
                                       2,
                                       6, // Columns 2-6 should be visible
@@ -71,14 +72,14 @@ public:
 
   void increment(uint32_t value)
   {
-    //pass value as increment through to value adjusting structure.
+    // Pass value as increment through to value adjusting structure.
     count_internal(five_second, value, TRUE);
     count_internal(five_minute, value, TRUE);
   }
 
   void decrement(uint32_t value)
   {
-    //pass value as decrement through to value adjusting structure.
+    // Pass value as decrement through to value adjusting structure.
     count_internal(five_second, value, FALSE);
     count_internal(five_minute, value, FALSE);
   }
@@ -117,8 +118,8 @@ private:
     }
     else
     {
-      //check to ensure the value to accumulate will not be negative,
-      //and then set to 0 or decrement appropriately.
+      // Check to ensure the value to accumulate will not be negative,
+      // and then set to 0 or decrement appropriately.
       if (total < value)
       {
         total = 0;
@@ -131,9 +132,10 @@ private:
     accumulate_internal(current_data, total, now);
   }
 
-  void accumulate_internal(ContinuousStatistics* current_data, uint32_t sample, const struct timespec& now)
+  void accumulate_internal(ContinuousStatistics* current_data,
+                           uint32_t sample,
+                           const struct timespec& now)
   {
-
     current_data->count++;
 
     // Compute the updated sum and sqsum based on the previous values, dependent on
@@ -218,7 +220,7 @@ ColumnData ContinuousAccumulatorRow::get_columns()
 
   if (period_count > 0)
   {
-    // Calculate the average and the variance from the stored average/time of last upadted
+    // Calculate the average and the variance from the stored average/time of last updated
     // and sum-of-squares.
     sum += time_since_last_update_ms * current_value;
     accumulated->sum.store(sum);
@@ -226,7 +228,6 @@ ColumnData ContinuousAccumulatorRow::get_columns()
     accumulated->sqsum.store(sqsum);
     avg = sum / period_count;
     variance = ((sqsum * period_count) - (sum * sum)) / (period_count * period_count);
-//    variance = sqsum / period_count - (sum * sum);
   }
 
   // Construct and return a ColumnData with the appropriate values
@@ -240,7 +241,8 @@ ColumnData ContinuousAccumulatorRow::get_columns()
   return ret;
 }
 
-ContinuousIncrementTable* ContinuousIncrementTable::create(std::string name, std::string oid)
+ContinuousIncrementTable* ContinuousIncrementTable::create(std::string name,
+                                                           std::string oid)
 {
   return new ContinuousIncrementTableImpl(name, oid);
 }

--- a/src/snmp_continuous_increment_table.cpp
+++ b/src/snmp_continuous_increment_table.cpp
@@ -73,9 +73,7 @@ public:
   {
     TRC_DEBUG("Received request to increment by %u", value);
     //pass value as increment through to value adjusting structure.
-    //TRC_DEBUG("Passing to count_internal with CurrentAndPrevious = five_second");
     count_internal(five_second, value, TRUE);
-    //TRC_DEBUG("Passing to count_internal with CurrentAndPrevious = five_minute");
     count_internal(five_minute, value, TRUE);
   }
 
@@ -83,9 +81,7 @@ public:
   {
     TRC_DEBUG("Received request to decrement by %uui", value);
     //pass value as decrement through to value adjusting structure.
-    //TRC_DEBUG("Passing to count_internal with CurrentAndPrevious = five_second");
     count_internal(five_second, value, FALSE);
-    //TRC_DEBUG("Passing to count_internal with CurrentAndPrevious = five_minute");
     count_internal(five_minute, value, FALSE);
   }
 
@@ -119,12 +115,10 @@ private:
 
     if(increment_total)
       {
-        //TRC_DEBUG("Count_internal Incrementing value");
         total+=value;
       }
     else
       {
-        //TRC_DEBUG("Count_internal decrementing value");
         total-=value;
         //check to ensure the value to accumulate is not negative
         if(value<0)
@@ -140,7 +134,6 @@ private:
   void accumulate_internal(ContinuousStatistics* current_data, uint32_t sample, const struct timespec& now)
   {
 
-    //TRC_DEBUG("Accumulating sample %uui into continuous accumulator statistic", sample);
 
     current_data->count++;
 
@@ -157,7 +150,6 @@ private:
     current_data->sum += current_value * time_since_last_update;
     current_data->sqsum += current_value * current_value * time_since_last_update;
     current_data->current_value = sample;
-    //TRC_DEBUG("Setting time since last update, sum, sqsum and current value");
 
     // Update the low- and high-water marks.  In each case, we get the current
     // value, decide whether a change is required and then atomically swap it
@@ -165,14 +157,12 @@ private:
     // compare_exchange_weak loads the current value into the expected value
     // parameter (lwm or hwm below) if the compare fails.
     uint_fast64_t lwm = current_data->lwm.load();
-    //TRC_DEBUG("comparing recorded LWM %u to the passed in sample %u", lwm, sample);
     while ((sample < lwm) &&
            (!current_data->lwm.compare_exchange_weak(lwm, sample)))
     {
       // Do nothing.
     }
     uint_fast64_t hwm = current_data->hwm.load();
-    //TRC_DEBUG("comparing recorded HWM %u to the passed in sample %u", hwm, sample);
     while ((sample > hwm) &&
            (!current_data->hwm.compare_exchange_weak(hwm, sample)))
     {
@@ -190,7 +180,6 @@ ColumnData ContinuousAccumulatorRow::get_columns()
   struct timespec now;
   clock_gettime(CLOCK_REALTIME_COARSE, &now);
 
-  //TRC_DEBUG("calling ColumnData ContinuousAccumulatorRow::get_columns()");
   ContinuousStatistics* accumulated = _view->get_data(now);
   uint32_t interval_ms = _view->get_interval_ms();
 

--- a/src/snmp_continuous_increment_table.cpp
+++ b/src/snmp_continuous_increment_table.cpp
@@ -111,20 +111,24 @@ private:
     ContinuousStatistics* current_data = data.get_current(now);
     uint32_t total = current_data->current_value;
 
-    if(increment_total)
-      {
-        total+=value;
-      }
+    if (increment_total)
+    {
+      total += value;
+    }
     else
+    {
+      //check to ensure the value to accumulate will not be negative,
+      //and then set to 0 or decrement appropriately.
+      if (total < value)
       {
-        total-=value;
-        //check to ensure the value to accumulate is not negative
-        if(value<0)
-        {
-          value=0;
-        }
+        total = 0;
       }
-      accumulate_internal(current_data, total, now);
+      else
+      {
+        total -= value;
+      }
+    }
+    accumulate_internal(current_data, total, now);
   }
 
 

--- a/src/snmp_continuous_increment_table.cpp
+++ b/src/snmp_continuous_increment_table.cpp
@@ -142,7 +142,6 @@ private:
     // how long since an update happened. Additionally update the sum of squares as a
     // rolling total, and update the time of the last update. Also maintain a
     // current value held, that can be used if the period ends.
-
     uint64_t time_since_last_update = ((now.tv_sec * 1000) + (now.tv_nsec / 1000000))
                                      - (current_data->time_last_update_ms.load());
     uint32_t current_value = current_data->current_value.load();

--- a/src/snmp_continuous_increment_table.cpp
+++ b/src/snmp_continuous_increment_table.cpp
@@ -71,7 +71,6 @@ public:
 
   void increment(uint32_t value)
   {
-    TRC_DEBUG("Received request to increment by %u", value);
     //pass value as increment through to value adjusting structure.
     count_internal(five_second, value, TRUE);
     count_internal(five_minute, value, TRUE);
@@ -79,7 +78,6 @@ public:
 
   void decrement(uint32_t value)
   {
-    TRC_DEBUG("Received request to decrement by %uui", value);
     //pass value as decrement through to value adjusting structure.
     count_internal(five_second, value, FALSE);
     count_internal(five_minute, value, FALSE);

--- a/src/snmp_continuous_increment_table.cpp
+++ b/src/snmp_continuous_increment_table.cpp
@@ -71,11 +71,11 @@ public:
 
   void increment(uint32_t value)
   {
-    TRC_DEBUG("Received request to increment by %uui", value);
+    TRC_DEBUG("Received request to increment by %u", value);
     //pass value as increment through to value adjusting structure.
-    TRC_DEBUG("Passing to count_internal with CurrentAndPrevious = five_second");
+    //TRC_DEBUG("Passing to count_internal with CurrentAndPrevious = five_second");
     count_internal(five_second, value, TRUE);
-    TRC_DEBUG("Passing to count_internal with CurrentAndPrevious = five_minute");
+    //TRC_DEBUG("Passing to count_internal with CurrentAndPrevious = five_minute");
     count_internal(five_minute, value, TRUE);
   }
 
@@ -83,9 +83,9 @@ public:
   {
     TRC_DEBUG("Received request to decrement by %uui", value);
     //pass value as decrement through to value adjusting structure.
-    TRC_DEBUG("Passing to count_internal with CurrentAndPrevious = five_second");
+    //TRC_DEBUG("Passing to count_internal with CurrentAndPrevious = five_second");
     count_internal(five_second, value, FALSE);
-    TRC_DEBUG("Passing to count_internal with CurrentAndPrevious = five_minute");
+    //TRC_DEBUG("Passing to count_internal with CurrentAndPrevious = five_minute");
     count_internal(five_minute, value, FALSE);
   }
 
@@ -119,12 +119,12 @@ private:
 
     if(increment_total)
       {
-        TRC_DEBUG("Count_internal Incrementing value");
+        //TRC_DEBUG("Count_internal Incrementing value");
         total+=value;
       }
     else
       {
-        TRC_DEBUG("Count_internal decrementing value");
+        //TRC_DEBUG("Count_internal decrementing value");
         total-=value;
         //check to ensure the value to accumulate is not negative
         if(value<0)
@@ -140,7 +140,7 @@ private:
   void accumulate_internal(ContinuousStatistics* current_data, uint32_t sample, const struct timespec& now)
   {
 
-    TRC_DEBUG("Accumulating sample %uui into continuous accumulator statistic", sample);
+    //TRC_DEBUG("Accumulating sample %uui into continuous accumulator statistic", sample);
 
     current_data->count++;
 
@@ -157,7 +157,7 @@ private:
     current_data->sum += current_value * time_since_last_update;
     current_data->sqsum += current_value * current_value * time_since_last_update;
     current_data->current_value = sample;
-    TRC_DEBUG("Setting time since last update, sum, sqsum and current value");
+    //TRC_DEBUG("Setting time since last update, sum, sqsum and current value");
 
     // Update the low- and high-water marks.  In each case, we get the current
     // value, decide whether a change is required and then atomically swap it
@@ -165,14 +165,14 @@ private:
     // compare_exchange_weak loads the current value into the expected value
     // parameter (lwm or hwm below) if the compare fails.
     uint_fast64_t lwm = current_data->lwm.load();
-    TRC_DEBUG("comparing recorded LWM %u to the passed in sample %u", lwm, sample);
+    //TRC_DEBUG("comparing recorded LWM %u to the passed in sample %u", lwm, sample);
     while ((sample < lwm) &&
            (!current_data->lwm.compare_exchange_weak(lwm, sample)))
     {
       // Do nothing.
     }
     uint_fast64_t hwm = current_data->hwm.load();
-    TRC_DEBUG("comparing recorded HWM %u to the passed in sample %u", hwm, sample);
+    //TRC_DEBUG("comparing recorded HWM %u to the passed in sample %u", hwm, sample);
     while ((sample > hwm) &&
            (!current_data->hwm.compare_exchange_weak(hwm, sample)))
     {
@@ -190,7 +190,7 @@ ColumnData ContinuousAccumulatorRow::get_columns()
   struct timespec now;
   clock_gettime(CLOCK_REALTIME_COARSE, &now);
 
-  TRC_DEBUG("calling ColumnData ContinuousAccumulatorRow::get_columns()");
+  //TRC_DEBUG("calling ColumnData ContinuousAccumulatorRow::get_columns()");
   ContinuousStatistics* accumulated = _view->get_data(now);
   uint32_t interval_ms = _view->get_interval_ms();
 

--- a/test_utils/mock_increment_table.cpp
+++ b/test_utils/mock_increment_table.cpp
@@ -1,5 +1,5 @@
 /**
- * @file mock_increment_table.h
+ * @file mock_increment_table.cpp
  *
  * Project Clearwater - IMS in the Cloud
  * Copyright (C) 2015  Metaswitch Networks Ltd

--- a/test_utils/mock_increment_table.cpp
+++ b/test_utils/mock_increment_table.cpp
@@ -1,0 +1,41 @@
+/**
+ * @file mock_increment_table.h
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2015  Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include "mock_increment_table.h"
+
+MockIncrementTable::MockIncrementTable() {}
+
+MockIncrementTable::~MockIncrementTable() {}

--- a/test_utils/mock_increment_table.h
+++ b/test_utils/mock_increment_table.h
@@ -1,0 +1,54 @@
+/**
+ * @file mock_increment_table.h
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2015  Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#ifndef MOCK_INCREMENT_TABLE_H_
+#define MOCK_INCREMENT_TABLE_H_
+
+#include "gmock/gmock.h"
+#include "snmp_continuous_increment_table.h"
+
+class MockIncrementTable : public SNMP::ContinuousIncrementTable
+{
+public:
+  MockIncrementTable ();
+
+  ~MockIncrementTable();
+
+  MOCK_METHOD1(increment, void(uint32_t value));
+  MOCK_METHOD1(decrement, void(uint32_t value));
+};
+
+#endif


### PR DESCRIPTION
The cpp and header for the new continuous_increment_table . 
This is essentially the same as the accumulator table, but with the api altered to accept increment and decrement. as such the main statistics function now accepts a timespec set in the api functions, as well as the data values. 

Increment and decrement pass on the data, time and modification values to count_internal, which takes the current data value, modifies it correctly, and passes it all on into accumulate_internal, which still holds all of the statistics calculations.

Linked to MIB PR https://github.com/Metaswitch/clearwater-snmp-handlers/pull/94