### PR TITLE
[Reviewer: AMC] Send flush markers and suppress connection management logs

### DIFF
--- a/include/diameterstack.h
+++ b/include/diameterstack.h
@@ -825,7 +825,14 @@ public:
               SAS::TrailId trail) :
     _msg(dict, *fd_msg, Stack::get_instance()), _trail(trail)
   {}
-  virtual ~Task() {}
+
+  virtual ~Task()
+  {
+    // Now the task is complete we should flush the trail to ensure it appears
+    // promptly in SAS.
+    SAS::Marker flush_marker(_trail, MARKED_ID_FLUSH);
+    SAS::report_marker(flush_marker);
+  }
 
   virtual void run() = 0;
 

--- a/include/httpstack_utils.h
+++ b/include/httpstack_utils.h
@@ -107,7 +107,13 @@ namespace HttpStackUtils
       _req(req), _trail(trail)
     {}
 
-    virtual ~Task() {}
+    virtual ~Task()
+    {
+      // Now the task is complete we should flush the trail to ensure it
+      // appears promptly in SAS.
+      SAS::Marker flush_marker(_trail, MARKED_ID_FLUSH);
+      SAS::report_marker(flush_marker);
+    }
 
     /// Process the request associated with this task. Subclasses of this
     /// class should implement it with their specific business logic.
@@ -195,7 +201,7 @@ namespace HttpStackUtils
       SAS::TrailId trail;
     };
 
-  public:  
+  public:
     static void exception_callback(RequestParams* work)
     {
       // Respond with a 500

--- a/src/diameterstack.cpp
+++ b/src/diameterstack.cpp
@@ -869,14 +869,15 @@ void Stack::fd_sas_log_diameter_message(enum fd_hook_type type,
   SAS::TrailId trail;
   Stack* stack = (Stack*)stack_ptr;
 
-  // Don't log the message if we don't have a peer (this must be an initial
-  // CER/CEA exchange which is not logged).
-  if (peer == NULL)
+  fd_msg_hdr(msg, &hdr);
+
+  // Don't log connection management requests.
+  if ((hdr->msg_code == CC_CAPABILITIES_EXCHANGE) ||
+      (hdr->msg_code == CC_DEVICE_WATCHDOG) ||
+      (hdr->msg_code == CC_DISCONNECT_PEER))
   {
     return;
   }
-
-  fd_msg_hdr(msg, &hdr);
 
   // Get the trail ID we should be logging on.
   if (type == HOOK_MESSAGE_RECEIVED)


### PR DESCRIPTION
Andy, please can you review this change to:

* Send flush markers when a HTTP/Diameter task is completed. 
* Suppress SAS logging of diameter connection management flows.

I tested this by running the live tests and checking that they worked, and that my SAS lint reported no unflushed trails related to diameter/HTTP transactions.