### PR TITLE
Reviewer Rob - Create the alarm_resend thread lazily

### DIFF
--- a/include/alarm.h
+++ b/include/alarm.h
@@ -122,7 +122,7 @@ protected:
 class AlarmManager
 {
 public:
-  static AlarmManager& get_instance() {return _instance;}
+  static AlarmManager& get_instance();
   bool _terminated;
   void register_alarm(BaseAlarm* alarm); 
   // Used to stop re-raising alarms in UTs
@@ -134,12 +134,16 @@ private:
   AlarmManager();
   ~AlarmManager();
 
+  // Called once (using pthread_once) to create the AlarmManager.
+  static void create_singleton();
+  static AlarmManager* _instance;
+  static pthread_once_t alarm_manager_singleton_once;
+
   bool _first_alarm_raised;
   // Static function called by the reraising alarms thread. This simply calls
   // the 'reraise_alarms' member method
   static void* reraise_alarms_function(void* data);
 
-  static AlarmManager _instance;
   // This runs on a thread (defined below) and iterates over _alarm_list
   // every 30 seconds. For each alarm it calls the reraise_last_state method.
   void reraise_alarms();


### PR DESCRIPTION
Don't spawn threads in things created statically, instead spawn the thread lazily the first time someone calls into `AlarmManager::get_instance()` which happens (among other times) when alarms are defined.  This means you should always wait until after demonizing/forking before defining alarms but this is a pretty reasonable requirement.

Also fixed up a locking mistake (we weren't protecting access to the list of registered alarms even though we iterate over the list in another thread).

Testing done:

- [x] UTs
- [ ] Clearwater Live Test - Doesn't test alarms
- [x] Manual live verification - Tested that alarms are still raised as expected and that the resync thread is running (checked in `gdb`)