### PR TITLE
[Reviewer: Matt W] Allow daemons to provide path for stdout/stderr

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -487,8 +487,12 @@ namespace Utils
   uint64_t get_time(clockid_t clock = CLOCK_MONOTONIC);
 
   // Daemonize the current process, detaching it from the parent and redirecting
-  // file descriptors.
+  // file descriptors, with stdout and stderr going to /dev/null.
   int daemonize();
+
+  // Daemonize the current process, detaching it from the parent and redirecting
+  // file descriptors.
+  int daemonize(std::string out, std::string err);
 } // namespace Utils
 
 #endif /* UTILS_H_ */

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -486,6 +486,11 @@ uint64_t Utils::get_time(clockid_t clock)
 
 int Utils::daemonize()
 {
+  return daemonize("/dev/null", "/dev/null");
+}
+
+int Utils::daemonize(std::string out, std::string err)
+{
   TRC_STATUS("Switching to daemon mode");
 
   // First fork
@@ -505,11 +510,11 @@ int Utils::daemonize()
   {
     return errno;
   }
-  if (freopen("/dev/null", "w", stdout) == NULL)
+  if (freopen(out.c_str(), "a", stdout) == NULL)
   {
     return errno;
   }
-  if (freopen("/dev/null", "w", stderr) == NULL)
+  if (freopen(err.c_str(), "a", stderr) == NULL)
   {
     return errno;
   }


### PR DESCRIPTION
Small change to allow daemons to specify the path for stdout and stderr to be used when the daemon process is forked. Also change to append to these files instead of just blasting away the contents.

This is the first half of a fix to Metaswitch/sprout#965.