### PR TITLE
[No Reviewer] Remove clear_all from header file

### DIFF
--- a/include/alarm.h
+++ b/include/alarm.h
@@ -62,11 +62,6 @@ public:
   /// state associated with severity, for the specified issuer.
   void issue();
 
-  /// Queue request to clear all active alarms initiated by issuer.
-  /// This will result in a state change to CLEARED for all alarms
-  /// whose state was set to non-CLEARED by the issuer.
-  static void clear_all(const std::string& issuer);
-
   std::string& get_issuer() {return _issuer;}
   std::string& get_identifier() {return _identifier;}
 


### PR DESCRIPTION
Missed this when making changes to increase alarm reliability in https://github.com/Metaswitch/cpp-common/pull/476 