### PR TITLE
Fix unit discrepancy

### DIFF
--- a/include/http_connection_pool.h
+++ b/include/http_connection_pool.h
@@ -69,7 +69,7 @@ static const long SINGLE_CONNECT_TIMEOUT_MS = 50;
 
 /// The length of time a connection can remain idle before it is removed from
 /// the pool
-static const double MAX_IDLE_TIME_MS = 60 * 1000.0;
+static const int MAX_IDLE_TIME_S = 60;
 
 class HttpConnectionPool : public ConnectionPool<CURL*>
 {

--- a/src/http_connection_pool.cpp
+++ b/src/http_connection_pool.cpp
@@ -40,7 +40,7 @@
 
 HttpConnectionPool::HttpConnectionPool(LoadMonitor* load_monitor,
                                        SNMP::IPCountTable* stat_table) :
-  ConnectionPool<CURL*>(MAX_IDLE_TIME_MS),
+  ConnectionPool<CURL*>(MAX_IDLE_TIME_S),
   _stat_table(stat_table)
 {
   _timeout_ms = calc_req_timeout_from_latency((load_monitor != NULL) ?


### PR DESCRIPTION
The maximum idle time for a HTTP connection in the connection pool is passed into the connection pool constructor in milliseconds, but the constructor expects it in seconds. This pull request fixes this, changing the maximum idle time to seconds.