### PR TITLE
[Reviewer: Andy] Catch a thrift timeout exception and retry when doing a HA get

### DIFF
--- a/src/cassandra_store.cpp
+++ b/src/cassandra_store.cpp
@@ -701,6 +701,16 @@ enum class Quorum_Consistency_Levels
             static_cast<uint32_t>(Quorum_Consistency_Levels::TWO));          \
           SAS::report_event(event);                                          \
           METHOD(__VA_ARGS__, ConsistencyLevel::ONE);                        \
+        }                                                                    \
+        catch(TimedOutException& te)                                         \
+        {                                                                    \
+          TRC_DEBUG("Failed TWO read for %s. Try ONE", #METHOD);             \
+          int event_id = SASEvent::QUORUM_FAILURE;                           \
+          SAS::Event event(TRAIL_ID, event_id, 1);                           \
+          event.add_static_param(                                            \
+            static_cast<uint32_t>(Quorum_Consistency_Levels::TWO));          \
+          SAS::report_event(event);                                          \
+          METHOD(__VA_ARGS__, ConsistencyLevel::ONE);                        \
         }
 
 


### PR DESCRIPTION
Andy, as discussed yesterday, our HA get code had a bug where we didn't trap timeout exception properly. Tested in UT and live. 

Not the prettiest of code but I didn't think it was worth the effort to tidy it up. Shout if you disagree. 