### PR TITLE
[Reviewer: Alex] Use TWO in reads

### DIFF
--- a/include/sasevent.h
+++ b/include/sasevent.h
@@ -139,6 +139,7 @@ namespace SASEvent {
   const int CASS_CONNECT_FAIL = COMMON_BASE + 0x0300;
 
   const int QUORUM_FAILURE = COMMON_BASE + 0x0400;
+  const int TWO_FAILURE = COMMON_BASE + 0x0401;
 
 } // namespace SASEvent
 

--- a/include/sasevent.h
+++ b/include/sasevent.h
@@ -139,7 +139,6 @@ namespace SASEvent {
   const int CASS_CONNECT_FAIL = COMMON_BASE + 0x0300;
 
   const int QUORUM_FAILURE = COMMON_BASE + 0x0400;
-  const int TWO_FAILURE = COMMON_BASE + 0x0401;
 
 } // namespace SASEvent
 

--- a/src/cassandra_store.cpp
+++ b/src/cassandra_store.cpp
@@ -696,10 +696,8 @@ enum class Quorum_Consistency_Levels
         catch(UnavailableException& ue)                                      \
         {                                                                    \
           TRC_DEBUG("Failed TWO read for %s. Try ONE", #METHOD);             \
-          int event_id = SASEvent::QUORUM_FAILURE;                           \
+          int event_id = SASEvent::TWO_FAILURE;                              \
           SAS::Event event(TRAIL_ID, event_id, 0);                           \
-          event.add_static_param(                                            \
-            static_cast<uint32_t>(ConsistencyLevel::TWO));                   \
           SAS::report_event(event);                                          \
           METHOD(__VA_ARGS__, ConsistencyLevel::ONE);                        \
         }


### PR DESCRIPTION
Use TWO in reads rather than LOCAL_QUORUM/QUORUM. 

UT'd in Homestead (not yet tested as chef is playing up)