### PR TITLE
[Reviewer: Rob] Alarm reliability

### DIFF
--- a/include/alarm.h
+++ b/include/alarm.h
@@ -110,7 +110,7 @@ public:
   void reraise_last_state();
   
   /// Returns the current state of the alarm as one of UNKNOWN, CLEARED, or ALARMED.
-  virtual AlarmCondition get_alarm_state();
+  virtual AlarmState::AlarmCondition get_alarm_state();
 
   // If an alarm is currently in a different state to the one we wish to raise
   // the alarm in, we raise the alarm and update _last_state_raised.

--- a/include/alarm.h
+++ b/include/alarm.h
@@ -50,7 +50,7 @@
 /// @enum AlarmStatus
 ///
 /// Enum for the three possible alarm states
-enum Alarm
+enum AlarmStatus
 {
   // The NULL state in which all alarms start
   UNKNOWN,
@@ -58,7 +58,7 @@ enum Alarm
   CLEARED,
   // The alarm has been raised at any severity other than cleared
   ALARMED
-}
+};
 
 /// @class AlarmState
 ///

--- a/include/alarm.h
+++ b/include/alarm.h
@@ -72,7 +72,8 @@ public:
 
   /// @enum AlarmCondition
   ///
-  /// Enum for the three possible alarm states
+  /// Enum for the three possible general states an alarm can be in.
+  /// i.e. Not yet set, raised or cleared.
   enum AlarmCondition
   {
     // The state in which all alarms start, indicating that

--- a/include/alarm.h
+++ b/include/alarm.h
@@ -47,19 +47,6 @@
 #include "alarmdefinition.h"
 #include "eventq.h"
 
-/// @enum AlarmStatus
-///
-/// Enum for the three possible alarm states
-enum AlarmStatus
-{
-  // The NULL state in which all alarms start
-  UNKNOWN,
-  // The alarm has been explicitly cleared
-  CLEARED,
-  // The alarm has been raised at any severity other than cleared
-  ALARMED
-};
-
 /// @class AlarmState
 ///
 /// Provides the basic interface for updating an SNMP alarm's state.
@@ -82,6 +69,21 @@ public:
 
   std::string& get_issuer() {return _issuer;}
   std::string& get_identifier() {return _identifier;}
+
+  /// @enum AlarmCondition
+  ///
+  /// Enum for the three possible alarm states
+  enum AlarmCondition
+  {
+    // The state in which all alarms start, indicating that
+    // no state has been explicitly raised
+    UNKNOWN,
+    // The alarm has been explicitly cleared
+    CLEARED,
+    // The alarm has been raised at any severity other than cleared
+    ALARMED
+  };
+
 
 private:
   std::string _issuer;
@@ -108,7 +110,7 @@ public:
   void reraise_last_state();
   
   /// Returns the current state of the alarm as one of UNKNOWN, CLEARED, or ALARMED.
-  virtual AlarmStatus get_alarm_state();
+  virtual AlarmCondition get_alarm_state();
 
   // If an alarm is currently in a different state to the one we wish to raise
   // the alarm in, we raise the alarm and update _last_state_raised.

--- a/include/alarm.h
+++ b/include/alarm.h
@@ -47,6 +47,19 @@
 #include "alarmdefinition.h"
 #include "eventq.h"
 
+/// @enum AlarmStatus
+///
+/// Enum for the three possible alarm states
+enum Alarm
+{
+  // The NULL state in which all alarms start
+  UNKNOWN,
+  // The alarm has been explicitly cleared
+  CLEARED,
+  // The alarm has been raised at any severity other than cleared
+  ALARMED
+}
+
 /// @class AlarmState
 ///
 /// Provides the basic interface for updating an SNMP alarm's state.
@@ -81,7 +94,7 @@ private:
 /// alarms into subclasses. Those alarms which only have one possible raised
 /// state will be constructed by subclass Alarm. Those alarms which have two or
 /// more possible raised states will be constructed by subclass
-/// MultiStateAlarm. 
+/// MultiStateAlarm.
 
 class BaseAlarm
 {
@@ -94,6 +107,9 @@ public:
   /// of the alarm.
   void reraise_last_state();
   
+  /// Returns the current state of the alarm as one of UNKNOWN, CLEARED, or ALARMED.
+  virtual AlarmStatus get_alarm_state();
+
   // If an alarm is currently in a different state to the one we wish to raise
   // the alarm in, we raise the alarm and update _last_state_raised.
   void switch_to_state(AlarmState* new_state);

--- a/include/alarm.h
+++ b/include/alarm.h
@@ -94,10 +94,6 @@ public:
   /// of the alarm.
   void reraise_last_state();
   
-  /// Indicates whether the alarm state currently maintained by this object
-  /// corresponds to the non-CLEARED severity.
-  virtual bool alarmed() {return (_last_state_raised != &_clear_state);}
-
   // If an alarm is currently in a different state to the one we wish to raise
   // the alarm in, we raise the alarm and update _last_state_raised.
   void switch_to_state(AlarmState* new_state);

--- a/src/alarm.cpp
+++ b/src/alarm.cpp
@@ -104,7 +104,7 @@ void BaseAlarm::reraise_last_state()
   }
 }
 
