### PR TITLE
BGCF-12 Updating SAS Resource bundle version number for failover logs.

### DIFF
--- a/include/sasevent.h
+++ b/include/sasevent.h
@@ -42,7 +42,7 @@
 
 namespace SASEvent {
 
-  const std::string CURRENT_RESOURCE_BUNDLE_DATESTAMP = "20160815";
+  const std::string CURRENT_RESOURCE_BUNDLE_DATESTAMP = "20161003";
   const std::string RESOURCE_BUNDLE_NAME = "org.projectclearwater";
   const std::string CURRENT_RESOURCE_BUNDLE =
                  RESOURCE_BUNDLE_NAME + "." + CURRENT_RESOURCE_BUNDLE_DATESTAMP;


### PR DESCRIPTION
Updated the Resource bundle number, to that which includes the new failover logs.