### PR TITLE
[Reviewer AJH] Retry attempt to open log file after 5s.

### DIFF
--- a/include/logger.h
+++ b/include/logger.h
@@ -100,9 +100,11 @@ private:
   std::string _directory;
   pthread_mutex_t _lock;
 
+  void gettime_monotonic(struct timespec* ts);
+
   /// Defines how frequently (in seconds) we will try to reopen a log
   /// file when we have previously failed to use it.
-  static const double LOGFILE_RETRY_FREQUENCY = 5.0l;
+  const static double LOGFILE_RETRY_FREQUENCY;
 };
 
 

--- a/include/logger.h
+++ b/include/logger.h
@@ -92,6 +92,7 @@ private:
   int _flags;
   int _last_hour;
   bool _rotate;
+  struct timespec _last_rotate;
   FILE* _fd;
   int _discards;
   int _saved_errno;
@@ -99,9 +100,9 @@ private:
   std::string _directory;
   pthread_mutex_t _lock;
 
-  /// Defines how frequently (in terms of log attempts) we will try to
-  /// open the log file if we failed to open it previously.
-  static const int LOGFILE_CHECK_FREQUENCY = 1000;
+  /// Defines how frequently (in seconds) we will try to reopen a log
+  /// file when we have previously failed to use it.
+  static const double LOGFILE_RETRY_FREQUENCY = 5.0l;
 };
 
 

--- a/include/logger.h
+++ b/include/logger.h
@@ -55,8 +55,6 @@ public:
   int get_flags() const;
   void set_flags(int flags);
 
-  virtual void gettime(struct timespec* ts);
-
   virtual void write(const char* data);
   virtual void flush();
   virtual void commit();
@@ -65,6 +63,10 @@ public:
   // called when no other threads are running - generally from a signal
   // handler.
   virtual void backtrace(const char* data);
+
+protected:
+  virtual void gettime_monotonic(struct timespec* ts);
+  virtual void gettime(struct timespec* ts);
 
 private:
   /// Encodes the time as needed by the logger.
@@ -99,8 +101,6 @@ private:
   std::string _filename;
   std::string _directory;
   pthread_mutex_t _lock;
-
-  void gettime_monotonic(struct timespec* ts);
 
   /// Defines how frequently (in seconds) we will try to reopen a log
   /// file when we have previously failed to use it.

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -229,6 +229,12 @@ void Logger::write_log_file(const char *data, const timestamp_t& ts)
   {
     fflush(_fd);
   }
+
+  if (ferror(_fd))
+  {
+    fclose(_fd);
+    _fd = NULL;
+  }
 }
 
 
@@ -321,6 +327,12 @@ void Logger::backtrace(const char *data)
     }
 
     fflush(_fd);
+
+    if (ferror(_fd))
+    {
+      fclose(_fd);
+      _fd == NULL;
+    }
   }
 }
 

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -60,6 +60,7 @@
 Logger::Logger() :
   _flags(ADD_TIMESTAMPS),
   _last_hour(0),
+  _last_rotate(0),
   _rotate(false),
   _fd(stdout)
 {
@@ -70,6 +71,7 @@ Logger::Logger() :
 Logger::Logger(const std::string& directory, const std::string& filename) :
   _flags(ADD_TIMESTAMPS),
   _last_hour(0),
+  _last_rotate(0),
   _rotate(true),
   _fd(NULL),
   _discards(0),
@@ -104,6 +106,12 @@ void Logger::gettime(struct timespec* ts)
 }
 
 
+void Logger::gettime_monotonic(struct timespec* ts)
+{
+  clock_gettime(CLOCK_MONOTONIC, ts);
+}
+
+
 /// Writes a log to the logfile, cycling or opening the log file when
 /// necessary.
 void Logger::write(const char* data)
@@ -117,37 +125,52 @@ void Logger::write(const char* data)
   pthread_mutex_lock(&_lock);
   pthread_cleanup_push(Logger::release_lock, this);
 
