### PR TITLE
[Reviewer: Alex] Allow construction of a localhost-only memcached

### DIFF
--- a/include/memcachedstore.h
+++ b/include/memcachedstore.h
@@ -114,6 +114,7 @@ protected:
                      MemcachedConfigReader* config_reader,
                      BaseCommunicationMonitor* comm_monitor,
                      Alarm* vbucket_alarm);
+  BaseMemcachedStore(BaseCommunicationMonitor* comm_monitor);
 
 private:
   // A copy of this structure is maintained for each worker thread, as
@@ -300,6 +301,12 @@ public:
                  MemcachedConfigReader* config_reader,
                  BaseCommunicationMonitor* comm_monitor = NULL,
                  Alarm* vbucket_alarm = NULL);
+
+  /// Construct a MemcachedStore that only talks to the memcached proxy on localhost.
+  ///
+  /// @param comm_monitor  - Object tracking memcached communications.
+  MemcachedStore(BaseCommunicationMonitor* comm_monitor = NULL);
+
 };
 
 #endif

--- a/include/memcachedstore.h
+++ b/include/memcachedstore.h
@@ -72,12 +72,7 @@ extern "C" {
 class BaseMemcachedStore : public Store
 {
 public:
-  ~BaseMemcachedStore();
-
-  /// Flags that the store should use a new view of the memcached cluster to
-  /// distribute data.  Note that this is public because it is called from
-  /// the MemcachedStoreUpdater class and from UT classes.
-  void new_view(const MemcachedConfig& config);
+  virtual ~BaseMemcachedStore();
 
   bool has_servers() { return (_servers.size() > 0); };
 
@@ -104,18 +99,23 @@ public:
                             SAS::TrailId trail = 0);
 
 
-  /// Updates the cluster settings
-  void update_config();
-
 protected:
   // Constructor. This is protected to prevent the BaseMemcachedStore from being
   // instantiated directly.
   BaseMemcachedStore(int replicas,
                      int vbuckets,
                      bool binary,
-                     MemcachedConfigReader* config_reader,
                      BaseCommunicationMonitor* comm_monitor,
                      Alarm* vbucket_alarm);
+
+  // Stores the number of vbuckets being used.  This currently doesn't change,
+  // but in future we may choose to increase it when the cluster gets
+  // sufficiently large.  Note that it _must_ be a power of two.
+  const int _vbuckets;
+
+  // Stores the number of replicas configured for the store (one means the
+  // data is stored on one server, two means it is stored on two servers etc.).
+  const int _replicas;
 
   // The current global view number.  Note that this is not protected by the
   // _view_lock.
@@ -206,20 +206,8 @@ private:
                                                uint32_t flags,
                                                SAS::TrailId trail);
 
-  // Stores a pointer to an updater object
-  Updater<void, BaseMemcachedStore>* _updater;
-
   // Used to store a connection structure for each worker thread.
   pthread_key_t _thread_local;
-
-  // Stores the number of replicas configured for the store (one means the
-  // data is stored on one server, two means it is stored on two servers etc.).
-  const int _replicas;
-
-  // Stores the number of vbuckets being used.  This currently doesn't change,
-  // but in future we may choose to increase it when the cluster gets
-  // sufficiently large.  Note that it _must_ be a power of two.
-  const int _vbuckets;
 
   // The options string used to create appropriate memcached_st's for the
   // current view.
@@ -262,9 +250,6 @@ private:
   //
   // Atomic as it is set by the updater thread and read by application threads.
   std::atomic<int> _tombstone_lifetime;
-
-  // Object used to read the memcached config.
-  MemcachedConfigReader* _config_reader;
 };
 
 
