### PR TITLE
[Reviewer: Graeme] Add unregister_alarm call in alarm destructor

### DIFF
--- a/include/alarm.h
+++ b/include/alarm.h
@@ -192,6 +192,9 @@ protected:
   // alarm has just been cleared this would be the corresponding _clear_state
   // for the alarm.
   AlarmState* _last_state_raised;
+
+  // The manager this alarm is registered with.
+  AlarmManager* _alarm_manager;
 };
 
 /// @class AlarmReRaiser
@@ -203,6 +206,9 @@ class AlarmReRaiser
 public:
   // Tell the Alarm Manager about an alarm
   void register_alarm(BaseAlarm* alarm); 
+
+  // Tell the AlarmManager an alarm has been deleted
+  void unregister_alarm(BaseAlarm* alarm);
 
   // The AlarmManager is the only class allowed to create the AlarmReRaiser
   friend class AlarmManager;

--- a/include/alarm.h
+++ b/include/alarm.h
@@ -204,7 +204,8 @@ protected:
 class AlarmReRaiser
 {
 public:
-  // Tell the Alarm Manager about an alarm
+  // Tell the AlarmManager about an alarm. While this alarm is registered (i.e.
+  // until unregister_alarm is called), the AlarmManager must not be deleted.
   void register_alarm(BaseAlarm* alarm); 
 
   // Tell the AlarmManager an alarm has been deleted

--- a/src/alarm.cpp
+++ b/src/alarm.cpp
@@ -70,7 +70,8 @@ BaseAlarm::BaseAlarm(AlarmManager* alarm_manager,
                issuer,
                index,
                AlarmDef::CLEARED),
-  _last_state_raised(NULL)
+  _last_state_raised(NULL),
+  _alarm_manager(alarm_manager)
 {
   pthread_mutex_init(&_issue_alarm_change_state, NULL);
   alarm_manager->alarm_re_raiser()->register_alarm(this);
@@ -78,6 +79,7 @@ BaseAlarm::BaseAlarm(AlarmManager* alarm_manager,
 
 BaseAlarm::~BaseAlarm()
 {
+  _alarm_manager->alarm_re_raiser()->unregister_alarm(this);
   pthread_mutex_destroy(&_issue_alarm_change_state);
 }
 
@@ -210,6 +212,17 @@ void AlarmReRaiser::register_alarm(BaseAlarm* alarm)
 {
   pthread_mutex_lock(&_lock);
   _alarm_list.push_back(alarm);
+  pthread_mutex_unlock(&_lock);
+}
+
+void AlarmReRaiser::unregister_alarm(BaseAlarm* alarm)
+{
+  pthread_mutex_lock(&_lock);
+  std::vector<BaseAlarm*>::iterator it = std::find(_alarm_list.begin(), _alarm_list.end(), alarm);
+  if (it != _alarm_list.end())
+  {
+    _alarm_list.erase(it);
+  }
   pthread_mutex_unlock(&_lock);
 }
 


### PR DESCRIPTION
I think the crash you hit when we tried a version of this code last week might have been due to not saving off the `alarm_manager` constructor argument - that seems like a possible thing not to do, and if I comment out that line, I also hit a crash at the same point.