### PR TITLE
Reviewer AJH: Treat NOT FOUND as a DATA CONTENTION on a CAS

### DIFF
--- a/src/memcachedstore.cpp
+++ b/src/memcachedstore.cpp
@@ -599,7 +599,8 @@ Store::Status BaseMemcachedStore::set_data(const std::string& table,
       TRC_DEBUG("Conditional write succeeded to replica %d", replica_idx);
       break;
     }
-    else if ((rc == MEMCACHED_NOTSTORED) ||
+    else if ((rc == MEMCACHED_NOTFOUND) ||
+             (rc == MEMCACHED_NOTSTORED) ||
              (rc == MEMCACHED_DATA_EXISTS))
     {
       if (trail != 0)
@@ -640,6 +641,7 @@ Store::Status BaseMemcachedStore::set_data(const std::string& table,
   }
 
   if ((!memcached_success(rc)) &&
+      (rc != MEMCACHED_NOTFOUND) &&
       (rc != MEMCACHED_NOTSTORED) &&
       (rc != MEMCACHED_DATA_EXISTS))
   {


### PR DESCRIPTION
Hi Alex,

Please can you review this change to treat NOTFOUND as a DATA_CONTENTION when trying to do a CAS update. Currently we return an ERROR. A client should retry data contentions, which should change the flows to something like the following.

* Client attempts a CAS update which fails because the primary memcached has no record of the key (for some reason - presumably it's just crashed).
* Client receives a DATA_CONTENTION error and so does a GET.
* The primary memcached still has no record of the key, but the backup does. The value is returned, and a CAS of 0 is returned.
* The client now does an add (since the CAS has been set to 0). This succeeds on the primary and is replicated to the backup.

I'm just proposing to merge this into the 3sitegr branch.

Thanks,
Graeme