### PR TITLE
[Reviewer: Ellie] Allow DnsCachedResolver to load static DNS records

### DIFF
--- a/include/cpp_common_pd_definitions.h
+++ b/include/cpp_common_pd_definitions.h
@@ -167,6 +167,36 @@ static const PDLog CL_DNS_FILE_DUPLICATES
   "The DNS config file /etc/clearwater/dns_config contains duplicate entries.",
   "Only the first of the duplicates will be used - the others will be ignored.",
   "(1). Check the DNS config file for duplicates."
+  "(2). Upload the corrected config with "
+  "/usr/share/clearwater/clearwater-config-manager/scripts/upload_dns_config"
+);
+
+static const PDLog CL_DNS_FILE_MISSING
+(
+  PDLogBase::CL_CPP_COMMON_ID + 13,
+  PDLOG_ERR,
+  "DNS config file is missing.",
+  "The DNS config file /etc/clearwater/dns_config is not present.",
+  "The DNS config file will be ignored, and all DNS queries will be directed at "
+  "the DNS server rather than using any local overrides.",
+  "(1). Replace the missing DNS config file if desired."
+  "(2). Upload the corrected config with "
+  "/usr/share/clearwater/clearwater-config-manager/scripts/upload_dns_config "
+  "(if no config file is present, the empty file at "
+  "/etc/clearwater/sample/dns_config will be used)"
+);
+
+static const PDLog CL_DNS_FILE_BAD_ENTRY
+(
+  PDLogBase::CL_CPP_COMMON_ID + 14,
+  PDLOG_ERR,
+  "DNS config file has malformed entry.",
+  "The DNS config file /etc/clearwater/dns_config contains a malformed entry.",
+  "The malformed entry will be ignored. Other, correctly formed, entries will "
+  "still be used.",
+  "(1). Check the DNS config file for correctness."
+  "(2). Upload the corrected config with "
+  "/usr/share/clearwater/clearwater-config-manager/scripts/upload_dns_config"
 );
 
 #endif

--- a/include/cpp_common_pd_definitions.h
+++ b/include/cpp_common_pd_definitions.h
@@ -190,7 +190,7 @@ static const PDLog CL_DNS_FILE_BAD_ENTRY
 (
   PDLogBase::CL_CPP_COMMON_ID + 14,
   PDLOG_ERR,
-  "DNS config file has malformed entry.",
+  "DNS config file has a malformed entry.",
   "The DNS config file /etc/clearwater/dns_config contains a malformed entry.",
   "The malformed entry will be ignored. Other, correctly formed, entries will "
   "still be used.",

--- a/include/cpp_common_pd_definitions.h
+++ b/include/cpp_common_pd_definitions.h
@@ -152,8 +152,11 @@ static const PDLog CL_DNS_FILE_MALFORMED
   PDLOG_ERR,
   "DNS config file is malformed.",
   "The DNS config file /etc/clearwater/dns_config is invalid JSON.",
-  "The DNS config file will be ignored.",
+  "The DNS config file will be ignored, and all DNS queries will be directed at "
+  "the DNS server rather than using any local overrides.",
   "(1). Check the DNS config file for correctness."
+  "(2). Upload the corrected config with "
+  "/usr/share/clearwater/clearwater-config-manager/scripts/upload_dns_config"
 );
 
 static const PDLog CL_DNS_FILE_DUPLICATES

--- a/include/cpp_common_pd_definitions.h
+++ b/include/cpp_common_pd_definitions.h
@@ -44,14 +44,14 @@
 
 // The fields for each PDLog instance contains:
 //   Identity - Identifies the log id to be used in the syslog id field.
-//   Severity - One of Emergency, Alert, Critical, Error, Warning, Notice, 
+//   Severity - One of Emergency, Alert, Critical, Error, Warning, Notice,
 //              and Info.  Directly corresponds to the syslog severity types.
-//              Only PDLOG_ERROR or PDLOG_NOTICE are used.  
+//              Only PDLOG_ERROR or PDLOG_NOTICE are used.
 //              See syslog_facade.h for definitions.
 //   Message  - Formatted description of the condition.
 //   Cause    - The cause of the condition.
 //   Effect   - The effect the condition.
-//   Action   - A list of one or more actions to take to resolve the condition 
+//   Action   - A list of one or more actions to take to resolve the condition
 //              if it is an error.
 static const PDLog CL_DIAMETER_START
 (
@@ -144,6 +144,26 @@ static const PDLog2<const char*, const char*> CL_CM_CONNECTION_CLEARED
   "trying to connect to, and has seen no errors in the previous monitoring period",
   "Normal.",
   "None."
+);
+
+static const PDLog CL_DNS_FILE_MALFORMED
+(
+  PDLogBase::CL_CPP_COMMON_ID + 11,
+  PDLOG_ERR,
+  "DNS config file is malformed.",
+  "The DNS config file /etc/clearwater/dns_config is invalid JSON.",
+  "The DNS config file will be ignored.",
+  "(1). Check the DNS config file for correctness."
+);
+
+static const PDLog CL_DNS_FILE_DUPLICATES
+(
+  PDLogBase::CL_CPP_COMMON_ID + 12,
+  PDLOG_INFO,
+  "Duplicate entries found in the DNS config file",
+  "The DNS config file /etc/clearwater/dns_config contains duplicate entries.",
+  "Only the first of the duplicates will be used - the others will be ignored.",
+  "(1). Check the DNS config file for duplicates."
 );
 
 #endif

