### PR TITLE
[Reviewer: Andy] Add safe_pidfile function to write a pidfile only if we have an excus…

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -439,7 +439,7 @@ namespace Utils
   // This also returns true if b hasoverflown, and hence looks like b < a
   bool overflow_less_than(uint32_t a, uint32_t b);
   
-  int safe_pidfile(std::string filename);
+  int lock_and_write_pidfile(std::string filename);
 
 } // namespace Utils
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -438,6 +438,8 @@ namespace Utils
   // Compares two 32 bit numbers and returns if a < b.
   // This also returns true if b hasoverflown, and hence looks like b < a
   bool overflow_less_than(uint32_t a, uint32_t b);
+  
+  int safe_pidfile(std::string filename);
 
 } // namespace Utils
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -332,7 +332,7 @@ bool Utils::overflow_less_than(uint32_t a, uint32_t b)
     return ((a - b) > ((uint32_t)(1) << 31));
 }
 
-int Utils::safe_pidfile(std::string filename)
+int Utils::lock_and_write_pidfile(std::string filename)
 {
   std::string lockfilename = filename + ".lock";
   int lockfd = open(lockfilename.c_str(), O_WRONLY);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -335,7 +335,7 @@ bool Utils::overflow_less_than(uint32_t a, uint32_t b)
 int Utils::lock_and_write_pidfile(std::string filename)
 {
   std::string lockfilename = filename + ".lock";
-  int lockfd = open(lockfilename.c_str(), O_WRONLY);
+  int lockfd = open(lockfilename.c_str(), O_WRONLY | O_CREAT);
   int rc = flock(lockfd, LOCK_EX | LOCK_NB);
   if (rc == -1)
   {


### PR DESCRIPTION
…ive file lock

Basically https://github.com/Metaswitch/python-common/blob/dev/metaswitch/common/utils.py#L404 but in C++.

I should probably call it `lock_and_write_pidfile` for consistency, shouldn't I?