### PR TITLE
[Reviewer: Rob] Alarm refactoring: Adjusts Alarm class hierarchy so that alarms...

### DIFF
--- a/include/alarm.h
+++ b/include/alarm.h
@@ -185,23 +185,6 @@ public:
   virtual void set_critical() {MultiStateAlarm::multi_set_critical();}
 };
 
-/// @class CedarLicenseErrorAlarm
-///
-/// Represents a Clearwater alarm with multiple raised states. This class gives
-/// the MultiStateAlarm object visibility of just those functions corresponding
-/// to states of the alarm that can be raised.
-
-//class CedarFTPDLicenseErrorAlarm: public MultiStateAlarm
-//{
-//public:
-  //CedarFTPDLicenseErrorAlarm(const std::string& issuer,
-    //                         const int index):
-    //MultiStateAlarm(issuer,
-    //                index){}
-  //virtual void set_major() {MultiStateAlarm::multi_set_major();}
-  //virtual void set_critical() {MultiStateAlarm::multi_set_critical();}
-//};
-
 /// @class AlarmReqAgent
 ///
 /// Singleton which provides an agent thead to accept queued alarm requests from

--- a/include/alarm.h
+++ b/include/alarm.h
@@ -191,16 +191,16 @@ public:
 /// the MultiStateAlarm object visibility of just those functions corresponding
 /// to states of the alarm that can be raised.
 
-class CedarFTPDLicenseErrorAlarm: public MultiStateAlarm
-{
-public:
-  CedarFTPDLicenseErrorAlarm(const std::string& issuer,
-                             const int index):
-    MultiStateAlarm(issuer,
-                    index){}
-  virtual void set_major() {MultiStateAlarm::multi_set_major();}
-  virtual void set_critical() {MultiStateAlarm::multi_set_critical();}
-};
+//class CedarFTPDLicenseErrorAlarm: public MultiStateAlarm
+//{
+//public:
+  //CedarFTPDLicenseErrorAlarm(const std::string& issuer,
+    //                         const int index):
+    //MultiStateAlarm(issuer,
+    //                index){}
+  //virtual void set_major() {MultiStateAlarm::multi_set_major();}
+  //virtual void set_critical() {MultiStateAlarm::multi_set_critical();}
+//};
 
 /// @class AlarmReqAgent
 ///

--- a/src/alarm.cpp
+++ b/src/alarm.cpp
@@ -87,52 +87,16 @@ Alarm::Alarm(const std::string& issuer,
 }
 
 MultiStateAlarm::MultiStateAlarm(const std::string& issuer,
-                                 const int index,
-                                 std::vector<AlarmDef::Severity> severities) :
-  _issuer(issuer),
+                                 const int index) :
+  _index(index),
   _alarmed(false),
-  _indeterminate_state(NULL),
-  _warning_state(NULL),
-  _minor_state(NULL),
-  _major_state(NULL),
-  _critical_state(NULL) 
+  _indeterminate_state(issuer, index, AlarmDef::INDETERMINATE),
+  _warning_state(issuer, index, AlarmDef::WARNING),
+  _minor_state(issuer, index, AlarmDef::MINOR),
+  _major_state(issuer, index, AlarmDef::MAJOR),
+  _critical_state(issuer, index, AlarmDef::CRITICAL),
+  _clear_state(issuer, index, AlarmDef::CLEARED) 
 {
-  for (unsigned int i = 0; i < severities.length(); i++)
-  {
-    switch(severities[i])
-    {
-      case AlarmDef::INDETERMINATE:
-      {
-        _indeterminate_state = AlarmState(issuer, index, AlarmDef::INDETERMINATE);
-      }
-      break;
-      case AlarmDef::WARNING:
-      {
-        _warning_state = AlarmState(issuer, index, AlarmDef::WARNING);
-      }
-      break;
-      case AlarmDef::MINOR:
-      {
-        _minor_state = AlarmState(issuer, index, AlarmDef::MINOR);
-      }
-      break;
-      case AlarmDef::MAJOR:
-      {
-        _major_state = AlarmState(issuer, index, AlarmDef::MAJOR);
-      }
-      break;
-      case AlarmDef::CRITICAL:
-      {
-        _critical_state = AlarmState(issuer, index, AlarmDef::CRITICAL);
-      }
-      break;
-
-      default: /** We shouldn't get here */
-      {
-        TRC_ERROR("unknown Alarm severity");
-      }
-    }
-  }
 }
 
 void Alarm::set()
