### PR TITLE
[Reviewer: Ellie] Adds support for enterprise alarms MIB

### DIFF
--- a/include/alarmdefinition.h
+++ b/include/alarmdefinition.h
@@ -141,7 +141,6 @@ namespace AlarmDef {
     int _index;
     Cause _cause;
     std::vector<SeverityDetails> _severity_details;
-    int _resource_ID;
   };
 
   Cause cause_to_enum(std::string cause);

--- a/include/alarmdefinition.h
+++ b/include/alarmdefinition.h
@@ -103,13 +103,17 @@ namespace AlarmDef {
                     std::string details,
                     std::string cause,
                     std::string effect,
-                    std::string action):
+                    std::string action,
+                    std::string extended_details,
+                    std::string extended_description):
       _severity(severity),
       _description(description),
       _details(details),
       _cause(cause),
       _effect(effect),
-      _action(action) {};
+      _action(action),
+      _extended_details(extended_details),
+      _extended_description(extended_description) {};
 
     Severity _severity;
     std::string _description;
@@ -117,19 +121,27 @@ namespace AlarmDef {
     std::string _cause;
     std::string _effect;
     std::string _action;
+    std::string _extended_details;
+    std::string _extended_description;
   };
 
   struct AlarmDefinition {
     AlarmDefinition() {};
 
-    AlarmDefinition(int index, Cause cause, std::vector<SeverityDetails> severity_details):
+    AlarmDefinition(std::string name,
+                    int index,
+                    Cause cause,
+                    std::vector<SeverityDetails> severity_details):
+      _name(name),
       _index(index),
       _cause(cause),
-      _severity_details(severity_details){};
+      _severity_details(severity_details) {};
 
+    std::string _name;
     int _index;
     Cause _cause;
     std::vector<SeverityDetails> _severity_details;
+    int _resource_ID;
   };
 
   Cause cause_to_enum(std::string cause);

--- a/include/json_alarms.h
+++ b/include/json_alarms.h
@@ -75,9 +75,13 @@ namespace JSONAlarms
                                  std::string& error,
                                  std::vector<AlarmDef::AlarmDefinition>& alarms);
 
+  // Processes the name of an alarm into a human readable format, for example
+  // "SPROUT_PROCESS_FAILURE" becomes "Sprout process failure"
   std::string process_alarm_name(std::string raw_name);
 
-  std::string prepare_error_message(std::string field, int max_length, int index);
+  // Prepares a string that can be used to report the error that a specific
+  // field has exceeded the character limit
+  std::string exceeded_character_limit_error(std::string field, int max_length, int index);
 
   // Writes a header file that includes the alarm IDs and their index
   void write_header_file(std::string name, std::map<std::string, int> alarms);

--- a/include/json_alarms.h
+++ b/include/json_alarms.h
@@ -77,6 +77,8 @@ namespace JSONAlarms
 
   std::string process_alarm_name(std::string raw_name);
 
+  std::string prepare_error_message(std::string field, int max_length, int index);
+
   // Writes a header file that includes the alarm IDs and their index
   void write_header_file(std::string name, std::map<std::string, int> alarms);
 };

--- a/include/json_alarms.h
+++ b/include/json_alarms.h
@@ -75,6 +75,8 @@ namespace JSONAlarms
                                  std::string& error,
                                  std::vector<AlarmDef::AlarmDefinition>& alarms);
 
+  std::string process_alarm_name(std::string raw_name);
+
   // Writes a header file that includes the alarm IDs and their index
   void write_header_file(std::string name, std::map<std::string, int> alarms);
 };

--- a/src/json_alarms.cpp
+++ b/src/json_alarms.cpp
@@ -180,9 +180,9 @@ namespace JSONAlarms
 
           // We check if any extended details have been included in each
           // alarms's JSON file.
