### PR TITLE
[Reviewer: Andrew] Take lock when clearing alarm list

### DIFF
--- a/include/alarm.h
+++ b/include/alarm.h
@@ -140,7 +140,7 @@ public:
   bool _terminated;
   void register_alarm(BaseAlarm* alarm); 
   // Used to stop re-raising alarms in UTs
-  void forget_alarm_list(void) {_alarm_list.clear();}
+  void forget_alarm_list(void) {pthread_mutex_lock(&_lock); _alarm_list.clear(); pthread_mutex_unlock(&_lock); }
   void start_resending_alarms(void) { _first_alarm_raised = true; }
   void stop_resending_alarms(void) { _first_alarm_raised = false; }
 


### PR DESCRIPTION
I think this fixes https://github.com/Metaswitch/cpp-common-test/issues/16 - I ran `LD_LIBRARY_PATH=../usr/lib valgrind --track-origins=yes --malloc-fill=cc --free-fill=df ../build/bin/cpp_common_test_test --gtest_filter="AlarmTest*"` ten times without this fix, and hit that issue four times; I then ran it ten times with this fix and didn't hit it.

I think you added this function originally - it's worth being aware that any time you access a data structure from multiple threads, you need to take a lock, even if you're clearing it - I suspect the issue was that one thread was trying to access elements of the vector that other threads had cleared, and corrupted some other memory when it did so.