### PR TITLE
[Reviewer: Ellie] Changes success percent stats to report 100% when there are no errors

### DIFF
--- a/src/snmp_success_fail_count_by_request_type_table.cpp
+++ b/src/snmp_success_fail_count_by_request_type_table.cpp
@@ -60,7 +60,14 @@ public:
     uint_fast32_t successes = counts->successes.load();
     uint_fast32_t failures = counts->failures.load();
     uint_fast32_t success_percent = 0;
-    if (successes > 0)
+    if (attempts == uint_fast32_t(0))
+    {
+      // If there are no attempts made we report the Success Percent as being
+      // 100% to indicate that there have been no errors.
+      // Note that units for Success Percent are actually 10,000's of a percent.
+      success_percent = 100 * 10000;
+    }
+    else if (successes > 0)
     {
       // Units for Success Percent are actually 10,000's of a percent.
       success_percent = (successes * 100 * 10000) / (successes + failures);

--- a/src/snmp_success_fail_count_by_request_type_table.cpp
+++ b/src/snmp_success_fail_count_by_request_type_table.cpp
@@ -59,18 +59,18 @@ public:
     uint_fast32_t attempts = counts->attempts.load();
     uint_fast32_t successes = counts->successes.load();
     uint_fast32_t failures = counts->failures.load();
-    uint_fast32_t success_percent = 0;
+    uint_fast32_t success_percent_in_ten_thousands = 0;
     if (attempts == uint_fast32_t(0))
     {
       // If there are no attempts made we report the Success Percent as being
       // 100% to indicate that there have been no errors.
       // Note that units for Success Percent are actually 10,000's of a percent.
-      success_percent = 100 * 10000;
+      success_percent_in_ten_thousands = 100 * 10000;
     }
     else if (successes > 0)
     {
       // Units for Success Percent are actually 10,000's of a percent.
-      success_percent = (successes * 100 * 10000) / (successes + failures);
+      success_percent_in_ten_thousands = (successes * 100 * 10000) / (successes + failures);
     }
 
     // Construct and return a ColumnData with the appropriate values
@@ -80,7 +80,7 @@ public:
     ret[3] = Value::uint(attempts);
     ret[4] = Value::uint(successes);
     ret[5] = Value::uint(failures);
-    ret[6] = Value::uint(success_percent);
+    ret[6] = Value::uint(success_percent_in_ten_thousands);
     return ret;
   }
   static int get_count_size() { return 4; }

--- a/src/snmp_success_fail_count_table.cpp
+++ b/src/snmp_success_fail_count_table.cpp
@@ -64,7 +64,6 @@ public:
       // If there are no attempts made we report the Success Percent as being
       // 100% to indicate that there have been no errors.
       // Note that units for Success Percent are actually 10,000's of a percent.
-      TRC_ERROR("\n\n@@@ame2 setting success percent to 100 \n\n");
       success_percent = 100 * 10000;
     }
     else if (successes > 0)

--- a/src/snmp_success_fail_count_table.cpp
+++ b/src/snmp_success_fail_count_table.cpp
@@ -58,18 +58,18 @@ public:
     uint_fast32_t attempts = counts->attempts.load();
     uint_fast32_t successes = counts->successes.load();
     uint_fast32_t failures = counts->failures.load();
-    uint_fast32_t success_percent = 0;
+    uint_fast32_t success_percent_in_ten_thousands = 0;
     if (attempts == uint_fast32_t(0))
     {
       // If there are no attempts made we report the Success Percent as being
       // 100% to indicate that there have been no errors.
       // Note that units for Success Percent are actually 10,000's of a percent.
-      success_percent = 100 * 10000;
+      success_percent_in_ten_thousands = 100 * 10000;
     }
     else if (successes > 0)
     {
       // Units for Success Percent are actually 10,000's of a percent.
-      success_percent = (successes * 100 * 10000) / (successes + failures);
+      success_percent_in_ten_thousands = (successes * 100 * 10000) / (successes + failures);
     }
 
     // Construct and return a ColumnData with the appropriate values
@@ -77,8 +77,8 @@ public:
     ret[1] = Value::integer(_index);
     ret[2] = Value::uint(attempts);
     ret[3] = Value::uint(successes);
-    ret[4] = Value::uint(failures);
-    ret[5] = Value::uint(success_percent);
+    ret[4] = Value::uint(failures)
+    ret[5] = Value::uint(success_percent_in_ten_thousands);
     return ret;
   }
 };

--- a/src/snmp_success_fail_count_table.cpp
+++ b/src/snmp_success_fail_count_table.cpp
@@ -77,7 +77,7 @@ public:
     ret[1] = Value::integer(_index);
     ret[2] = Value::uint(attempts);
     ret[3] = Value::uint(successes);
-    ret[4] = Value::uint(failures)
+    ret[4] = Value::uint(failures);
     ret[5] = Value::uint(success_percent_in_ten_thousands);
     return ret;
   }

--- a/src/snmp_success_fail_count_table.cpp
+++ b/src/snmp_success_fail_count_table.cpp
@@ -59,7 +59,15 @@ public:
     uint_fast32_t successes = counts->successes.load();
     uint_fast32_t failures = counts->failures.load();
     uint_fast32_t success_percent = 0;
-    if (successes > 0)
+    if (attempts == uint_fast32_t(0))
+    {
+      // If there are no attempts made we report the Success Percent as being
+      // 100% to indicate that there have been no errors.
+      // Note that units for Success Percent are actually 10,000's of a percent.
+      TRC_ERROR("\n\n@@@ame2 setting success percent to 100 \n\n");
+      success_percent = 100 * 10000;
+    }
+    else if (successes > 0)
     {
       // Units for Success Percent are actually 10,000's of a percent.
       success_percent = (successes * 100 * 10000) / (successes + failures);


### PR DESCRIPTION
Only weird thing here is that we report percentages in units of 10,000 of a percent to maintain accuracy whilst still using integers.