-AlarmCondition BaseAlarm::get_alarm_state()
+AlarmState::AlarmCondition BaseAlarm::get_alarm_state()
 {
   if (_last_state_raised == NULL)
   {

--- a/src/alarm.cpp
+++ b/src/alarm.cpp
@@ -88,7 +88,7 @@ BaseAlarm::BaseAlarm(const std::string& issuer,
                      const int index):
   _index(index),
   _clear_state(issuer, index, AlarmDef::CLEARED),
-  _last_state_raised(&_clear_state)
+  _last_state_raised(NULL)
 {
   AlarmManager::get_instance().register_alarm(this);
 }
@@ -110,7 +110,10 @@ void BaseAlarm::clear()
 
 void BaseAlarm::reraise_last_state()
 {
-  _last_state_raised->issue();
+  if (_last_state_raised != NULL)
+  {
+    _last_state_raised->issue();
+  }
 }
 
 Alarm::Alarm(const std::string& issuer,

--- a/src/alarm.cpp
+++ b/src/alarm.cpp
@@ -104,6 +104,22 @@ void BaseAlarm::reraise_last_state()
   }
 }
 
+AlarmStatus BaseAlarm::get_alarm_state()
+{
+  if (_last_state_raised == NULL)
+  {
+    return UNKNOWN;
+  }
+  else if (_last_state_raised == &_clear_state)
+  {
+    return CLEARED;
+  }
+  else
+  {
+    return ALARMED;
+  }
+}
+
 Alarm::Alarm(const std::string& issuer,
              const int index,
              AlarmDef::Severity severity) :

--- a/src/alarm.cpp
+++ b/src/alarm.cpp
@@ -69,19 +69,7 @@ void AlarmState::issue()
   req.push_back(_issuer);
   req.push_back(_identifier);
   AlarmReqAgent::get_instance().alarm_request(req);
-  TRC_DEBUG("%s issued %s alarm", _issuer.c_str(), _identifier.c_str());
-}
-
-void AlarmState::clear_all(const std::string& issuer)
-{
-  std::vector<std::string> req;
-
-  req.push_back("clear-alarms");
-  req.push_back(issuer);
-
-  AlarmReqAgent::get_instance().alarm_request(req);
-
-  TRC_DEBUG("%s cleared its alarms", issuer.c_str());
+  TRC_STATUS("%s issued %s alarm", _issuer.c_str(), _identifier.c_str());
 }
 
 BaseAlarm::BaseAlarm(const std::string& issuer,

--- a/src/alarm.cpp
+++ b/src/alarm.cpp
@@ -104,7 +104,7 @@ void BaseAlarm::reraise_last_state()
   }
 }
 
-AlarmStatus BaseAlarm::get_alarm_state()
+AlarmCondition BaseAlarm::get_alarm_state()
 {
   if (_last_state_raised == NULL)
   {

--- a/src/communicationmonitor.cpp
+++ b/src/communicationmonitor.cpp
@@ -122,7 +122,6 @@ void CommunicationMonitor::track_communication_changes(unsigned long now_ms)
             case ONLY_ERRORS:
               CL_CM_CONNECTION_ERRORED.log(_sender.c_str(),
                                            _receiver.c_str());
-              TRC_STATUS("Setting alarm %d", _alarm->index());
               _alarm->set();
               break;
           }
@@ -142,7 +141,6 @@ void CommunicationMonitor::track_communication_changes(unsigned long now_ms)
             case ONLY_ERRORS:
               CL_CM_CONNECTION_ERRORED.log(_sender.c_str(),
                                            _receiver.c_str());
-              TRC_STATUS("Setting alarm %d", _alarm->index());
               _alarm->set();
               break;
           }
