### PR TITLE
[Reviewer: Alex] Don't set the umask as a side-effect of daemonising

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -591,6 +591,9 @@ void Utils::daemon_log_setup(int argc,
       exit(0);
     }
   }
+  
+  mode_t old_umask = umask(0022);
+  TRC_STATUS("umask set to 022 (was %o)", old_umask);
 
   Log::setLoggingLevel(log_level);
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -539,9 +539,6 @@ int Utils::daemonize(std::string out, std::string err)
     return errno;
   }
 
-  // Clear any restricted umask
-  umask(0);
-
   // Second fork
   pid = fork();
   if (pid == -1)


### PR DESCRIPTION
Fixes the issue from https://github.com/Metaswitch/cpp-common/pull/570#issuecomment-253198617. I'll probably merge after the end of the UK day then keep an eye on the live tests to make sure this doesn't break anything. (We only introduced this `umask(0)` change in March so it shouldn't be too disruptive to revert it.)
