### PR TITLE
Reviewer RKD: Allow cwtest_completely_control_time to set time to start of epoch

### DIFF
--- a/test_utils/test_interposer.cpp
+++ b/test_utils/test_interposer.cpp
@@ -144,7 +144,7 @@ void cwtest_reset_time()
   pthread_mutex_unlock(&time_lock);
 }
 
-void cwtest_completely_control_time()
+void cwtest_completely_control_time(bool start_of_epoch)
 {
   if (!real_clock_gettime)
   {
@@ -167,8 +167,17 @@ void cwtest_completely_control_time()
        ++i)
   {
     clockid_t clock_id = supported_clock_ids[i];
-    real_clock_gettime(clock_id, &ts);
-    abs_timespecs[clock_id] = ts;
+    if (start_of_epoch)
+    {
+      ts.tv_sec = 0;
+      ts.tv_nsec = 0;
+      abs_timespecs[clock_id] = ts;
+    }
+    else
+    {
+      real_clock_gettime(clock_id, &ts);
+      abs_timespecs[clock_id] = ts;
+    }
   }
 
   abs_time = real_time(NULL);

--- a/test_utils/test_interposer.cpp
+++ b/test_utils/test_interposer.cpp
@@ -169,9 +169,7 @@ void cwtest_completely_control_time(bool start_of_epoch)
     clockid_t clock_id = supported_clock_ids[i];
     if (start_of_epoch)
     {
-      ts.tv_sec = 0;
-      ts.tv_nsec = 0;
-      abs_timespecs[clock_id] = ts;
+      abs_timespecs[clock_id] = {0, 0};
     }
     else
     {

--- a/test_utils/test_interposer.hpp
+++ b/test_utils/test_interposer.hpp
@@ -43,7 +43,7 @@ void cwtest_add_host_mapping(std::string host, std::string target);
 void cwtest_clear_host_mapping();
 void cwtest_advance_time_ms(long delta_ms);
 void cwtest_reset_time();
-void cwtest_completely_control_time();
+void cwtest_completely_control_time(bool start_of_epoch = false);
 
 // Control file manipulation.
 void cwtest_control_fopen(FILE* fd);


### PR DESCRIPTION
I've verified that using this at least fixes the first failure detailed in https://github.com/Metaswitch/clearwater-fv-test/issues/41.