### PR TITLE
Reviewer Rob - Store the AlarmManager in a unique pointer to prevent leaks

### DIFF
--- a/include/alarm.h
+++ b/include/alarm.h
@@ -42,6 +42,7 @@
 #include <string>
 #include <vector>
 #include <atomic>
+#include <memory>
 
 #include "alarmdefinition.h"
 #include "eventq.h"
@@ -122,6 +123,9 @@ protected:
 class AlarmManager
 {
 public:
+  // Public so std::unique_ptr can destroy us at end of day.
+  ~AlarmManager();
+
   static AlarmManager& get_instance();
   bool _terminated;
   void register_alarm(BaseAlarm* alarm); 
@@ -131,12 +135,12 @@ public:
   void stop_resending_alarms(void) { _first_alarm_raised = false; }
 
 private:
+  // Private since this is a singleton
   AlarmManager();
-  ~AlarmManager();
 
   // Called once (using pthread_once) to create the AlarmManager.
   static void create_singleton();
-  static AlarmManager* _instance;
+  static std::unique_ptr<AlarmManager> _instance;
   static pthread_once_t alarm_manager_singleton_once;
 
   bool _first_alarm_raised;

--- a/src/alarm.cpp
+++ b/src/alarm.cpp
@@ -49,7 +49,7 @@
 pthread_mutex_t issue_alarm_change_state;
 
 AlarmReqAgent AlarmReqAgent::_instance;
-AlarmManager* AlarmManager::_instance;
+std::unique_ptr<AlarmManager> AlarmManager::_instance;
 pthread_once_t AlarmManager::alarm_manager_singleton_once = PTHREAD_ONCE_INIT;
 
 AlarmState::AlarmState(const std::string& issuer,
@@ -167,7 +167,7 @@ void MultiStateAlarm::set_critical()
 
 void AlarmManager::create_singleton()
 {
-  _instance = new AlarmManager();
+  _instance = std::unique_ptr<AlarmManager>(new AlarmManager());
 }
 
 AlarmManager& AlarmManager::get_instance()


### PR DESCRIPTION
Don't leak the `AlarmManager`.  I'll raise an issue for the use of `start-stop-daemon --daemonize`.