### PR TITLE
[Reviewer: Alex] Fix Clang warnings

### DIFF
--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -325,10 +325,10 @@ void DnsCachedResolver::dns_query(const std::vector<std::string>& domains,
                 ce->domain.c_str(),
                 DnsRRecord::rrtype_to_string(ce->dnstype).c_str());
 
-      results.push_back(std::move(DnsResult(ce->domain,
+      results.push_back(DnsResult(ce->domain,
                                             ce->dnstype,
                                             ce->records,
-                                            ce->expires - time(NULL))));
+                                            ce->expires - time(NULL)));
     }
     else
     {

--- a/test_utils/mockdiameterstack.hpp
+++ b/test_utils/mockdiameterstack.hpp
@@ -44,8 +44,6 @@ class MockDiameterStack : public Diameter::Stack
 {
 public:
   MOCK_METHOD0(initialize, void());
-  MOCK_METHOD1(configure, void(const std::string&));
-  MOCK_METHOD1(advertize_application, void(const Diameter::Dictionary::Application&));
   MOCK_METHOD3(register_handler, void(const Diameter::Dictionary::Application&, const Diameter::Dictionary::Message&, HandlerInterface*));
   MOCK_METHOD1(register_fallback_handler, void(const Diameter::Dictionary::Application&));
   MOCK_METHOD2(register_peer_hook_hdlr, void(std::string, Diameter::PeerConnectionCB));


### PR DESCRIPTION
Fixes two warnings I saw with Clang 3.8 - sending to you for review as a std::move expert.

* Two of the mockdiameterstack.hpp methods had different signatures to the parent methods. As they weren't used, I've just deleted them.
* Clang told me `moving a temporary object prevents copy elision [-Werror,-Wpessimizing-move]` and told me to remove the offending std::move call. I've done so and it seems OK.