@@ -155,9 +119,19 @@ void Alarm::clear()
   }
 }
 
-void MultiStateAlarm::set_indeterminate()
+void MultiStateAlarm::clear()
 {
-  bool previous_alarmed = _alarmed.exchange(true);
+  bool previously_alarmed = _alarmed.exchange(false);
+
+  if (previously_alarmed)
+  {
+    _clear_state.issue();
+  }
+}
+
+void MultiStateAlarm::multi_set_indeterminate()
+{
+  bool previously_alarmed = _alarmed.exchange(true);
 
   if (!previously_alarmed)
   {
@@ -165,9 +139,9 @@ void MultiStateAlarm::set_indeterminate()
   }
 }
 
-void MultiStateAlarm::set_warning()
+void MultiStateAlarm::multi_set_warning()
 {
-  bool previous_alarmed = _alarmed.exchange(true);
+  bool previously_alarmed = _alarmed.exchange(true);
 
   if (!previously_alarmed)
   {
@@ -175,9 +149,9 @@ void MultiStateAlarm::set_warning()
   }
 }
 
-void MultiStateAlarm::set_minor()
+void MultiStateAlarm::multi_set_minor()
 {
-  bool previous_alarmed = _alarmed.exchange(true);
+  bool previously_alarmed = _alarmed.exchange(true);
 
   if (!previously_alarmed)
   {
@@ -185,9 +159,9 @@ void MultiStateAlarm::set_minor()
   }
 }
 
-void MultiStateAlarm::set_major()
+void MultiStateAlarm::multi_set_major()
 {
-  bool previous_alarmed = _alarmed.exchange(true);
+  bool previously_alarmed = _alarmed.exchange(true);
 
   if (!previously_alarmed)
   {
@@ -195,9 +169,9 @@ void MultiStateAlarm::set_major()
   }
 }
 
-void MultiStateAlarm::set_critical()
+void MultiStateAlarm::multi_set_critical()
 {
-  bool previous_alarmed = _alarmed.exchange(true);
+  bool previously_alarmed = _alarmed.exchange(true);
 
   if (!previously_alarmed)
   {

--- a/src/alarm.cpp
+++ b/src/alarm.cpp
@@ -79,23 +79,19 @@ void AlarmState::clear_all(const std::string& issuer)
 Alarm::Alarm(const std::string& issuer,
              const int index,
              AlarmDef::Severity severity) :
-  _index(index),
-  _clear_state(issuer, index, AlarmDef::CLEARED),
-  _set_state(issuer, index, severity),
-  _alarmed(false)
+  BaseAlarm(issuer, index),
+  _set_state(issuer, index, severity)
 {
 }
 
 MultiStateAlarm::MultiStateAlarm(const std::string& issuer,
                                  const int index) :
-  _index(index),
-  _alarmed(false),
+  BaseAlarm(issuer, index),
   _indeterminate_state(issuer, index, AlarmDef::INDETERMINATE),
   _warning_state(issuer, index, AlarmDef::WARNING),
   _minor_state(issuer, index, AlarmDef::MINOR),
   _major_state(issuer, index, AlarmDef::MAJOR),
-  _critical_state(issuer, index, AlarmDef::CRITICAL),
-  _clear_state(issuer, index, AlarmDef::CLEARED) 
+  _critical_state(issuer, index, AlarmDef::CRITICAL)
 {
 }
 
@@ -109,17 +105,7 @@ void Alarm::set()
   }
 }
 
