### PR TITLE
Reviewer EM: Add AVPException class

### DIFF
--- a/include/diameterstack.h
+++ b/include/diameterstack.h
@@ -471,6 +471,13 @@ private:
   }
 };
 
+class AVPException
+{
+public:
+  inline AVPException(const char* missing_avp): _missing_avp(missing_avp) {};
+  const char* _missing_avp;
+};
+
 class AVP::iterator
 {
 public:


### PR DESCRIPTION
Moving this to diameterstack.cpp so we can use it in other places. I'll update everywhere that it's currently used too.