### PR TITLE
[Reviewer: Rob] Fix for alarm crashes

### DIFF
--- a/include/alarm.h
+++ b/include/alarm.h
@@ -66,7 +66,7 @@ class AlarmReqAgent
 public:
   enum
   {
-    MAX_Q_DEPTH = 100
+    MAX_Q_DEPTH = 1000
   };
 
   /// Queue an alarm request to be forwarded to snmpd.

--- a/include/alarm.h
+++ b/include/alarm.h
@@ -69,14 +69,11 @@ public:
     MAX_Q_DEPTH = 100
   };
 
-  /// Initialize ZMQ context and start agent thread.
-  bool start();
-
-  /// Gracefully stop the agent thread and remove ZMQ context.
-  void stop();
-
   /// Queue an alarm request to be forwarded to snmpd.
   void alarm_request(std::vector<std::string> req);
+
+  // The AlarmManager is the only class allowed to create the AlarmReqAgent
+  friend class AlarmManager;
 
 private:
   AlarmReqAgent();
@@ -207,6 +204,9 @@ public:
   // Tell the Alarm Manager about an alarm
   void register_alarm(BaseAlarm* alarm); 
 
+  // The AlarmManager is the only class allowed to create the AlarmReRaiser
+  friend class AlarmManager;
+
 private:
   AlarmReRaiser();
   ~AlarmReRaiser();
@@ -254,16 +254,8 @@ public:
     delete _alarm_req_agent; _alarm_req_agent = NULL;
   }
 
-  bool start() { return _alarm_req_agent->start(); }
-  void stop() { _alarm_req_agent->stop(); }
-
   AlarmReqAgent* alarm_req_agent() { return _alarm_req_agent; }
   AlarmReRaiser* alarm_re_raiser() { return _alarm_re_raiser; }
-
-  // The AlarmManager is the only class allowed to create the AlarmReqAgent
-  // and the AlarmReRaiser
-  friend class AlarmReqAgent;
-  friend class AlarmReRaiser;
 
 private:
   AlarmReqAgent* _alarm_req_agent;

--- a/include/alarm.h
+++ b/include/alarm.h
@@ -47,6 +47,68 @@
 #include "alarmdefinition.h"
 #include "eventq.h"
 
+#ifdef UNIT_TEST
+#include "pthread_cond_var_helper.h"
+#else
+#include "cond_var.h"
+#endif
+
+class AlarmManager;
+
+/// @class AlarmReqAgent
+///
+/// Class which provides an agent thead to accept queued alarm requests from
+/// clients and forward them via ZMQ to snmpd (which will actually generate the
+/// inform message(s)).
+
+class AlarmReqAgent
+{
+public:
+  AlarmReqAgent();
+  ~AlarmReqAgent();
+
+  enum
+  {
+    MAX_Q_DEPTH = 100
+  };
+
+  /// Initialize ZMQ context and start agent thread.
+  bool start();
+
+  /// Gracefully stop the agent thread and remove ZMQ context.
+  void stop();
+
+  /// Queue an alarm request to be forwarded to snmpd.
+  void alarm_request(std::vector<std::string> req);
+
+private:
+  enum
+  {
+    ZMQ_PORT = 6664,
+    MAX_REPLY_LEN = 16
+  };
+
+  static void* agent_thread(void* alarm_req_agent);
+
+  bool zmq_init_ctx();
+  bool zmq_init_sck();
+
+  void zmq_clean_ctx();
+  void zmq_clean_sck();
+
+  void agent();
+
+  pthread_t _thread;
+
+  pthread_mutex_t _start_mutex;
+  pthread_cond_t  _start_cond;
+
+  void* _ctx;
+  void* _sck;
+
+  eventq<std::vector<std::string> >* _req_q;
+};
+
 /// @class AlarmState
 ///
 /// Provides the basic interface for updating an SNMP alarm's state.
@@ -54,7 +116,8 @@
 class AlarmState
 {
 public:
-  AlarmState(const std::string& issuer,
+  AlarmState(AlarmReqAgent* alarm_req_agent,
+             const std::string& issuer,
              const int index,
              AlarmDef::Severity severity);
 
@@ -80,8 +143,8 @@ public:
     ALARMED
   };
 
-
 private:
+  AlarmReqAgent* _alarm_req_agent;
   std::string _issuer;
   std::string _identifier;
 };
@@ -113,7 +176,8 @@ public:
   void switch_to_state(AlarmState* new_state);
 
 protected:
