### PR TITLE
[Reviewer: Alex] Move thread creation out of constructor

### DIFF
--- a/include/communicationmonitor.h
+++ b/include/communicationmonitor.h
@@ -51,6 +51,8 @@
 /// one is detected, an alarm clear state is requested. Note that timing is
 /// driven by calls to the inform_* methods. As such the intervals will not
 /// be very precise at low call volume.
+///
+/// The communication monitor takes ownership of the alarm it's given.
 class CommunicationMonitor : public BaseCommunicationMonitor
 {
 public:

--- a/include/signalhandler.h
+++ b/include/signalhandler.h
@@ -80,21 +80,6 @@ public:
 
     // Create the semaphore
     sem_init(&_sema, 0, 0);
-
-    // Create the dispatcher thread.
-    pthread_create(&_dispatcher_thread, 0, &SignalHandler::dispatcher, (void*)this);
-
-    // Hook the signal.
-    sighandler_t old_handler = signal(SIGNUM, &SignalHandler::handler);
-
-    if (old_handler != SIG_DFL)
-    {
-// LCOV_EXCL_START
-      // Old handler is not the default handler, so someone else has previously
-      // hooked the signal.
-      TRC_WARNING("SIGNAL already hooked");
-// LCOV_EXCL_STOP
-    }
   }
 
   ~SignalHandler()
@@ -112,6 +97,24 @@ public:
     // Destroy the mutex and condition.
     pthread_mutex_destroy(&_mutex);
     pthread_cond_destroy(&_cond);
+  }
+
+  void start()
+  {
+    // Create the dispatcher thread.
+    pthread_create(&_dispatcher_thread, 0, &SignalHandler::dispatcher, (void*)this);
+
+    // Hook the signal.
+    sighandler_t old_handler = signal(SIGNUM, &SignalHandler::handler);
+
+    if (old_handler != SIG_DFL)
+    {
+// LCOV_EXCL_START
+      // Old handler is not the default handler, so someone else has previously
+      // hooked the signal.
+      TRC_WARNING("SIGNAL already hooked");
+// LCOV_EXCL_STOP
+    }
   }
 
   bool wait_for_signal()

--- a/include/signalhandler.h
+++ b/include/signalhandler.h
@@ -95,8 +95,8 @@ public:
     sem_destroy(&_sema);
 
     // Destroy the mutex and condition.
-    pthread_mutex_destroy(&_mutex);
     pthread_cond_destroy(&_cond);
+    pthread_mutex_destroy(&_mutex);
   }
 
   void start()

--- a/include/utils.h
+++ b/include/utils.h
@@ -486,6 +486,8 @@ namespace Utils
   // file descriptors.
   int daemonize();
 
+  void start_signal_handlers();
+
 } // namespace Utils
 
 #endif /* UTILS_H_ */

--- a/include/utils.h
+++ b/include/utils.h
@@ -486,6 +486,9 @@ namespace Utils
   // file descriptors.
   int daemonize();
 
+  // This starts the signal handlers. This creates a new thread for each
+  // handler, so this function must not be called before the process has
+  // daemonised (if it's going to)
   void start_signal_handlers();
 
 } // namespace Utils

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -54,6 +54,7 @@
 
 #include "utils.h"
 #include "log.h"
+#include "signalhandler.h"
 
 bool Utils::parse_http_url(const std::string& url, std::string& server, std::string& path)
 {
@@ -531,4 +532,10 @@ int Utils::daemonize()
   }
 
   return 0;
+}
+
+void Utils::start_signal_handlers()
+{
+  _sighup_handler.start();
+  _sigusr1_handler.start();
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -534,9 +534,6 @@ int Utils::daemonize()
   return 0;
 }
 
-// This starts the signal handlers. This creates a new thread for each
-// handler, so this function must not be called before the process has
-// daemonised (if it's going to)
 void Utils::start_signal_handlers()
 {
   _sighup_handler.start();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -534,6 +534,9 @@ int Utils::daemonize()
   return 0;
 }
 
+// This starts the signal handlers. This creates a new thread for each
+// handler, so this function must not be called before the process has
+// daemonised (if it's going to)
 void Utils::start_signal_handlers()
 {
   _sighup_handler.start();


### PR DESCRIPTION
This moves the thread creation out of the signal handler constructors

Fixes #504 