### PR TITLE
[Reviewer: GDR] HttpStack and CassandraStore changes for the cached data API

### DIFF
--- a/include/cassandra_store.h
+++ b/include/cassandra_store.h
@@ -170,6 +170,11 @@ public:
                       const cass::ColumnPath& column_path,
                       const int64_t timestamp,
                       const cass::ConsistencyLevel::type consistency_level) = 0;
+  virtual void get_range_slices(std::vector<cass::KeySlice> & _return,
+                                const cass::ColumnParent& column_parent,
+                                const cass::SlicePredicate& predicate,
+                                const cass::KeyRange& range,
+                                const cass::ConsistencyLevel::type consistency_level) = 0;
 
   //
   // Utility methods for interacting with cassandra. These abstract away the
@@ -396,7 +401,9 @@ public:
   bool is_connected();
   void connect();
   void set_keyspace(const std::string& keyspace);
-  void batch_mutate(const std::map<std::string, std::map<std::string, std::vector<cass::Mutation> > >& mutation_map,
+  void batch_mutate(const std::map<std::string,
+                    std::map<std::string,
+                    std::vector<cass::Mutation> > >& mutation_map,
                     const cass::ConsistencyLevel::type consistency_level);
   void get_slice(std::vector<cass::ColumnOrSuperColumn>& _return,
                  const std::string& key,
@@ -412,6 +419,11 @@ public:
               const cass::ColumnPath& column_path,
               const int64_t timestamp,
               const cass::ConsistencyLevel::type consistency_level);
+  void get_range_slices(std::vector<cass::KeySlice> & _return,
+                        const cass::ColumnParent& column_parent,
+                        const cass::SlicePredicate& predicate,
+                        const cass::KeyRange& range,
+                        const cass::ConsistencyLevel::type consistency_level);
 
 private:
   cass::CassandraClient _cass_client;

--- a/include/httpclient.h
+++ b/include/httpclient.h
@@ -68,6 +68,7 @@ static const long HTTP_CONFLICT = 409;
 static const long HTTP_TEMP_UNAVAILABLE = 480;
 static const long HTTP_SERVER_ERROR = 500;
 static const long HTTP_NOT_IMPLEMENTED = 501;
+static const long HTTP_BAD_GATEWAY = 502;
 static const long HTTP_SERVER_UNAVAILABLE = 503;
 static const long HTTP_GATEWAY_TIMEOUT = 504;
 

--- a/include/httpstack.h
+++ b/include/httpstack.h
@@ -468,7 +468,7 @@ private:
     HttpStack* stack;
     HandlerInterface* handler;
 
-    HandlerRegistration(): HandlerRegistration(nullptr, nullptr) {}
+    HandlerRegistration() : HandlerRegistration(nullptr, nullptr) {}
     HandlerRegistration(HttpStack* stack_param, HandlerInterface* handler_param) :
       stack(stack_param), handler(handler_param)
     {}

--- a/include/httpstack.h
+++ b/include/httpstack.h
@@ -409,7 +409,7 @@ public:
   };
 
   HttpStack();
-  virtual ~HttpStack() {}
+  virtual ~HttpStack();
 
   virtual void initialize();
   virtual void configure(const std::string& bind_address,

--- a/include/httpstack.h
+++ b/include/httpstack.h
@@ -408,17 +408,17 @@ public:
     virtual void incr_http_rejected_overload() = 0;
   };
 
-  HttpStack();
+  HttpStack(int num_threads,
+            ExceptionHandler* exception_handler,
+            AccessLogger* access_logger = NULL,
+            LoadMonitor* load_monitor = NULL,
+            StatsInterface* stats = NULL);
   virtual ~HttpStack();
 
   virtual void initialize();
