### PR TITLE
[Reviewer: Alex] Don't increase our token rate spuriously during slow periods

### DIFF
--- a/include/load_monitor.h
+++ b/include/load_monitor.h
@@ -100,7 +100,7 @@ class LoadMonitor
     int target_latency;
     int smoothed_latency;
     int adjust_count;
-    timespec last_adjustment_time;
+    unsigned long last_adjustment_time_ms;
     float min_token_rate;
     TokenBucket bucket;
     SNMP::ContinuousAccumulatorTable* _token_rate_table;


### PR DESCRIPTION
Fixes https://github.com/Metaswitch/cpp-common/issues/384 using the approach discussed there.

I've UTed, and I'll live test by running light stress with SIPp and checking that this doesn't cause stress to go badly wrong.