### PR TITLE
[Reviewer AMC] Don't make ENT logs for client side HTTP errors

### DIFF
--- a/src/httpconnection.cpp
+++ b/src/httpconnection.cpp
@@ -661,8 +661,10 @@ HTTPCode HttpConnection::send_request(const std::string& path,                 /
       {
         CL_HTTP_COMM_ERR.log(url.c_str(), remote_ip, curl_easy_strerror(rc), rc);
       }
-      else
+      else if (http_rc >= 500)
       {
+        // Only make an ENT log for 5XX (server) errors as client (4XX) errors are
+        // not relevant to ENT logs, which are intended to highlight indicate server-side problems.
         CL_HTTP_PROTOCOL_ERR.log(url.c_str(), remote_ip, http_rc);
       }
 


### PR DESCRIPTION
The problem addressed here is that, if a client attempts to do something that results in a client-side error at the sprout->homestead interface (e.g., "404 not found" from a reg-data or location query), a "Request for <URL> to HTTP server A.B.C.D failed with error <client side error>" ENT log is made.

This is wrong - ENT logs are intended to record server side problems.  Client side problems are recorded and diagnosed using SAS.

Tested by checking that REGISTERs as unknown users no longer generate this ENT log (but REGISTERs when homestead is down continue to do so)