### PR TITLE
[Reviewer: Andy] Integrate ENT logs with communication monitor

### DIFF
--- a/include/communicationmonitor.h
+++ b/include/communicationmonitor.h
@@ -55,6 +55,8 @@ class CommunicationMonitor : public BaseCommunicationMonitor
 {
 public:
   CommunicationMonitor(Alarm* alarm,
+                       std::string sender,
+                       std::string receiver,
                        unsigned int clear_confirm_sec = 30,
                        unsigned int set_confirm_sec = 15);
 
@@ -65,9 +67,12 @@ private:
   unsigned long current_time_ms();
 
   Alarm* _alarm;
+  std::string _sender;
+  std::string _receiver;
   unsigned int _clear_confirm_ms;
   unsigned int _set_confirm_ms;
   unsigned long _next_check;
+  bool _error_state;
 };
 
 #endif

--- a/include/cpp_common_pd_definitions.h
+++ b/include/cpp_common_pd_definitions.h
@@ -73,22 +73,6 @@ static const PDLog CL_DIAMETER_INIT_CMPL
   "None."
 );
 
-static const PDLog4<const char*, int, const char*, const char*> 
-  CL_DIAMETER_ROUTE_ERR
-(
-  PDLogBase::CL_CPP_COMMON_ID + 3,
-  PDLOG_ERR,
-  "Diameter routing error: %s for message with Command-Code %d, "
-  "Destination-Host %s and Destination-Realm %s.",
-  "No route was found for a Diameter message.",
-  "The Diameter message with the specified command code could not "
-  "be routed to the destination host within the destination realm.",
-  "(1). Check the Diameter host configuration. "
-  "(2). Check to see that there is a route to the destination host. "
-  "(3). Check for IP connectivity on the Diameter interface using ping. "
-  "(4). Wireshark the Diameter interface."
-);
-
 static const PDLog1<const char*> CL_DIAMETER_CONN_ERR
 (
   PDLogBase::CL_CPP_COMMON_ID + 4,
@@ -100,18 +84,6 @@ static const PDLog1<const char*> CL_DIAMETER_CONN_ERR
   "(2). Check to see that there is a route to the destination host. "
   "(3). Check for IP connectivity on the Diameter interface using ping. "
   "(4). Wireshark the interface on Diameter interface."
-);
-
-static const PDLog4<const char*, const char*, const char*, int> CL_HTTP_COMM_ERR
-(
-  PDLogBase::CL_CPP_COMMON_ID + 5,
-  PDLOG_ERR,
-  "Request for %s to HTTP server %s failed with error \"%s\" (code %d).",
-  "An HTTP request to the specified server failed with the specified error code.",
-  "This condition may impact the ability to register, subscribe, or make a call.",
-  "(1). Check to see if the specified host has failed. "
-  "(2). Check to see if there is TCP connectivity to the host by using ping "
-  "and/or Wireshark."
 );
 
 static const PDLog2<int, const char*> CL_MEMCACHED_CLUSTER_UPDATE_STABLE
@@ -134,14 +106,30 @@ static const PDLog3<int, int, const char*> CL_MEMCACHED_CLUSTER_UPDATE_RESIZE
   "None."
 );
 
-static const PDLog3<const char*, const char*, int> CL_HTTP_PROTOCOL_ERR
+static const PDLog2<const char*, const char*> CL_CM_CONNECTION_ERRORED
 (
-  PDLogBase::CL_CPP_COMMON_ID + 8,
+  PDLogBase::CL_CPP_COMMON_ID + 9,
   PDLOG_ERR,
-  "Request for %s to HTTP server %s failed with HTTP status %d.",
-  "An HTTP request was rejected at the specified server with the specified status code.",
-  "This condition may impact the ability to register, subscribe, or make a call.",
-  "Check for logs on the specified server to see why it rejected the request."
+  "%s is unable to contact any %s applications. It will periodically "
+  "attempt to reconnect",
+  "This process is unable to contact any instances of the application "
+  "it's trying to connect to",
+  "This process is unable to contact any instances of the application "
+  "it's trying to connect to",
+  "(1). Check that the application this process is trying to connect to is running."
+  "(2). Check the configuration in /etc/clearwater is correct."
+  "(3). Check that this process has connectivity to the application it's trying to connect to."
+);
+
+static const PDLog2<const char*, const char*> CL_CM_CONNECTION_CLEARED
+(
+  PDLogBase::CL_CPP_COMMON_ID + 10,
+  PDLOG_INFO,
+  "Connection between %s and %s has been restored.",
+  "This process can now contact at least one instance of the application "
+  "it's trying to connect to",
+  "Normal.",
+  "None."
 );
 
 #endif

--- a/src/communicationmonitor.cpp
+++ b/src/communicationmonitor.cpp
@@ -88,6 +88,7 @@ void CommunicationMonitor::track_communication_changes(unsigned long now_ms)
       //    in the last 'set_confirm' ms.
       if ((!_error_state) && (succeeded == 0) && (failed != 0))
       {
+        _error_state = true;
         CL_CM_CONNECTION_ERRORED.log(_sender.c_str(),
                                      _receiver.c_str());
 
@@ -95,11 +96,11 @@ void CommunicationMonitor::track_communication_changes(unsigned long now_ms)
         {
           TRC_STATUS("Setting alarm %d", _alarm->index());
           _alarm->set();
-          _error_state = true;
         }
       }
       else if ((_error_state) && (succeeded != 0))
       {
+        _error_state = false;
         CL_CM_CONNECTION_CLEARED.log(_sender.c_str(),
                                      _receiver.c_str());
 
@@ -107,7 +108,6 @@ void CommunicationMonitor::track_communication_changes(unsigned long now_ms)
         {
           TRC_STATUS("Clearing alarm %d", _alarm->index());
           _alarm->clear();
-          _error_state = false;
         }
       }
 

--- a/src/httpconnection.cpp
+++ b/src/httpconnection.cpp
@@ -657,15 +657,6 @@ HTTPCode HttpConnection::send_request(const std::string& path,                 /
     }
     else
     {
-      if (rc != CURLE_OK)
-      {
-        CL_HTTP_COMM_ERR.log(url.c_str(), remote_ip, curl_easy_strerror(rc), rc);
-      }
-      else
-      {
-        CL_HTTP_PROTOCOL_ERR.log(url.c_str(), remote_ip, http_rc);
-      }
-
       // If we forced a new connection and we failed even to establish an HTTP
       // connection, blacklist this IP address.
       if (recycle_conn &&

--- a/test_utils/mockcommunicationmonitor.h
+++ b/test_utils/mockcommunicationmonitor.h
@@ -44,7 +44,7 @@ class MockCommunicationMonitor : public CommunicationMonitor
 {
 public:
   MockCommunicationMonitor() : 
-    CommunicationMonitor(new Alarm("sprout", 0, AlarmDef::CRITICAL)) {}
+    CommunicationMonitor(new Alarm("sprout", 0, AlarmDef::CRITICAL), "sprout", "chronos") {}
 
   MOCK_METHOD1(inform_success, void(unsigned long now_ms));
   MOCK_METHOD1(inform_failure, void(unsigned long now_ms));


### PR DESCRIPTION
Andy, can you review this fix to add ENT logs to the communication monitor (so that the per call ENT logs can be dropped).

Fixes #317 