### PR TITLE
[Reviewer: Graeme] Don't put signal handler stuff in utils

### DIFF
--- a/include/signalhandler.h
+++ b/include/signalhandler.h
@@ -194,4 +194,13 @@ template<int SIGNUM> sem_t SignalHandler<SIGNUM>::_sema;
 extern SignalHandler<SIGHUP> _sighup_handler;
 extern SignalHandler<SIGUSR1> _sigusr1_handler;
 
+// This starts the signal handlers. This creates a new thread for each
+// handler, so this function must not be called before the process has
+// daemonised (if it's going to)
+inline void start_signal_handlers()
+{
+  _sighup_handler.start();
+  _sigusr1_handler.start();
+}
+
 #endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -485,12 +485,6 @@ namespace Utils
   // Daemonize the current process, detaching it from the parent and redirecting
   // file descriptors.
   int daemonize();
-
-  // This starts the signal handlers. This creates a new thread for each
-  // handler, so this function must not be called before the process has
-  // daemonised (if it's going to)
-  void start_signal_handlers();
-
 } // namespace Utils
 
 #endif /* UTILS_H_ */

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -54,7 +54,6 @@
 
 #include "utils.h"
 #include "log.h"
-#include "signalhandler.h"
 
 bool Utils::parse_http_url(const std::string& url, std::string& server, std::string& path)
 {
@@ -532,10 +531,4 @@ int Utils::daemonize()
   }
 
   return 0;
-}
-
-void Utils::start_signal_handlers()
-{
-  _sighup_handler.start();
-  _sigusr1_handler.start();
 }


### PR DESCRIPTION
Don't make utils.cpp dependent on signal_handler.h