### PR TITLE
Reviewer MIRW: Clear vbucket alarms

### DIFF
--- a/src/memcachedstore.cpp
+++ b/src/memcachedstore.cpp
@@ -308,7 +308,7 @@ void BaseMemcachedStore::update_vbucket_comm_state(int vbucket, CommState state)
           _vbucket_alarm->clear();
         }
 
-        TRC_INFO("vbucket %d no longer inaccessible, now %d inaccessable vbucket(s)",
+        TRC_INFO("vbucket %d now accessible, %d inaccessible vbucket(s) remain",
                  vbucket,
                  _vbucket_comm_fail_count);
       }
@@ -316,7 +316,7 @@ void BaseMemcachedStore::update_vbucket_comm_state(int vbucket, CommState state)
       {
         _vbucket_comm_fail_count++;
         _vbucket_alarm->set();
-        TRC_INFO("vbucket %d inaccessible, now %d inaccessable vbucket(s)",
+        TRC_INFO("vbucket %d inaccessible, now %d inaccessible vbucket(s)",
                  vbucket,
                  _vbucket_comm_fail_count);
       }

--- a/src/memcachedstore.cpp
+++ b/src/memcachedstore.cpp
@@ -303,15 +303,22 @@ void BaseMemcachedStore::update_vbucket_comm_state(int vbucket, CommState state)
     {
       if (state == OK)
       {
-        if ((_vbucket_comm_fail_count--) == 0)
+        if (--_vbucket_comm_fail_count == 0)
         {
           _vbucket_alarm->clear();
         }
+
+        TRC_INFO("vbucket %d no longer inaccessible, now %d inaccessable vbucket(s)",
+                 vbucket,
+                 _vbucket_comm_fail_count);
       }
       else
       {
         _vbucket_comm_fail_count++;
         _vbucket_alarm->set();
+        TRC_INFO("vbucket %d inaccessible, now %d inaccessable vbucket(s)",
+                 vbucket,
+                 _vbucket_comm_fail_count);
       }
 
       _vbucket_comm_state[vbucket] = state;


### PR DESCRIPTION
Fixes https://github.com/Metaswitch/sprout/issues/1422. I've also added some useful TRC_INFO logs because we don't currently have any diags at all for this alarm.

I've tested by spinning up a 2 site GR deployment with a cluster of 2 Sprout nodes in each site, and turning off the memcacheds in the remote site to trigger the alarm, and then turning them back on. Without this change, the alarm was raised and never cleared. With this change the alarm was raised and then cleared again when the memcacheds came back up.

@JimBunch I'm going to merge into release-94-fixes once this is reviewed and update all the C++ projects with this new cpp-common - is that ok? I'll leave it up to you whether you want to take a new build with it.