### PR TITLE
Reviewer Rob - HTTPStack registers handlers by const string

### DIFF
--- a/include/httpstack.h
+++ b/include/httpstack.h
@@ -416,7 +416,7 @@ public:
                          AccessLogger* access_logger = NULL,
                          LoadMonitor* load_monitor = NULL,
                          StatsInterface* stats = NULL);
-  virtual void register_handler(char* path, HandlerInterface* handler);
+  virtual void register_handler(const char* path, HandlerInterface* handler);
   virtual void start(evhtp_thread_init_cb init_cb = NULL);
   virtual void stop();
   virtual void wait_stopped();

--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -146,7 +146,7 @@ void HttpStack::configure(const std::string& bind_address,
   _stats = stats;
 }
 
-void HttpStack::register_handler(char* path,
+void HttpStack::register_handler(const char* path,
                                  HttpStack::HandlerInterface* handler)
 {
   evhtp_callback_t* cb = evhtp_set_regex_cb(_evhtp,


### PR DESCRIPTION
All our builds have `-fno-write-strings` enabled because this function forgot to put `const` on one of it's arguments.  Disabling compiler checks makes me a sad :panda_face: so here's the fix.