### PR TITLE
Add Utils::parse_http_url

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -119,6 +119,8 @@ namespace Utils
 
   void hashToHex(unsigned char *hash_char, unsigned char *hex_char);
 
+  bool parse_http_url(const std::string& url, std::string& server, std::string& path);
+
   std::string url_unescape(const std::string& s);
   std::string url_escape(const std::string& s);
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -119,6 +119,12 @@ namespace Utils
 
   void hashToHex(unsigned char *hash_char, unsigned char *hex_char);
 
+  /// Splits a URL of the form "http://<servername>[/<path>]" into
+  /// servername and path.
+  ///
+  /// Returns true iff the URL is in the corrects form, and sets the server
+  /// and path arguments to the URL components.  If the path in the URL is
+  /// missing, it defaults to "/".
   bool parse_http_url(const std::string& url, std::string& server, std::string& path);
 
   std::string url_unescape(const std::string& s);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -51,7 +51,7 @@
 bool Utils::parse_http_url(const std::string& url, std::string& server, std::string& path)
 {
   size_t colon_pos = url.find(':');
-  if (colon_pos == std::string::npos || url.substr(0, colon_pos) != "http")
+  if ((colon_pos == std::string::npos) || (url.substr(0, colon_pos) != "http"))
   {
     // Not HTTP.
     return false;
@@ -71,7 +71,7 @@ bool Utils::parse_http_url(const std::string& url, std::string& server, std::str
   }
   else
   {
-    server = url.substr(slash_slash_pos + 2, slash_pos - slash_slash_pos - 2);
+    server = url.substr(slash_slash_pos + 2, slash_pos - (slash_slash_pos + 2));
     path = url.substr(slash_pos);
   }
   return true;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -48,6 +48,35 @@
 
 #include "utils.h"
 
+bool Utils::parse_http_url(const std::string& url, std::string& server, std::string& path)
+{
+  size_t colon_pos = url.find(':');
+  if (colon_pos == std::string::npos || url.substr(0, colon_pos) != "http")
+  {
+    // Not HTTP.
+    return false;
+  }
+  size_t slash_slash_pos = url.find("//", colon_pos + 1);
+  if (slash_slash_pos != colon_pos + 1)
+  {
+    // Not full URL.
+    return false;
+  }
+  size_t slash_pos = url.find('/', slash_slash_pos + 2);
+  if (slash_pos == std::string::npos)
+  {
+    // No path.
+    server = url.substr(slash_slash_pos + 2);
+    path = "/";
+  }
+  else
+  {
+    server = url.substr(slash_slash_pos + 2, slash_pos - slash_slash_pos - 2);
+    path = url.substr(slash_pos);
+  }
+  return true;
+}
+
 #define REPLACE(CHAR1, CHAR2, RESULT) if ((s[(ii+1)] == CHAR1) && (s[(ii+2)] == CHAR2)) { r.append(RESULT); ii = ii+2; continue; }
 
 std::string Utils::url_unescape(const std::string& s)


### PR DESCRIPTION
Adds a utility function for parsing http URLs into their components (server name and path).