-  BaseAlarm(const std::string& issuer,
+  BaseAlarm(AlarmManager* alarm_manager,
+            const std::string& issuer,
             const int index);
 
   const int _index;
@@ -125,35 +189,22 @@ protected:
   AlarmState* _last_state_raised;
 };
 
-/// @class AlarmManager
+/// @class AlarmReRaiser
 ///
-/// Singleton class responsible for calling BaseAlarm's reraise_latest_state
+/// Class responsible for calling BaseAlarm's reraise_latest_state
 /// function on each alarm every thirty seconds.
-
-class AlarmManager
+class AlarmReRaiser
 {
 public:
-  // Public so std::unique_ptr can destroy us at end of day.
-  ~AlarmManager();
+  AlarmReRaiser();
+  ~AlarmReRaiser();
 
-  static AlarmManager& get_instance();
-  bool _terminated;
+  // Tell the Alarm Manager about an alarm
   void register_alarm(BaseAlarm* alarm); 
-  // Used to stop re-raising alarms in UTs
-  void forget_alarm_list(void) {pthread_mutex_lock(&_lock); _alarm_list.clear(); pthread_mutex_unlock(&_lock); }
-  void start_resending_alarms(void) { _first_alarm_raised = true; }
-  void stop_resending_alarms(void) { _first_alarm_raised = false; }
 
 private:
-  // Private since this is a singleton
-  AlarmManager();
+  bool _terminated;
 
-  // Called once (using pthread_once) to create the AlarmManager.
-  static void create_singleton();
-  static std::unique_ptr<AlarmManager> _instance;
-  static pthread_once_t alarm_manager_singleton_once;
-
-  bool _first_alarm_raised;
   // Static function called by the reraising alarms thread. This simply calls
   // the 'reraise_alarms' member method
   static void* reraise_alarms_function(void* data);
@@ -161,14 +212,49 @@ private:
   // This runs on a thread (defined below) and iterates over _alarm_list
   // every 30 seconds. For each alarm it calls the reraise_last_state method.
   void reraise_alarms();
+
   // This is used for storing all of the BaseAlarm objects as they get
   // registered.
   std::vector<BaseAlarm*> _alarm_list;
+
   // Defines a lock and condition variable to protect the reraising alarms
   // thread.
   pthread_mutex_t _lock;
-  pthread_cond_t _condition;
+#ifdef UNIT_TEST
+  MockPThreadCondVar* _condition;
+#else
+  CondVar* _condition;
+#endif
   pthread_t _reraising_alarms_thread;
+};
+
+/// @class AlarmManager
+///
+/// Class responsible for calling BaseAlarm's reraise_latest_state
+/// function on each alarm every thirty seconds.
+class AlarmManager
+{
+public:
+  AlarmManager() :
+    _alarm_req_agent(new AlarmReqAgent()),
+    _alarm_re_raiser(new AlarmReRaiser())
+  {}
+
+  ~AlarmManager()
+  {
+    delete _alarm_re_raiser; _alarm_re_raiser = NULL;
+    delete _alarm_req_agent; _alarm_req_agent = NULL;
+  }
+
+  bool start() { return _alarm_req_agent->start(); }
+  void stop() { _alarm_req_agent->stop(); }
+
+  AlarmReqAgent* alarm_req_agent() { return _alarm_req_agent; }
+  AlarmReRaiser* alarm_re_raiser() { return _alarm_re_raiser; }
+
+private:
+  AlarmReqAgent* _alarm_req_agent;
+  AlarmReRaiser* _alarm_re_raiser;
 };
 
 /// @class Alarm
