### PR TITLE
Reviewer AJH: Check for port in astaire resolver

### DIFF
--- a/src/astaire_resolver.cpp
+++ b/src/astaire_resolver.cpp
@@ -63,6 +63,8 @@ void AstaireResolver::resolve(const std::string& host,
                               std::vector<AddrInfo>& targets,
                               SAS::TrailId trail)
 {
+  std::string host_without_port;
+  int port;
   AddrInfo ai;
   int dummy_ttl = 0;
 
@@ -72,13 +74,10 @@ void AstaireResolver::resolve(const std::string& host,
   targets.clear();
 
   // Check if host contains a port. Otherwise use the default PORT.
-  std::string host_without_port = host;
-  int port = PORT;
-  size_t pos = host.find(":");
-  if (pos != std::string::npos)
+  if (!Utils::split_host_port(host, host_without_port, port))
   {
-    host_without_port = host.substr(0, pos);
-    port = stoi(host.substr(pos+1));
+    host_without_port = host;
+    port = PORT;
   }
 
   if (parse_ip_target(host_without_port, ai.address))

--- a/src/astaire_resolver.cpp
+++ b/src/astaire_resolver.cpp
@@ -71,19 +71,29 @@ void AstaireResolver::resolve(const std::string& host,
 
   targets.clear();
 
-  if (parse_ip_target(host, ai.address))
+  // Check if host contains a port. Otherwise use the default PORT.
+  std::string host_without_port = host;
+  int port = PORT;
+  size_t pos = host.find(":");
+  if (pos != std::string::npos)
+  {
+    host_without_port = host.substr(0, pos);
+    port = stoi(host.substr(pos+1));
+  }
+
+  if (parse_ip_target(host_without_port, ai.address))
   {
     // The name is already an IP address, so no DNS resolution is possible.
     TRC_DEBUG("Target is an IP address");
-    ai.port = PORT;
+    ai.port = port;
     ai.transport = TRANSPORT;
     targets.push_back(ai);
   }
   else
   {
-    a_resolve(host,
+    a_resolve(host_without_port,
               _address_family,
-              PORT,
+              port,
               TRANSPORT,
               max_targets,
               targets,


### PR DESCRIPTION
The Astaire resolver may need to resolve something of the form <host>:<port> according to the spec, and I don't think it currently does. This addresses that issue.

Graeme