--- a/include/dnscachedresolver.h
+++ b/include/dnscachedresolver.h
@@ -49,6 +49,9 @@
 #include <arpa/nameser.h>
 #include <ares.h>
 
+#include <boost/thread/locks.hpp>
+#include <boost/thread/shared_mutex.hpp>
+
 #include "utils.h"
 #include "dnsrrecords.h"
 #include "sas.h"
@@ -104,6 +107,9 @@ public:
 
   /// Clear the cache
   void clear();
+
+  // Reads DNS records from _dns_config_file and stores them in _static_records
+  void reload_static_records();
 
 private:
   void init(const std::vector<IP46Address>& dns_server);
@@ -211,9 +217,7 @@ private:
 
   std::string _dns_config_file;
   std::map<std::string, std::vector<DnsRRecord*>> _static_records;
-
-  // Reads DNS records from _dns_config_file and stores them in _static_records
-  void read_records_from_file();
+  boost::shared_mutex _static_records_mutex;
 
   // Expiry is done efficiently by storing pointers to cache entries in a
   // multimap indexed on expiry time.

--- a/include/dnscachedresolver.h
+++ b/include/dnscachedresolver.h
@@ -49,9 +49,6 @@
 #include <arpa/nameser.h>
 #include <ares.h>
 
-#include <boost/thread/locks.hpp>
-#include <boost/thread/shared_mutex.hpp>
-
 #include "utils.h"
 #include "dnsrrecords.h"
 #include "sas.h"
@@ -217,7 +214,6 @@ private:
 
   std::string _dns_config_file;
   std::map<std::string, std::vector<DnsRRecord*>> _static_records;
-  boost::shared_mutex _static_records_mutex;
 
   // Expiry is done efficiently by storing pointers to cache entries in a
   // multimap indexed on expiry time.

--- a/include/dnscachedresolver.h
+++ b/include/dnscachedresolver.h
@@ -77,9 +77,9 @@ private:
 class DnsCachedResolver
 {
 public:
-  DnsCachedResolver(const std::vector<IP46Address>& dns_servers);
-  DnsCachedResolver(const std::vector<std::string>& dns_servers);
-  DnsCachedResolver(const std::string& dns_server, int port);
+  DnsCachedResolver(const std::vector<IP46Address>& dns_servers, const std::string& filename = "");
+  DnsCachedResolver(const std::vector<std::string>& dns_servers, const std::string& filename = "");
+  DnsCachedResolver(const std::string& dns_server, int port, const std::string& filename = "");
   DnsCachedResolver(const std::string& dns_server) : DnsCachedResolver(dns_server, 53) {};
   ~DnsCachedResolver();
 
@@ -169,6 +169,12 @@ private:
                    DnsCacheEntryPtr,
                    DnsCacheKeyCompare> DnsCache;
 
+  /// Performs the actual DNS query.
+  void inner_dns_query(const std::vector<std::string>& domains,
+                       int dnstype,
+                       std::vector<DnsResult>& results,
+                       SAS::TrailId trail);
+
   void dns_response(const std::string& domain,
                     int dnstype,
                     int status,
@@ -202,6 +208,12 @@ private:
   pthread_mutex_t _cache_lock;
   pthread_cond_t _got_reply_cond;
   DnsCache _cache;
+
+  std::string _dns_config_file;
+  std::map<std::string, std::vector<DnsRRecord*>> _static_records;
+
+  // Reads DNS records from _dns_config_file and stores them in _static_records
+  void read_records_from_file();
 
   // Expiry is done efficiently by storing pointers to cache entries in a
   // multimap indexed on expiry time.

--- a/include/signalhandler.h
+++ b/include/signalhandler.h
@@ -193,6 +193,7 @@ template<int SIGNUM> sem_t SignalHandler<SIGNUM>::_sema;
 // Concrete instances of signal handers
 extern SignalHandler<SIGHUP> _sighup_handler;
 extern SignalHandler<SIGUSR1> _sigusr1_handler;
+extern SignalHandler<SIGUSR2> _sigusr2_handler;
 
 // This starts the signal handlers. This creates a new thread for each
 // handler, so this function must not be called before the process has
@@ -201,6 +202,7 @@ inline void start_signal_handlers()
 {
   _sighup_handler.start();
   _sigusr1_handler.start();
+  _sigusr2_handler.start();
 }
 
 #endif

--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -268,6 +268,9 @@ void DnsCachedResolver::reload_static_records()
     return;
   }
 
+  TRC_DEBUG("Loading static DNS records from %s",
+            _dns_config_file.c_str());
+
   // File exists and is ready
   std::string dns_config((std::istreambuf_iterator<char>(fs)),
                          std::istreambuf_iterator<char>());

--- a/src/signalhandler.cpp
+++ b/src/signalhandler.cpp
@@ -1,5 +1,5 @@
 /**
- * @file signalhandler.cpp 
+ * @file signalhandler.cpp
  *
  * Project Clearwater - IMS in the Cloud
  * Copyright (C) 2013  Metaswitch Networks Ltd
@@ -40,4 +40,5 @@
 
 SignalHandler<SIGHUP> _sighup_handler;
 SignalHandler<SIGUSR1> _sigusr1_handler;
+SignalHandler<SIGUSR2> _sigusr2_handler;
 


### PR DESCRIPTION
 - constructors now take an optional filename
 - it will try to read this as a JSON file, storing the static records in memory
 - when doing a dns_query, these records will be examined first.

Currently, only CNAME records are supported
 - if one is found, the DNS query is performed on the redirected host rather than the original

Testing done:
 - UTs (in cpp-common-test)
 - some live testing (though more will follow)