### PR TITLE
[Reviewer: Alex] Reference count rows of the IP time counter table

### DIFF
--- a/include/snmp_ip_time_based_counter_table.h
+++ b/include/snmp_ip_time_based_counter_table.h
@@ -53,15 +53,20 @@ public:
   /// @return     - The table instance.
   static IPTimeBasedCounterTable* create(std::string name, std::string oid);
 
-  /// Add rows to the table for the specified IP address. This is a no-op if
-  /// the IP is already known to the table.
+  /// Add rows to the table for the specified IP address. If this IP already
+  /// exists in the table, an additional reference count will be added for
+  /// it.
+  ///
+  /// Calls to add_ip and remove_ip should be balanced.
   ///
   /// @param ip - The IP address to add. Must be a valid IPv4 or IPv6 IP
   ///             address.
   virtual void add_ip(const std::string& ip) = 0;
 
-  /// Removes rows for the specified IP address from the table. This is a no-op
-  /// if the IP address is not known to the table.
+  /// Removes rows for the specified IP address from the table. If this IP has
+  /// been added multiple times, this just removes one from the reference count.
+  ///
+  /// Calls to add_ip and remove_ip should be balanced.
   ///
   /// @param ip - The IP address to remove. Must be a valid IPv4 or IPv6 IP
   ///             address.
@@ -71,7 +76,7 @@ public:
   /// previously added to the table by calling `add_ip`. If it has not, the
   /// increment is ignored.
   ///
-  /// @param ip - The IP address t
+  /// @param ip - The IP address to increment the stat for.
   virtual void increment(const std::string& ip) = 0;
 
 protected:

--- a/src/snmp_ip_time_based_counter_table.cpp
+++ b/src/snmp_ip_time_based_counter_table.cpp
@@ -110,12 +110,12 @@ public:
     ManagedTable<IPTimeBasedCounterRow, IPTimeBasedCounterIndex>(
       name, tbl_oid, 4, 4, { ASN_INTEGER, ASN_OCTET_STR, ASN_INTEGER })
   {
-    pthread_rwlock_init(&_counters_lock, NULL);
+    pthread_rwlock_init(&_table_lock, NULL);
   }
 
   ~IPTimeBasedCounterTableImpl()
   {
-    pthread_rwlock_destroy(&_counters_lock);
+    pthread_rwlock_destroy(&_table_lock);
 
     for(std::map<std::string, IPEntry*>::iterator it = _counters_by_ip.begin();
         it != _counters_by_ip.end();
@@ -129,7 +129,7 @@ public:
   {
     // Add an IP address. We might be about to mutate the counter map, so grab
     // the write lock.
-    pthread_rwlock_wrlock(&_counters_lock);
+    pthread_rwlock_wrlock(&_table_lock);
 
     std::map<std::string, uint32_t>::iterator ref_entry = _ref_count_by_ip.find(ip);
 
@@ -161,14 +161,14 @@ public:
       ref_entry->second++;
     }
 
-    pthread_rwlock_unlock(&_counters_lock);
+    pthread_rwlock_unlock(&_table_lock);
   }
 
   void remove_ip(const std::string& ip)
   {
     // Remove an IP address. We might be about to mutate the counter map, so
     // grab the write lock.
-    pthread_rwlock_wrlock(&_counters_lock);
+    pthread_rwlock_wrlock(&_table_lock);
 
     std::map<std::string, uint32_t>::iterator ref_entry = _ref_count_by_ip.find(ip);
 
@@ -185,8 +185,8 @@ public:
       // counts table.
       if (ref_entry->second == 0)
       {
-
         std::map<std::string, IPEntry*>::iterator entry = _counters_by_ip.find(ip);
+
         if (entry != _counters_by_ip.end())
         {
           // IP address already exists - remove the entry from the counts map and
@@ -207,7 +207,7 @@ public:
       }
     }
 
-    pthread_rwlock_unlock(&_counters_lock);
+    pthread_rwlock_unlock(&_table_lock);
   }
 
   void increment(const std::string& ip)
@@ -215,7 +215,7 @@ public:
     // Increment the count for the specified IP. This cannot mutate the counts
     // map (only the counts stored within it, which are atomic), so we only need
     // the read lock.
-    pthread_rwlock_rdlock(&_counters_lock);
+    pthread_rwlock_rdlock(&_table_lock);
 
     std::map<std::string, IPEntry*>::iterator entry = _counters_by_ip.find(ip);
     if (entry != _counters_by_ip.end())
@@ -225,7 +225,7 @@ public:
       entry->second->five_min.get_current()->counter++;
     }
 
-    pthread_rwlock_unlock(&_counters_lock);
+    pthread_rwlock_unlock(&_table_lock);
   }
 
   uint32_t get_count(const std::string& ip, TimePeriodIndexes time_period)
@@ -236,7 +236,7 @@ public:
 
     // Reading a count cannot mutate the counts map (only the counts stored
     // within it which are atomic), so we only need the read lock.
-    pthread_rwlock_rdlock(&_counters_lock);
+    pthread_rwlock_rdlock(&_table_lock);
 
     std::map<std::string, IPEntry*>::iterator entry = _counters_by_ip.find(ip);
     if (entry != _counters_by_ip.end())
@@ -264,7 +264,7 @@ public:
       }
     }
 
-    pthread_rwlock_unlock(&_counters_lock);
+    pthread_rwlock_unlock(&_table_lock);
 
     TRC_DEBUG("Counter is %d", count);
     return count;
@@ -318,13 +318,14 @@ private:
   };
 
   // A container of counts indexed by IP address. This can be accessed on
-  // multiple threads so is protected by a lock.
+  // multiple threads, and so is protected by _table_lock.
   std::map<std::string, IPEntry*> _counters_by_ip;
-  pthread_rwlock_t _counters_lock;
 
   // A reference count for each IP address, keeping track of how many times
-  // it's been added and removed. This is protected by _counters_lock
+  // it's been added and removed. This is protected by _table_lock.
   std::map<std::string, uint32_t> _ref_count_by_ip;
+
+  pthread_rwlock_t _table_lock;
 };
 
 


### PR DESCRIPTION
Instead of ignoring add methods that occur when a row already exists,
keep track of them, and only remove a row when the same number have
occurred.

I've got an additional FV test in https://github.com/Metaswitch/clearwater-fv-test/pull/48