### PR TITLE
Reviewer MIRW: Don't unregister callback handler in multiple places

### DIFF
--- a/src/diameterstack.cpp
+++ b/src/diameterstack.cpp
@@ -602,8 +602,6 @@ void Stack::stop()
                     _peer_connection_cbs.begin()->first.c_str());
       }
       pthread_rwlock_unlock(&_peer_connection_cbs_lock);
-
-      fd_hook_unregister(_peer_cb_hdlr);
     }
 
     if (_rt_out_cb_hdlr)
@@ -615,8 +613,6 @@ void Stack::stop()
                     _rt_out_cbs.begin()->first.c_str());
       }
       pthread_rwlock_unlock(&_rt_out_cbs_lock);
-
-      fd_rt_out_unregister(_rt_out_cb_hdlr, NULL);
     }
 
     if (_error_cb_hdlr)


### PR DESCRIPTION
This fixes https://github.com/Metaswitch/homestead/issues/328. By the time the Diameter stack is being shutdown, any applications that registered callback handlers should have unregistered them, so we shouldn't unregister them here - we do drop a warning log if we think there is a listener that hasn't unregistered its callback.

I've tested by running (with https://github.com/Metaswitch/homestead/pull/335) against an HSS and restarting Homestead. There is no crash and Homestead shuts down smoothly and quickly.