-void Alarm::clear()
-{
-  bool previously_alarmed = _alarmed.exchange(false);
-
-  if (previously_alarmed)
-  {
-    _clear_state.issue();
-  }
-}
-
-void MultiStateAlarm::clear()
+void BaseAlarm::clear()
 {
   bool previously_alarmed = _alarmed.exchange(false);
 

--- a/src/alarm.cpp
+++ b/src/alarm.cpp
@@ -86,6 +86,55 @@ Alarm::Alarm(const std::string& issuer,
 {
 }
 
+MultiStateAlarm::MultiStateAlarm(const std::string& issuer,
+                                 const int index,
+                                 std::vector<AlarmDef::Severity> severities) :
+  _issuer(issuer),
+  _alarmed(false),
+  _indeterminate_state(NULL),
+  _warning_state(NULL),
+  _minor_state(NULL),
+  _major_state(NULL),
+  _critical_state(NULL) 
+{
+  for (unsigned int i = 0; i < severities.length(); i++)
+  {
+    switch(severities[i])
+    {
+      case AlarmDef::INDETERMINATE:
+      {
+        _indeterminate_state = AlarmState(issuer, index, AlarmDef::INDETERMINATE);
+      }
+      break;
+      case AlarmDef::WARNING:
+      {
+        _warning_state = AlarmState(issuer, index, AlarmDef::WARNING);
+      }
+      break;
+      case AlarmDef::MINOR:
+      {
+        _minor_state = AlarmState(issuer, index, AlarmDef::MINOR);
+      }
+      break;
+      case AlarmDef::MAJOR:
+      {
+        _major_state = AlarmState(issuer, index, AlarmDef::MAJOR);
+      }
+      break;
+      case AlarmDef::CRITICAL:
+      {
+        _critical_state = AlarmState(issuer, index, AlarmDef::CRITICAL);
+      }
+      break;
+
+      default: /** We shouldn't get here */
+      {
+        TRC_ERROR("unknown Alarm severity");
+      }
+    }
+  }
+}
+
 void Alarm::set()
 {
   bool previously_alarmed = _alarmed.exchange(true);
@@ -103,6 +152,56 @@ void Alarm::clear()
   if (previously_alarmed)
   {
     _clear_state.issue();
+  }
+}
+
+void MultiStateAlarm::set_indeterminate()
+{
+  bool previous_alarmed = _alarmed.exchange(true);
+
+  if (!previously_alarmed)
+  {
+    _indeterminate_state.issue();
+  }
+}
+
+void MultiStateAlarm::set_warning()
+{
+  bool previous_alarmed = _alarmed.exchange(true);
+
+  if (!previously_alarmed)
+  {
+    _warning_state.issue();
+  }
+}
+
+void MultiStateAlarm::set_minor()
+{
+  bool previous_alarmed = _alarmed.exchange(true);
+
+  if (!previously_alarmed)
+  {
+    _minor_state.issue();
+  }
+}
+
+void MultiStateAlarm::set_major()
+{
+  bool previous_alarmed = _alarmed.exchange(true);
+
+  if (!previously_alarmed)
+  {
+    _major_state.issue();
+  }
+}
+
+void MultiStateAlarm::set_critical()
+{
+  bool previous_alarmed = _alarmed.exchange(true);
+
+  if (!previously_alarmed)
+  {
+    _critical_state.issue();
   }
 }
 


### PR DESCRIPTION
with more than one severity are represented as one object of class MultiStateAlarm.

The main changes here include creating the superclass: BaseAlarm that allows us to split different types of alarms into subclasses. Those alarms which only have one possible raised state will be constructed by subclass Alarm. Those alarms which have two or more possible raised states will be constructed by subclass MultiStateAlarm.

MultiStateAlarm is then further subclassed into classes that represent individual alarms. These subclasses gives the MultiStateAlarm objects visibility of just those functions corresponding to states of the alarm that can be raised.