### PR TITLE
[Reviewer: GDR] Experimental Result Codes must be scoped by vendor

### DIFF
--- a/include/diameterstack.h
+++ b/include/diameterstack.h
@@ -419,7 +419,7 @@ public:
     result = _result;
     return (result != 0);
   }
-  int32_t experimental_result_code() const;
+  bool experimental_result(int32_t& experimental_result_code, uint32_t& vendor_id) const;
   int32_t vendor_id() const;
   inline std::string impi() const
   {

--- a/src/diameterstack.cpp
+++ b/src/diameterstack.cpp
@@ -1359,23 +1359,28 @@ bool Message::get_u32_from_avp(const Dictionary::AVP& type, uint32_t& u32) const
   }
 }
 
-// Get the experimental result code from the EXPERIMENTAL_RESULT_CODE AVP
-// of a Diameter message if it is present. This AVP is inside the
+// Get the experimental result code and it's vendor from the
+// EXPERIMENTAL_RESULT_CODE AVP and VENDOR_ID AVP
+// of a Diameter message if it is present. These AVPs are inside the
 // EXPERIMENTAL_RESULT AVP.
-int32_t Message::experimental_result_code() const
+bool Message::experimental_result(int32_t& experimental_result_code, uint32_t& vendor_id) const
 {
-  int32_t experimental_result_code = 0;
+  bool found_experimental_result = false;
   AVP::iterator avps = begin(dict()->EXPERIMENTAL_RESULT);
   if (avps != end())
   {
-    AVP::iterator avps2 = avps->begin(dict()->EXPERIMENTAL_RESULT_CODE);
-    if (avps2 != avps->end())
+    AVP::iterator code = avps->begin(dict()->EXPERIMENTAL_RESULT_CODE);
+    AVP::iterator vendor = avps->begin(dict()->VENDOR_ID);
+    if (code != avps->end() && vendor != avps->end())
     {
-      experimental_result_code = avps2->val_i32();
-      TRC_DEBUG("Got Experimental-Result-Code %d", experimental_result_code);
+      experimental_result_code = code->val_i32();
+      vendor_id = vendor->val_u32();
+      found_experimental_result = true;
+      TRC_DEBUG("Got Experimental-Result-Code %d for Vendor %d",
+                experimental_result_code, vendor_id);
     }
   }
-  return experimental_result_code;
+  return found_experimental_result;
 }
 
 // Get the vendor ID from the VENDOR_ID AVP of a Diameter message if it


### PR DESCRIPTION
Graeme,

As discussed, the current experimental result API on a Diameter Message only returns the experimental result code, as opposed to also including the vendor ID.

As experimental result codes are scoped by vendor ID, we should also include the vendor ID in the response - a better name for 'Experimental Result' would be 'Vendor Specific Result' I think.

Note, that the vendor ID may differ between the VENDOR_SPECIFIC_APPLICATION_ID and the EXPERIMENTAL_RESULT AVPs - although I suspect that's in practice not very likely - so the existing call to vendor_id() is not appropriate here.

As such, I've changed cpp-common to have a experimental_result function which will provide the code and the vendor ID of the first Experimental Result found, returning true if found, and false otherwise. It will return false in the event of a malformed EXPERIMENTAL_RESULT - which is against spec.

This is part of a co-ordinate checkin with homestead which uses the new function.