-  virtual void configure(const std::string& bind_address,
-                         unsigned short port,
-                         int num_threads,
-                         ExceptionHandler* exception_handler,
-                         AccessLogger* access_logger = NULL,
-                         LoadMonitor* load_monitor = NULL,
-                         StatsInterface* stats = NULL);
+  virtual void bind_tcp_socket(const std::string& bind_address,
+                               unsigned short port);
+  virtual void bind_unix_socket(const std::string& bind_path);
   virtual void register_handler(const char* path, HandlerInterface* handler);
   virtual void start(evhtp_thread_init_cb init_cb = NULL);
   virtual void stop();
@@ -448,14 +448,12 @@ private:
   HttpStack(HttpStack const&);
   void operator=(HttpStack const&);
 
-  std::string _bind_address;
-  unsigned short _bind_port;
   int _num_threads;
 
   ExceptionHandler* _exception_handler;
   AccessLogger* _access_logger;
-  StatsInterface* _stats;
   LoadMonitor* _load_monitor;
+  StatsInterface* _stats;
 
   evbase_t* _evbase;
   evhtp_t* _evhtp;

--- a/src/cassandra_store.cpp
+++ b/src/cassandra_store.cpp
@@ -129,6 +129,7 @@ void RealThriftClient::remove(const std::string& key,
 {
   _cass_client.remove(key, column_path, timestamp, consistency_level);
 }
+
 void RealThriftClient::get_range_slices(std::vector<KeySlice> & _return,
                                         const ColumnParent& column_parent,
                                         const SlicePredicate& predicate,

--- a/src/cassandra_store.cpp
+++ b/src/cassandra_store.cpp
@@ -129,6 +129,14 @@ void RealThriftClient::remove(const std::string& key,
 {
   _cass_client.remove(key, column_path, timestamp, consistency_level);
 }
+void RealThriftClient::get_range_slices(std::vector<KeySlice> & _return,
+                                        const ColumnParent& column_parent,
+                                        const SlicePredicate& predicate,
+                                        const KeyRange& range,
+                                        const ConsistencyLevel::type consistency_level)
+{
+  _cass_client.get_range_slices(_return, column_parent, predicate, range, consistency_level);
+}
 // LCOV_EXCL_STOP
 
 

--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -51,7 +51,9 @@ HttpStack::HttpStack(int num_threads,
   _exception_handler(exception_handler),
   _access_logger(access_logger),
   _load_monitor(load_monitor),
-  _stats(stats)
+  _stats(stats),
+  _evbase(nullptr),
+  _evhtp(nullptr)
 {
   TRC_STATUS("Constructing HTTP stack with %d threads", _num_threads);
 }

--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -49,6 +49,16 @@ HttpStack::HttpStack() :
   _load_monitor(NULL)
 {}
 
+HttpStack::~HttpStack()
+{
+  for(std::set<HandlerRegistration*>::iterator reg = _handler_registrations.begin();
+      reg != _handler_registrations.end();
+      ++reg)
+  {
+    delete *reg;
+  }
+}
+
 void HttpStack::Request::send_reply(int rc, SAS::TrailId trail)
 {
   _stopwatch.stop();

--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -205,7 +205,7 @@ void HttpStack::bind_tcp_socket(const std::string& bind_address,
     TRC_ERROR("evhtp_bind_socket failed with address %s and port %d",
               full_bind_address.c_str(),
               port);
-    throw Exception("evhtp_bind_socket", rc);
+    throw Exception("evhtp_bind_socket (tcp)", rc);
     // LCOV_EXCL_STOP
   }
 
@@ -222,7 +222,7 @@ void HttpStack::bind_tcp_socket(const std::string& bind_address,
       TRC_ERROR("evhtp_bind_socket failed with address %s and port %d",
                 local_bind_address.c_str(),
                 port);
-      throw Exception("evhtp_bind_socket - localhost", rc);
+      throw Exception("evhtp_bind_socket (tcp) - localhost", rc);
       // LCOV_EXCL_STOP
     }
   }
@@ -230,7 +230,18 @@ void HttpStack::bind_tcp_socket(const std::string& bind_address,
 
 void HttpStack::bind_unix_socket(const std::string& bind_path)
 {
-  // TODO
+  TRC_STATUS("Binding HTTP unix socket: path=%s", bind_path.c_str());
+  std::string full_bind_address = "unix:" + bind_path;
+
+  int rc = evhtp_bind_socket(_evhtp, full_bind_address.c_str(), 0, 1024);
+  if (rc != 0)
+  {
+    // LCOV_EXCL_START
+    TRC_ERROR("evhtp_bind_socket failed with path %s",
+              full_bind_address.c_str());
+    throw Exception("evhtp_bind_socket (unix)", rc);
+    // LCOV_EXCL_STOP
+  }
 }
 
 void HttpStack::start(evhtp_thread_init_cb init_cb)

--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -233,6 +233,11 @@ void HttpStack::bind_tcp_socket(const std::string& bind_address,
 void HttpStack::bind_unix_socket(const std::string& bind_path)
 {
   TRC_STATUS("Binding HTTP unix socket: path=%s", bind_path.c_str());
+
+  // libevhtp does not correctly remove any old socket before creating a new
+  // one, so we have to do this ourselves.
+  ::remove(bind_path.c_str());
+
   std::string full_bind_address = "unix:" + bind_path;
 
   int rc = evhtp_bind_socket(_evhtp, full_bind_address.c_str(), 0, 1024);

--- a/test_utils/mock_cassandra_store.h
+++ b/test_utils/mock_cassandra_store.h
@@ -91,6 +91,11 @@ public:
   MOCK_METHOD4(remove, void(const std::string& key, const cass::ColumnPath& column_path, const int64_t timestamp, const cass::ConsistencyLevel::type consistency_level));
   MOCK_METHOD0(connect, void());
   MOCK_METHOD0(is_connected, bool());
+  MOCK_METHOD5(get_range_slices, void(std::vector<cass::KeySlice> & _return,
+                                      const cass::ColumnParent& column_parent,
+                                      const cass::SlicePredicate& predicate,
+                                      const cass::KeyRange& range,
+                                      const cass::ConsistencyLevel::type consistency_level));
 };
 
 

--- a/test_utils/mockhttpstack.hpp
+++ b/test_utils/mockhttpstack.hpp
@@ -68,7 +68,7 @@ public:
       const char* val = evhtp_header_find(_req->headers_out, name.c_str());
       return std::string((val != NULL ? val : ""));
     }
-    void add_header_to_incoming_req(const std::string& name, 
+    void add_header_to_incoming_req(const std::string& name,
                                     const std::string& value)
     {
       // This takes the name and value for the new header. These
@@ -97,8 +97,12 @@ public:
     }
   };
 
+  MockHttpStack() : HttpStack(1, nullptr, nullptr, nullptr, nullptr) {}
+
   MOCK_METHOD0(initialize, void());
-  MOCK_METHOD7(configure, void(const std::string&, unsigned short, int, ExceptionHandler*, AccessLogger*, LoadMonitor*, StatsInterface*));
+  MOCK_METHOD2(bind_tcp_socket, void(const std::string& bind_address,
+                                     unsigned short port));
+  MOCK_METHOD1(bind_unix_socket, void(const std::string& bind_path));
   MOCK_METHOD2(register_handler, void(const char*, HandlerInterface*));
   MOCK_METHOD1(start, void(evhtp_thread_init_cb));
   MOCK_METHOD0(stop, void());


### PR DESCRIPTION
Graeme, please can you review these changes to implement the cached data API. This consists of the following changes:

* HttpStack: allow a process can have multiple instances of it and enhance it to allow binding to a unix socket (includes some reworking of its API to allow this). 
* CassandraStore: allow clients to call the `get_range_slices` method to iterate over keys. 

Tested as part of https://github.com/Metaswitch/homestead/pull/375 and https://github.com/Metaswitch/sprout/pull/1559