### PR TITLE
[Reviewer: Graeme] Don't call fd_sess_getsid on NULL

### DIFF
--- a/src/diameterstack.cpp
+++ b/src/diameterstack.cpp
@@ -957,7 +957,8 @@ void Stack::fd_sas_log_diameter_message(enum fd_hook_type type,
   struct session* sess;
   int dummy_is_new;
 
-  if (fd_msg_sess_get(fd_g_config->cnf_dict, msg, &sess, &dummy_is_new) == 0)
+  if ((fd_msg_sess_get(fd_g_config->cnf_dict, msg, &sess, &dummy_is_new) == 0) &&
+      (sess != NULL))
   {
     os0_t session_id;
     size_t session_id_len;


### PR DESCRIPTION
`fd_msg_sess_get` can return 0, to indicate successful completion, but still set the session to NULL (see https://github.com/Metaswitch/freeDiameter/blob/33bdebe6674f3d98ce7b9d6e8d52db934914820d/libfdproto/messages.c#L1518). This PR checks for that case, and doesn't try to do anything with the session.

This caused https://github.com/Metaswitch/freeDiameter/issues/21 (although we no longer hit that issue, normally, as we've stopped SAS logging Device-Watchdog-Requests and therefore stopped going through this code path).