### PR TITLE
[Reviewer: Andy] recv_file_descriptor return -1 on error

### DIFF
--- a/src/namespace_hop.cpp
+++ b/src/namespace_hop.cpp
@@ -72,7 +72,7 @@ static int recv_file_descriptor(int socket)
   if (res <= 0)
   {
     TRC_WARNING("Failed to retrieve cross-namespace socket - recvmsg returned %d (%d %s)\n", res, errno, strerror(errno));
-    return res;
+    return -1;
   }
 
   // Iterate through control message to find if there is a SCM_RIGHTS entry containing file descriptors

--- a/src/namespace_hop.cpp
+++ b/src/namespace_hop.cpp
@@ -53,7 +53,7 @@ static int recv_file_descriptor(int socket)
   // Buffer to hold the dummy "actual data" we receive
   char data[1] = {0};
 
-  struct iovec iov[1];
+  struct iovec iov[1] = {0};
   iov[0].iov_base = data;
   iov[0].iov_len = sizeof(data);
 
@@ -78,7 +78,6 @@ static int recv_file_descriptor(int socket)
 
   // Iterate through control message to find if there is a SCM_RIGHTS entry containing file descriptors
   struct cmsghdr *control_message = NULL;
-
   for (control_message = CMSG_FIRSTHDR(&message);
        control_message != NULL;
        control_message = CMSG_NXTHDR(&message, control_message))

--- a/src/namespace_hop.cpp
+++ b/src/namespace_hop.cpp
@@ -52,8 +52,10 @@ static int recv_file_descriptor(int socket)
 {
   // Buffer to hold the dummy "actual data" we receive
   char data[1] = {0};
-  struct iovec iov = {.iov_base = data,
-                      .iov_len = sizeof(data)};
+
+  struct iovec iov[1];
+  iov[0].iov_base = data;
+  iov[0].iov_len = sizeof(data);
 
   // Buffer to hold the control messages we receive
   struct cmsghdr *control_message = NULL;
@@ -65,10 +67,10 @@ static int recv_file_descriptor(int socket)
   message.msg_namelen = 0;
   message.msg_control = ctrl_buf;
   message.msg_controllen = CMSG_SPACE(sizeof(int));
-  message.msg_iov = &iov;
+  message.msg_iov = iov;
   message.msg_iovlen = 1;
 
-  int res = recvmsg(socket, &message, 0);
+  int res = ::recvmsg(socket, &message, 0);
   if (res <= 0)
   {
     TRC_WARNING("Failed to retrieve cross-namespace socket - recvmsg returned %d (%d %s)\n", res, errno, strerror(errno));

--- a/src/namespace_hop.cpp
+++ b/src/namespace_hop.cpp
@@ -58,7 +58,6 @@ static int recv_file_descriptor(int socket)
   iov[0].iov_len = sizeof(data);
 
   // Buffer to hold the control messages we receive
-  struct cmsghdr *control_message = NULL;
   char ctrl_buf[CMSG_SPACE(sizeof(int))] = {0};
 
   // Message struct wrapping both buffers.
@@ -78,6 +77,8 @@ static int recv_file_descriptor(int socket)
   }
 
   // Iterate through control message to find if there is a SCM_RIGHTS entry containing file descriptors
+  struct cmsghdr *control_message = NULL;
+
   for (control_message = CMSG_FIRSTHDR(&message);
        control_message != NULL;
        control_message = CMSG_NXTHDR(&message, control_message))


### PR DESCRIPTION
This is to fix issue #408 

This should stop it returning a 0 on 'error', which would happen, according to http://linux.die.net/man/2/recvmsg, if the peer has performed an orderly shutdown. This fixes an error where listing a sas in shared_config, but not restarting clearwater-infrastructure to add it to the whitelist, causes sprout to become unresponsive and fall into a restart loop, caused by receiving file descriptor '0' for a socket.

I am not sure what essentially copying https://github.com/Metaswitch/sas-client/blob/clearwater/source/sas.cpp#L403 across would do, as i'm not quite sure why the differences have evolved, or what ramifications changes would make, so this PR is just to fix the bug that was causing sprout to become unresponsive and be shut down by monit.

The code still builds, and a previously faulty deployment has been upgraded and now doesn't hit the restart loop, so it appears to be fixed. Let me know if you think we still need to update this function to be more like the old code.