-  if ((_fd != NULL) ||
-      ((_discards % LOGFILE_CHECK_FREQUENCY) == 0))
-  {
-    // We have a valid file handle, or it is time to try opening the file
-    // again.
+  bool cycle_log_file_required = false;
 
+  if (_fd == NULL)
+  {
+    // When there is no valid log file, try to open one frequently to
+    // ensure that as few logs are lost as possible.
+    struct timespec current_time;
+    gettime_monotonic(&current_time);
+    double seconds = difftime(current_time, _last_rotate);
+    if (seconds > LOGFILE_RETRY_FREQUENCY)
+    {
+      cycle_log_file_required = true;
+    }
+  }
+  else
+  {
     // Convert the date/time into a rough number of hours since some base date.
     // This doesn't have to be exact, but it does have to be monotonically
     // increasing, so assume every year is a leap year.
     int hour = ts.year * 366 * 24 + ts.yday * 24 + ts.hour;
-
-    if ((_rotate && (hour > _last_hour)) ||
-        (_fd == NULL))
+    if (_rotate && (hour > _last_hour))
     {
-      // Open a new log file.
-      cycle_log_file(ts);
-      _last_hour = hour;
+      cycle_log_file_required = true;
+    }
+  }
 
-      if ((_fd != NULL) &&
-          (_discards != 0))
-      {
-        // LCOV_EXCL_START Currently don't force fopen failures in UT
-        char discard_msg[100];
-        sprintf(discard_msg,
-                "Failed to open logfile (%d - %s), %d logs discarded",
-                _saved_errno, ::strerror(_saved_errno), _discards);
-        write_log_file(discard_msg, ts);
-        _discards = 0;
-        _saved_errno = 0;
-        // LCOV_EXCL_STOP
-      }
+  if (cycle_log_file_required)
+  {
+    // Open a new log file.
+    cycle_log_file(ts);
+
+    _last_hour = hour;
+    gettime_monotonic(&_last_rotate);
+
+    if ((_fd != NULL) &&
+        (_discards != 0))
+    {
+      // LCOV_EXCL_START Currently don't force fopen failures in UT
+      char discard_msg[100];
+      sprintf(discard_msg,
+              "Failed to open logfile (%d - %s), %d logs discarded",
+              _saved_errno, ::strerror(_saved_errno), _discards);
+      write_log_file(discard_msg, ts);
+      _discards = 0;
+      _saved_errno = 0;
+      // LCOV_EXCL_STOP
     }
   }
 

--- a/test_utils/test_interposer.cpp
+++ b/test_utils/test_interposer.cpp
@@ -71,11 +71,18 @@ static const clockid_t supported_clock_ids[] = {CLOCK_REALTIME,
 static std::map<clockid_t, struct timespec> abs_timespecs;
 static time_t abs_time;
 
+// Whether file opening is completely controlled by the test script.
+static bool control_fopen = false;
+
+// When controlling fopen, this stores the file pointer to return.
+FILE* fopen_file_pointer = NULL;
+
 /// The real functions we are interposing.
 static int (*real_getaddrinfo)(const char*, const char*, const struct addrinfo*, struct addrinfo**);
 static struct hostent* (*real_gethostbyname)(const char*);
 static int (*real_clock_gettime)(clockid_t, struct timespec *);
 static time_t (*real_time)(time_t*);
+static FILE* (*real_fopen)(const char*, const char*);
 typedef int (*pthread_cond_timedwait_func_t)(pthread_cond_t*,
                                              pthread_mutex_t*,
                                              const struct timespec*);
@@ -331,4 +338,40 @@ int pthread_cond_timedwait(pthread_cond_t* cond,
   ts_add(real_time, delta_time, fixed_time);
 
   return real_pthread_cond_timedwait(cond, mutex, &fixed_time);
+}
+
+
+void cw_control_fopen(FILE* fd)
+{
+  control_fopen = true;
+  fopen_file_pointer = fd;
+}
+
+
+void cw_release_fopen()
+{
+  control_fopen = false;
+  fopen_file_pointer = NULL;
+}
+
+
+FILE* fopen(const char *path, const char *mode)
+{
+  if (!real_fopen)
+  {
+    real_fopen = (FILE* (*)(const char*, const char*))dlsym(RTLD_NEXT, "fopen");
+  }
+
+  FILE* rc;
+
+  if (control_fopen)
+  {
+    rc = fopen_file_pointer;
+  }
+  else
+  {
+    rc = real_fopen(path, mode);
+  }
+
+  return rc;
 }

--- a/test_utils/test_interposer.cpp
+++ b/test_utils/test_interposer.cpp
@@ -75,7 +75,7 @@ static time_t abs_time;
 static bool control_fopen = false;
 
 // When controlling fopen, this stores the file pointer to return.
-FILE* fopen_file_pointer = NULL;
+static FILE* fopen_file_pointer = NULL;
 
 /// The real functions we are interposing.
 static int (*real_getaddrinfo)(const char*, const char*, const struct addrinfo*, struct addrinfo**);
@@ -341,14 +341,14 @@ int pthread_cond_timedwait(pthread_cond_t* cond,
 }
 
 
-void cw_control_fopen(FILE* fd)
+void cwtest_control_fopen(FILE* fd)
 {
   control_fopen = true;
   fopen_file_pointer = fd;
 }
 
 
-void cw_release_fopen()
+void cwtest_release_fopen()
 {
   control_fopen = false;
   fopen_file_pointer = NULL;

--- a/test_utils/test_interposer.hpp
+++ b/test_utils/test_interposer.hpp
@@ -45,4 +45,6 @@ void cwtest_advance_time_ms(long delta_ms);
 void cwtest_reset_time();
 void cwtest_completely_control_time();
 
-
+// Control file manipulation.
+void cw_control_fopen(FILE* fd);
+void cw_release_fopen();

--- a/test_utils/test_interposer.hpp
+++ b/test_utils/test_interposer.hpp
@@ -46,5 +46,5 @@ void cwtest_reset_time();
 void cwtest_completely_control_time();
 
 // Control file manipulation.
-void cw_control_fopen(FILE* fd);
-void cw_release_fopen();
+void cwtest_control_fopen(FILE* fd);
+void cwtest_release_fopen();


### PR DESCRIPTION
As part of issue 383, we should attempt to reopen a log file every 5s until we succeed. This change adds that function, and also unit test infrastructure to allow us to control the results of attempting to open a file.

Tested through Sprout unit tests, and live.