@@ -275,19 +260,6 @@ private:
 class TopologyAwareMemcachedStore : public BaseMemcachedStore
 {
 public:
-  /// Construct a MemcachedStore that reads its config from a file.
-  ///
-  /// @param binary        - Whether to use the binary or text interface to
-  ///                        memcached.
-  /// @param config_file   - The file (name and path) to read the config from.
-  /// @param comm_monitor  - Object tracking memcached communications.
-  /// @param vbucket_alarm - Alarm object to kick if a vbucket is
-  ///                        uncontactable.
-  TopologyAwareMemcachedStore(bool binary,
-                              const std::string& config_file,
-                              BaseCommunicationMonitor* comm_monitor = NULL,
-                              Alarm* vbucket_alarm = NULL);
-
   /// Construct a MemcachedStore that reads its config from a user-supplied
   /// object.
   ///
@@ -304,6 +276,41 @@ public:
                               BaseCommunicationMonitor* comm_monitor = NULL,
                               Alarm* vbucket_alarm = NULL);
 
+  /// Construct a MemcachedStore that reads its config from a file.
+  ///
+  /// @param binary        - Whether to use the binary or text interface to
+  ///                        memcached.
+  /// @param config_file   - The file (name and path) to read the config from.
+  /// @param comm_monitor  - Object tracking memcached communications.
+  /// @param vbucket_alarm - Alarm object to kick if a vbucket is
+  ///                        uncontactable.
+  TopologyAwareMemcachedStore(bool binary,
+                              const std::string& config_file,
+                              BaseCommunicationMonitor* comm_monitor = NULL,
+                              Alarm* vbucket_alarm = NULL):
+    TopologyAwareMemcachedStore(binary,
+                                new MemcachedConfigFileReader(config_file),
+                                comm_monitor,
+                                vbucket_alarm) {}
+
+
+  ~TopologyAwareMemcachedStore();
+
+  /// Flags that the store should use a new view of the memcached cluster to
+  /// distribute data.  Note that this is public because it is called from
+  /// the MemcachedStoreUpdater class and from UT classes.
+  void new_view(const MemcachedConfig& config);
+
+  /// Updates the cluster settings
+  void update_config();
+
+
+private:
+  // Object used to read the memcached config.
+  MemcachedConfigReader* _config_reader;
+
+  // Stores a pointer to an updater object
+  Updater<void, TopologyAwareMemcachedStore>* _updater;
 };
 
 /// @class TopologyNeutralMemcachedStore

--- a/src/memcachedstore.cpp
+++ b/src/memcachedstore.cpp
@@ -113,11 +113,14 @@ BaseMemcachedStore::BaseMemcachedStore(BaseCommunicationMonitor* comm_monitor) :
   _replicas(1),
   _vbuckets(1),
   _options(),
-  _view_number(0),
-  _servers(),
+  // Set the view number to 1 - we're starting with a fixed localhost-only view
+  _view_number(1),
+
+  // Use the local memcached proxy as the only server and the only replica
+  _servers(1, "127.0.0.1:11211"),
   _max_connect_latency_ms(50),
-  _read_replicas(_vbuckets),
-  _write_replicas(_vbuckets),
+  _read_replicas(1, {"127.0.0.1:11211"}),
+  _write_replicas(1, {"127.0.0.1:11211"}),
   _comm_monitor(comm_monitor),
   _vbucket_comm_state(_vbuckets),
   _vbucket_comm_fail_count(0),
@@ -140,8 +143,6 @@ BaseMemcachedStore::BaseMemcachedStore(BaseCommunicationMonitor* comm_monitor) :
   // significant length of time.
   _options = "--CONNECT-TIMEOUT=10 --SUPPORT-CAS --POLL-TIMEOUT=250";
   _options += (_binary) ? " --BINARY-PROTOCOL" : "";
-
-  _servers.push_back("127.0.0.1");
 }
 
 


### PR DESCRIPTION
This adds a new MemcachedStore constructor, which just directs all traffic to 127.0.0.1:11211.

I've left all the rest of the code in although Sprout/Ralf/etc. no longer need much of it - this is because:

* you're going to need it for Astaire
* the more of this we rewrite, the more painful merges will be
* some of it is useful - e.g. trying twice to workaround a memcached connection reuse bug
* my use-case is genuinely a special case of the general use-case - I need to connect to one server with one vbucket and one replica