@@ -153,14 +151,12 @@ void CommunicationMonitor::track_communication_changes(unsigned long now_ms)
             case NO_ERRORS:
               CL_CM_CONNECTION_CLEARED.log(_sender.c_str(),
                                            _receiver.c_str());
-              TRC_STATUS("Clearing alarm %d", _alarm->index());
               _alarm->clear();
               break;
 
             case SOME_ERRORS:
               CL_CM_CONNECTION_PARTIAL_ERROR.log(_sender.c_str(),
                                                  _receiver.c_str());
-              TRC_STATUS("Clearing alarm %d", _alarm->index());
               _alarm->clear();
               break;
 

--- a/src/communicationmonitor.cpp
+++ b/src/communicationmonitor.cpp
@@ -117,6 +117,7 @@ void CommunicationMonitor::track_communication_changes(unsigned long now_ms)
             case SOME_ERRORS:
               CL_CM_CONNECTION_PARTIAL_ERROR.log(_sender.c_str(),
                                                  _receiver.c_str());
+              _alarm->clear();
               break;
 
             case ONLY_ERRORS:
@@ -132,6 +133,7 @@ void CommunicationMonitor::track_communication_changes(unsigned long now_ms)
             case NO_ERRORS:
               CL_CM_CONNECTION_CLEARED.log(_sender.c_str(),
                                            _receiver.c_str());
+              _alarm->clear();
               break;
 
             case SOME_ERRORS: // No change in state. Ensure alarm is cleared.
@@ -161,7 +163,7 @@ void CommunicationMonitor::track_communication_changes(unsigned long now_ms)
               break;
 
             case ONLY_ERRORS: // No change in state. Ensure alarm is raised.
-              _alarm->set()
+              _alarm->set();
               break;
           }
           break;

--- a/src/communicationmonitor.cpp
+++ b/src/communicationmonitor.cpp
@@ -110,7 +110,8 @@ void CommunicationMonitor::track_communication_changes(unsigned long now_ms)
         case NO_ERRORS:
           switch (_new_state)
           {
-            case NO_ERRORS: // No change in state. Do nothing.
+            case NO_ERRORS: // No change in state. Ensure alarm is cleared.
+              _alarm->clear();
               break;
 
             case SOME_ERRORS:
@@ -134,7 +135,8 @@ void CommunicationMonitor::track_communication_changes(unsigned long now_ms)
                                            _receiver.c_str());
               break;
 
-            case SOME_ERRORS: // No change in state. Do nothing.
+            case SOME_ERRORS: // No change in state. Ensure alarm is cleared.
+              _alarm->clear();
               break;
 
             case ONLY_ERRORS:
@@ -162,7 +164,8 @@ void CommunicationMonitor::track_communication_changes(unsigned long now_ms)
               _alarm->clear();
               break;
 
-            case ONLY_ERRORS: // No change in state. Do nothing.
+            case ONLY_ERRORS: // No change in state. Ensure alarm is raised.
+              _alarm->set()
               break;
           }
           break;

--- a/test_utils/mockalarm.h
+++ b/test_utils/mockalarm.h
@@ -48,6 +48,8 @@ public:
 
   MOCK_METHOD0(clear, void());
   MOCK_METHOD0(set, void());
+  MOCK_METHOD0(get_alarm_state, AlarmStatus());
+
 };
 
 #endif

--- a/test_utils/mockalarm.h
+++ b/test_utils/mockalarm.h
@@ -48,7 +48,7 @@ public:
 
   MOCK_METHOD0(clear, void());
   MOCK_METHOD0(set, void());
-  MOCK_METHOD0(get_alarm_state, AlarmStatus());
+  MOCK_METHOD0(get_alarm_state, AlarmCondition());
 };
 
 #endif

--- a/test_utils/mockalarm.h
+++ b/test_utils/mockalarm.h
@@ -49,7 +49,6 @@ public:
   MOCK_METHOD0(clear, void());
   MOCK_METHOD0(set, void());
   MOCK_METHOD0(get_alarm_state, AlarmStatus());
-
 };
 
 #endif

--- a/test_utils/mockalarm.h
+++ b/test_utils/mockalarm.h
@@ -48,7 +48,6 @@ public:
 
   MOCK_METHOD0(clear, void());
   MOCK_METHOD0(set, void());
-  MOCK_METHOD0(alarmed, bool());
 };
 
 #endif


### PR DESCRIPTION
The main alarm changes. 
- Removed clear_all function
- Added get_alarm_state function, and associated enum
- altered communication_monitor alarm raising
- Alarms now start with severity pointing to NULL

I will link the pull request for cpp-common-test that covers these changes