@@ -180,7 +266,8 @@ private:
 class Alarm: public BaseAlarm
 {
 public:
-  Alarm(const std::string& issuer,
+  Alarm(AlarmManager* alarm_manager,
+        const std::string& issuer,
         const int index,
         AlarmDef::Severity severity);
 
@@ -210,7 +297,8 @@ private:
 class MultiStateAlarm: public BaseAlarm
 {
 public:
-  MultiStateAlarm(const std::string& issuer,
+  MultiStateAlarm(AlarmManager* alarm_manager,
+                  const std::string& issuer,
                   const int index);
 
   virtual ~MultiStateAlarm() {}
@@ -229,63 +317,6 @@ private:
   AlarmState _minor_state;
   AlarmState _major_state;
   AlarmState _critical_state;
-};
-
-/// @class AlarmReqAgent
-///
-/// Singleton which provides an agent thead to accept queued alarm requests from
-/// clients and forward them via ZMQ to snmpd (which will actually generate the
-/// inform message(s)).
-
-class AlarmReqAgent
-{
-public:
-  enum
-  {
-    MAX_Q_DEPTH = 100
-  };
-
-  /// Initialize ZMQ context and start agent thread.
-  bool start();
-
-  /// Gracefully stop the agent thread and remove ZMQ context.
-  void stop();
-
-  /// Queue an alarm request to be forwarded to snmpd.
-  void alarm_request(std::vector<std::string> req);
-
-  static AlarmReqAgent& get_instance() {return _instance;}
-
-private:
-  enum
-  {
-    ZMQ_PORT = 6664,
-    MAX_REPLY_LEN = 16
-  };
-
-  static void* agent_thread(void* alarm_req_agent);
-
-  AlarmReqAgent();
-
-  bool zmq_init_ctx();
-  bool zmq_init_sck();
-
-  void zmq_clean_ctx();
-  void zmq_clean_sck();
-
-  void agent();
-
-  pthread_t _thread;
-
-  pthread_mutex_t _start_mutex;
-  pthread_cond_t  _start_cond;
-
-  void* _ctx;
-  void* _sck;
-
-  eventq<std::vector<std::string> >* _req_q;
-
-  static AlarmReqAgent _instance;
 };
 
 #endif

--- a/test_utils/mockalarm.h
+++ b/test_utils/mockalarm.h
@@ -43,7 +43,7 @@
 class MockAlarm : public Alarm
 {
 public:
-  MockAlarm(AlarmManager* alarm_manager) : 
+  MockAlarm(AlarmManager* alarm_manager) :
     Alarm(alarm_manager, "sprout", 0, AlarmDef::CRITICAL) {}
 
   MOCK_METHOD0(clear, void());

--- a/test_utils/mockalarm.h
+++ b/test_utils/mockalarm.h
@@ -43,8 +43,8 @@
 class MockAlarm : public Alarm
 {
 public:
-  MockAlarm() : 
-    Alarm("sprout", 0, AlarmDef::CRITICAL) {}
+  MockAlarm(AlarmManager* alarm_manager) : 
+    Alarm(alarm_manager, "sprout", 0, AlarmDef::CRITICAL) {}
 
   MOCK_METHOD0(clear, void());
   MOCK_METHOD0(set, void());
@@ -54,8 +54,8 @@ public:
 class MockMultiStateAlarm : public MultiStateAlarm
 {
 public:
-  MockMultiStateAlarm() :
-    MultiStateAlarm("sprout", 0) {}
+  MockMultiStateAlarm(AlarmManager* alarm_manager) :
+    MultiStateAlarm(alarm_manager, "sprout", 0) {}
 
   MOCK_METHOD0(set_indeterminate, void());
   MOCK_METHOD0(set_warning, void());

--- a/test_utils/mockcommunicationmonitor.h
+++ b/test_utils/mockcommunicationmonitor.h
@@ -43,7 +43,7 @@
 class MockCommunicationMonitor : public CommunicationMonitor
 {
 public:
-  MockCommunicationMonitor(AlarmManager* alarm_manager) : 
+  MockCommunicationMonitor(AlarmManager* alarm_manager) :
     CommunicationMonitor(new Alarm(alarm_manager, "sprout", 0, AlarmDef::CRITICAL), "sprout", "chronos") {}
 
   MOCK_METHOD1(inform_success, void(unsigned long now_ms));

--- a/test_utils/mockcommunicationmonitor.h
+++ b/test_utils/mockcommunicationmonitor.h
@@ -43,8 +43,8 @@
 class MockCommunicationMonitor : public CommunicationMonitor
 {
 public:
-  MockCommunicationMonitor() : 
-    CommunicationMonitor(new Alarm("sprout", 0, AlarmDef::CRITICAL), "sprout", "chronos") {}
+  MockCommunicationMonitor(AlarmManager* alarm_manager) : 
+    CommunicationMonitor(new Alarm(alarm_manager, "sprout", 0, AlarmDef::CRITICAL), "sprout", "chronos") {}
 
   MOCK_METHOD1(inform_success, void(unsigned long now_ms));
   MOCK_METHOD1(inform_failure, void(unsigned long now_ms));


### PR DESCRIPTION
Rob, can you please review this change to the alarm classes.

This PR covers:
* Renaming the AlarmManager to the AlarmReRaiser
* Stopping the AlarmReqAgent and AlarmReRaiser from being singletons
* Adding a new AlarmManager that's responsible for the AlarmReqAgent and the AlarmManager (i.e. making sure they're created/deleted safely).
* Simplifying the re raising alarm function

This PR doesn't cover any change to the AlarmReqAgent/AlarmReRaiser (beyond simplifying the reraise function)

Fixes #521