-          if (alarms_def_it->HasMember("extended details"))
+          if (alarms_def_it->HasMember("extended_details"))
           {
-            JSON_GET_STRING_MEMBER(*alarms_def_it, "extended details", extended_details);
+            JSON_GET_STRING_MEMBER(*alarms_def_it, "extended_details", extended_details);
             if (extended_details.length() > 4096)
             {
               char error_text[100];
@@ -207,11 +207,11 @@ namespace JSONAlarms
             return false;
           }
           
-          // We check if a extended description have been included in each
+          // We check if an extended description have been included in each
           // alarms's JSON file.
-          if (alarms_def_it->HasMember("extended description"))
+          if (alarms_def_it->HasMember("extended_description"))
           {
-            JSON_GET_STRING_MEMBER(*alarms_def_it, "extended description", extended_description);
+            JSON_GET_STRING_MEMBER(*alarms_def_it, "extended_description", extended_description);
             if (extended_description.length() > 4096)
             {
               char error_text[100];

--- a/src/json_alarms.cpp
+++ b/src/json_alarms.cpp
@@ -36,7 +36,6 @@
 
 #include "json_alarms.h"
 #include <algorithm>
-#include <string>
 
 namespace JSONAlarms
 {
@@ -108,7 +107,7 @@ namespace JSONAlarms
       {
         int index;
         std::string cause;
-        std::string raw_name;
+        std::string name;
 
         JSON_GET_INT_MEMBER(*alarms_it, "index", index);
         JSON_GET_STRING_MEMBER(*alarms_it, "cause", cause);
@@ -121,8 +120,8 @@ namespace JSONAlarms
           return false;
         }
 
-        JSON_GET_STRING_MEMBER(*alarms_it, "name", raw_name);
-        header[raw_name] = index;
+        JSON_GET_STRING_MEMBER(*alarms_it, "name", name);
+        header[name] = index;
 
         JSON_ASSERT_CONTAINS(*alarms_it, "levels");
         JSON_ASSERT_ARRAY((*alarms_it)["levels"]);
@@ -281,13 +280,7 @@ namespace JSONAlarms
         }
         else 
         {
-          // Process the raw_name of each alarm (e.g. SPROUT_PROCESS_FAILURE)
-          // into a readable name (e.g. Sprout process failure) and use this in
-          // the AlarmDefinition
-          std::string name = raw_name;
-          std::replace(name.begin(), name.end(), '_', ' ');
-          std::transform(name.begin(), name.end(), name.begin(), ::tolower);
-          name[0] = toupper(name[0]);
+          // Here we use the human readable form of the alarm's name
           AlarmDef::AlarmDefinition ad = {name,
                                           index,
                                           e_cause,
@@ -305,6 +298,17 @@ namespace JSONAlarms
     }
 
     return true;
+  }
+
+  // Function to transform the name of each alarm from e.g.
+  // "SPROUT_PROCESS_FAILURE" to a human readable format e.g. "Sprout process
+  // failure"
+  std::string process_alarm_name(std::string raw_name)
+  {
+    std::replace(raw_name.begin(), raw_name.end(), '_', ' ');
+    std::transform(raw_name.begin(), raw_name.end(), raw_name.begin(), ::tolower);
+    raw_name[0] = toupper(raw_name[0]);
+    return raw_name;
   }
 
   // LCOV_EXCL_START - This function isn't tested in UTs

--- a/src/json_alarms.cpp
+++ b/src/json_alarms.cpp
@@ -180,9 +180,9 @@ namespace JSONAlarms
 
           // We check if any extended details have been included in each
           // alarms's JSON file.
-          if (alarms_def_it->HasMember("extended_details"))
+          if (alarms_def_it->HasMember("extended details"))
           {
-            JSON_GET_STRING_MEMBER(*alarms_def_it, "extended_details", extended_details);
+            JSON_GET_STRING_MEMBER(*alarms_def_it, "extended details", extended_details);
             if (extended_details.length() > 4096)
             {
               char error_text[100];
@@ -209,9 +209,9 @@ namespace JSONAlarms
           
           // We check if a extended description have been included in each
           // alarms's JSON file.
-          if (alarms_def_it->HasMember("extended_description"))
+          if (alarms_def_it->HasMember("extended description"))
           {
-            JSON_GET_STRING_MEMBER(*alarms_def_it, "extended_description", extended_description);
+            JSON_GET_STRING_MEMBER(*alarms_def_it, "extended description", extended_description);
             if (extended_description.length() > 4096)
             {
               char error_text[100];

--- a/src/json_alarms.cpp
+++ b/src/json_alarms.cpp
@@ -235,7 +235,7 @@ namespace JSONAlarms
           JSON_GET_STRING_MEMBER(*alarms_def_it, "action", action);
           if (action.length() > 4096)
           {
-            error = prepare_error_message("action", 4096, action);
+            error = prepare_error_message("action", 4096, index);
             return false;
           }
 
@@ -294,7 +294,7 @@ namespace JSONAlarms
     std::replace(name.begin(), name.end(), '_', ' ');
     std::transform(name.begin(), name.end(), name.begin(), ::tolower);
     name[0] = toupper(name[0]);
-    return raw_name;
+    return name;
   }
 
   std::string prepare_error_message(std::string field, int max_length, int index)

--- a/src/json_alarms.cpp
+++ b/src/json_alarms.cpp
@@ -171,7 +171,7 @@ namespace JSONAlarms
           JSON_GET_STRING_MEMBER(*alarms_def_it, "details", details);
           if (details.length() > 255)
           {
-            error = prepare_error_message("details", 255, index);
+            error = exceeded_character_limit_error("details", 255, index);
             return false;
           }
 
@@ -182,7 +182,7 @@ namespace JSONAlarms
             JSON_GET_STRING_MEMBER(*alarms_def_it, "extended_details", extended_details);
             if (extended_details.length() > 4096)
             {
-              error = prepare_error_message("extended_details", 4096, index);
+              error = exceeded_character_limit_error("extended_details", 4096, index);
               return false;
             }
           }
@@ -196,18 +196,18 @@ namespace JSONAlarms
           JSON_GET_STRING_MEMBER(*alarms_def_it, "description", description);
           if (description.length() > 255)
           {
-            error = prepare_error_message("description", 255, index);
+            error = exceeded_character_limit_error("description", 255, index);
             return false;
           }
           
-          // We check if an extended description have been included in each
+          // We check if an extended description has been included in each
           // alarms's JSON file.
           if (alarms_def_it->HasMember("extended_description"))
           {
             JSON_GET_STRING_MEMBER(*alarms_def_it, "extended_description", extended_description);
             if (extended_description.length() > 4096)
             {
-              error = prepare_error_message("extended_description", 4096, index);
+              error = exceeded_character_limit_error("extended_description", 4096, index);
               return false;
             }
           }
@@ -221,21 +221,21 @@ namespace JSONAlarms
           JSON_GET_STRING_MEMBER(*alarms_def_it, "cause", detailed_cause);
           if (detailed_cause.length() > 4096)
           {
-            error = prepare_error_message("cause", 4096, index);
+            error = exceeded_character_limit_error("cause", 4096, index);
             return false;
           }
 
           JSON_GET_STRING_MEMBER(*alarms_def_it, "effect", effect);
           if (effect.length() > 4096)
           {
-            error = prepare_error_message("effect", 4096, index);
+            error = exceeded_character_limit_error("effect", 4096, index);
             return false;
           }
 
           JSON_GET_STRING_MEMBER(*alarms_def_it, "action", action);
           if (action.length() > 4096)
           {
-            error = prepare_error_message("action", 4096, index);
+            error = exceeded_character_limit_error("action", 4096, index);
             return false;
           }
 
@@ -297,7 +297,7 @@ namespace JSONAlarms
     return name;
   }
 
-  std::string prepare_error_message(std::string field, int max_length, int index)
+  std::string exceeded_character_limit_error(std::string field, int max_length, int index)
   {
     char error_text[100];
     sprintf(error_text, "alarm %d: '%s' exceeds %d char limit", index, field.c_str(), max_length);

--- a/src/json_alarms.cpp
+++ b/src/json_alarms.cpp
@@ -171,9 +171,7 @@ namespace JSONAlarms
           JSON_GET_STRING_MEMBER(*alarms_def_it, "details", details);
           if (details.length() > 255)
           {
-            char error_text[100];
-            sprintf(error_text, "alarm %d: 'details' exceeds %d char limit", index, 255);
-            error = std::string(error_text);
+            error = prepare_error_message("details", 255, index);
             return false;
           }
 
@@ -184,9 +182,7 @@ namespace JSONAlarms
             JSON_GET_STRING_MEMBER(*alarms_def_it, "extended_details", extended_details);
             if (extended_details.length() > 4096)
             {
-              char error_text[100];
-              sprintf(error_text, "alarm %d: 'extended details' exceeds %d char limit", index, 4096);
-              error = std::string(error_text);
+              error = prepare_error_message("extended_details", 4096, index);
               return false;
             }
           }
@@ -200,9 +196,7 @@ namespace JSONAlarms
           JSON_GET_STRING_MEMBER(*alarms_def_it, "description", description);
           if (description.length() > 255)
           {
-            char error_text[100];
-            sprintf(error_text, "alarm %d: 'description' exceeds %d char limit", index, 255);
-            error = std::string(error_text);
+            error = prepare_error_message("description", 255, index);
             return false;
           }
           
@@ -213,9 +207,7 @@ namespace JSONAlarms
             JSON_GET_STRING_MEMBER(*alarms_def_it, "extended_description", extended_description);
             if (extended_description.length() > 4096)
             {
-              char error_text[100];
-              sprintf(error_text, "alarm %d: 'extended description' exceeds %d char limit", index, 4096);
-              error = std::string(error_text);
+              error = prepare_error_message("extended_description", 4096, index);
               return false;
             }
           }
@@ -229,27 +221,21 @@ namespace JSONAlarms
           JSON_GET_STRING_MEMBER(*alarms_def_it, "cause", detailed_cause);
           if (detailed_cause.length() > 4096)
           {
-            char error_text[100];
-            sprintf(error_text, "alarm %d: 'cause' exceeds %d char limit", index, 4096);
-            error = std::string(error_text);
+            error = prepare_error_message("cause", 4096, index);
             return false;
           }
 
           JSON_GET_STRING_MEMBER(*alarms_def_it, "effect", effect);
           if (effect.length() > 4096)
           {
-            char error_text[100];
-            sprintf(error_text, "alarm %d: 'effect' exceeds %d char limit", index, 4096);
-            error = std::string(error_text);
+            error = prepare_error_message("effect", 4096, index);
             return false;
           }
 
           JSON_GET_STRING_MEMBER(*alarms_def_it, "action", action);
           if (action.length() > 4096)
           {
-            char error_text[100];
-            sprintf(error_text, "alarm %d: 'action' exceeds %d char limit", index, 4096);
-            error = std::string(error_text);
+            error = prepare_error_message("action", 4096, action);
             return false;
           }
 
@@ -281,7 +267,7 @@ namespace JSONAlarms
         else 
         {
           // Here we use the human readable form of the alarm's name
-          AlarmDef::AlarmDefinition ad = {name,
+          AlarmDef::AlarmDefinition ad = {process_alarm_name(name),
                                           index,
                                           e_cause,
                                           severity_vec};
@@ -303,12 +289,19 @@ namespace JSONAlarms
   // Function to transform the name of each alarm from e.g.
   // "SPROUT_PROCESS_FAILURE" to a human readable format e.g. "Sprout process
   // failure"
-  std::string process_alarm_name(std::string raw_name)
+  std::string process_alarm_name(std::string name)
   {
-    std::replace(raw_name.begin(), raw_name.end(), '_', ' ');
-    std::transform(raw_name.begin(), raw_name.end(), raw_name.begin(), ::tolower);
-    raw_name[0] = toupper(raw_name[0]);
+    std::replace(name.begin(), name.end(), '_', ' ');
+    std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+    name[0] = toupper(name[0]);
     return raw_name;
+  }
+
+  std::string prepare_error_message(std::string field, int max_length, int index)
+  {
+    char error_text[100];
+    sprintf(error_text, "alarm %d: '%s' exceeds %d char limit", index, field.c_str(), max_length);
+    return std::string(error_text);
   }
 
   // LCOV_EXCL_START - This function isn't tested in UTs


### PR DESCRIPTION
The big changes here include:

- Updating the JSON parser to read the new fields, do some validity checking on them and then assign them to the new member variables of the SeverityDetails and AlarmDefinition structs.
- Adding methods to the AlarmTableDef class to retrieve the new values in the above structs (that are part of the AlarmTableDef object) and tests these get parsed correctly by the JSON parser. https://github.com/Metaswitch/clearwater-snmp-handlers/pull/157
- Testing that the JSON parser rejects JSON fields that are too long. https://github.com/Metaswitch/cpp-common-test/pull/26
- Updating the Python JSON parser to test that the new enterprise MIB fields are under 4096 characters. https://github.com/Metaswitch/python-common/pull/64

Notes:

- The way I've done the alarm name processing (SPROUT_PROCESS_FAILURE -> Sprout process failure) means that the name of each alarm will start with a capital letter. This is good for most alarms but not for the etcd ones. My opinion is that it's not worth the hassle to change it.