### PR TITLE
[Reviewer: Graeme] Avoid issues with high SRV priority values

### DIFF
--- a/include/baseresolver.h
+++ b/include/baseresolver.h
@@ -57,6 +57,10 @@ struct AddrInfo
   int priority;
   int weight;
 
+  AddrInfo():
+    priority(1),
+    weight(1) {};
+
   bool operator<(const AddrInfo& rhs) const
   {
     int addr_cmp = address.compare(rhs.address);

--- a/src/realmmanager.cpp
+++ b/src/realmmanager.cpp
@@ -175,7 +175,27 @@ void RealmManager::srv_priority_cb(struct fd_list* candidates)
     {
       // The lower the priority value, the higher the priority of the result, so
       // take away the priority value from the score.
-      candidate->score -= (ii->second)->addr_info().priority;
+      if (candidate->score > 0)
+      {
+        int new_score = candidate->score - (ii->second)->addr_info().priority;
+
+        // Very high priority values shouldn't cause us to go negative - we'll be ignored by
+        // freeDiameter
+        new_score = std::max(new_score, 1);
+        TRC_DEBUG("freeDiameter routing score for candidate %.*s is changing from %d to %d",
+                  candidate->cfg_diamidlen,
+                  candidate->cfg_diamid,
+                  candidate->score,
+                  new_score);
+        candidate->score = new_score;
+      }
+      else
+      {
+        TRC_DEBUG("freeDiameter routing score for candidate %.*s is negative (%d) - not changing",
+                  candidate->cfg_diamidlen,
+                  candidate->cfg_diamid,
+                  candidate->score);
+      }
     }
     else
     {


### PR DESCRIPTION
Two fixes:

- sets default values for priority and weight - these will otherwise be uninitialized for A records
- stops SRV priorities from making a score negative

I haven't risked any of the multiplication stuff - I thought about it, but got nervous about possible integer overflow issues.