### PR TITLE
[Reviewer: RJW2] Add scope indexed SNMP tables

### DIFF
--- a/include/load_monitor.h
+++ b/include/load_monitor.h
@@ -40,7 +40,7 @@
 #include <time.h>
 #include <pthread.h>
 #include "snmp_continuous_accumulator_table.h"
-#include "snmp_scalar.h"
+#include "snmp_abstract_scalar.h"
 #include "sas.h"
 
 class TokenBucket
@@ -63,11 +63,11 @@ class LoadMonitor
   public:
     LoadMonitor(int init_target_latency, int max_bucket_size,
                 float init_token_rate, float init_min_token_rate,
-                SNMP::ContinuousAccumulatorTable* token_rate_tbl = NULL,
-                SNMP::U32Scalar* smoothed_latency_scalar = NULL,
-                SNMP::U32Scalar* target_latency_scalar = NULL,
-                SNMP::U32Scalar* penalties_scalar = NULL,
-                SNMP::U32Scalar* token_rate_scalar = NULL);
+                SNMP::AbstractContinuousAccumulatorTable* token_rate_tbl = NULL,
+                SNMP::AbstractScalar* smoothed_latency_scalar = NULL,
+                SNMP::AbstractScalar* target_latency_scalar = NULL,
+                SNMP::AbstractScalar* penalties_scalar = NULL,
+                SNMP::AbstractScalar* token_rate_scalar = NULL);
     virtual ~LoadMonitor();
     virtual bool admit_request(SAS::TrailId trail);
     virtual void incr_penalties();
@@ -105,11 +105,11 @@ class LoadMonitor
     unsigned long last_adjustment_time_ms;
     float min_token_rate;
     TokenBucket bucket;
-    SNMP::ContinuousAccumulatorTable* _token_rate_table;
-    SNMP::U32Scalar* _smoothed_latency_scalar;
-    SNMP::U32Scalar* _target_latency_scalar;
-    SNMP::U32Scalar* _penalties_scalar;
-    SNMP::U32Scalar* _token_rate_scalar;
+    SNMP::AbstractContinuousAccumulatorTable* _token_rate_table;
+    SNMP::AbstractScalar* _smoothed_latency_scalar;
+    SNMP::AbstractScalar* _target_latency_scalar;
+    SNMP::AbstractScalar* _penalties_scalar;
+    SNMP::AbstractScalar* _token_rate_scalar;
 };
 
 #endif

--- a/include/snmp_abstract_continuous_accumulator_table.h
+++ b/include/snmp_abstract_continuous_accumulator_table.h
@@ -1,8 +1,8 @@
 /**
- * @file snmp_scalar.h
+ * @file snmp_abstract_continuous_accumulator_table.h
  *
  * Project Clearwater - IMS in the Cloud
- * Copyright (C) 2015 Metaswitch Networks Ltd
+ * Copyright (C) 2016 Metaswitch Networks Ltd
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -28,55 +28,40 @@
  * respects for all of the code used other than OpenSSL.
  * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
  * Project and licensed under the OpenSSL Licenses, or a work based on such
- * software and licensed under the OpenSSL Licenses.
+ * software and licensed und er the OpenSSL Licenses.
  * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
  * under which the OpenSSL Project distributes the OpenSSL toolkit software,
  * as those licenses appear in the file LICENSE-OPENSSL.
  */
 
+#include <vector>
+#include <map>
 #include <string>
-#include "snmp_abstract_scalar.h"
+#include <atomic>
 
-#ifndef SNMP_SCALAR_H
-#define SNMP_SCALAR_H
+#include "logger.h"
 
-// This file contains infrastructure for SNMP scalars (single values, not in a
-// table).
-//
-// To use one, simply create a U32Scalar and modify its `value` object as
-// necessary - changes to this will automatically be reflected over SNMP. For
-// example:
-//
-//     SNMP::U32Scalar* cxn_count = new SNMP::U32Scalar("bono_cxn_count", ".1.2.3");
-//     cxn_count->value = 42;
-//
-// Note that the OID scalars are exposed under has an additional element with
-// the value zero (so using the example above, would actually be obtained by
-// querying ".1.2.3.0"). This is extremely counter-intuitive and easy to
-// forget. Because of this the trailing ".0" should not be specified when
-// constructing the scalar - the scalar will add it when registering with
-// net-snmp.
+#ifndef SNMP_ABSTRACT_CONTINUOUS_ACCUMULATOR_TABLE_H
+#define SNMP_ABSTRACT_CONTINUOUS_ACCUMULATOR_TABLE_H
+
+// This file contains an abstract class used for creating tables Continuous
+// Accumulator tables e.g. ContinuousAccumulatorTable,
+// ContinuousAccumulatorByScopeTable.
 
 namespace SNMP
 {
 
-// Exposes a number as an SNMP Unsigned32.
-class U32Scalar: public AbstractScalar
+class AbstractContinuousAccumulatorTable
 {
 public:
-  /// Constructor
-  ///
-  /// @param name - The name of the scalar.
-  /// @param oid  - The OID for the scalar excluding the trailing ".0"
-  U32Scalar(std::string name, std::string oid);
-  ~U32Scalar();
-  virtual void set_value(unsigned long val);
-  unsigned long value;
+  AbstractContinuousAccumulatorTable() {};
+  virtual ~AbstractContinuousAccumulatorTable() {};
 
-private:
-  // The OID as registered with net-snmp (including the trailing ".0").
-  std::string _registered_oid;
+  // Accumulate a sample into the underlying statistics.
+  virtual void accumulate(uint32_t sample) = 0;
+
 };
 
 }
+
 #endif

--- a/include/snmp_abstract_scalar.h
+++ b/include/snmp_abstract_scalar.h
@@ -1,8 +1,8 @@
 /**
- * @file snmp_scalar.h
+ * @file snmp_abstract_scalar.h
  *
  * Project Clearwater - IMS in the Cloud
- * Copyright (C) 2015 Metaswitch Networks Ltd
+ * Copyright (C) 2016 Metaswitch Networks Ltd
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -35,47 +35,23 @@
  */
 
 #include <string>
-#include "snmp_abstract_scalar.h"
 
-#ifndef SNMP_SCALAR_H
-#define SNMP_SCALAR_H
+#ifndef SNMP_ABSTRACT_SCALAR_H
+#define SNMP_ABSTRACT_SCALAR_H
 
-// This file contains infrastructure for SNMP scalars (single values, not in a
-// table).
-//
-// To use one, simply create a U32Scalar and modify its `value` object as
-// necessary - changes to this will automatically be reflected over SNMP. For
-// example:
-//
-//     SNMP::U32Scalar* cxn_count = new SNMP::U32Scalar("bono_cxn_count", ".1.2.3");
-//     cxn_count->value = 42;
-//
-// Note that the OID scalars are exposed under has an additional element with
-// the value zero (so using the example above, would actually be obtained by
-// querying ".1.2.3.0"). This is extremely counter-intuitive and easy to
-// forget. Because of this the trailing ".0" should not be specified when
-// constructing the scalar - the scalar will add it when registering with
-// net-snmp.
+// This file contains a base abstract class for SNMP scalars e.g. U32Scalar,
+// ScalarByScopeTable.
 
 namespace SNMP
 {
 
 // Exposes a number as an SNMP Unsigned32.
-class U32Scalar: public AbstractScalar
+class AbstractScalar
 {
 public:
-  /// Constructor
-  ///
-  /// @param name - The name of the scalar.
-  /// @param oid  - The OID for the scalar excluding the trailing ".0"
-  U32Scalar(std::string name, std::string oid);
-  ~U32Scalar();
-  virtual void set_value(unsigned long val);
-  unsigned long value;
-
-private:
-  // The OID as registered with net-snmp (including the trailing ".0").
-  std::string _registered_oid;
+  AbstractScalar() {};
+  virtual ~AbstractScalar() {};
+  virtual void set_value(unsigned long value) = 0;
 };
 
 }

--- a/include/snmp_continuous_accumulator_by_scope_table.h
+++ b/include/snmp_continuous_accumulator_by_scope_table.h
@@ -40,6 +40,7 @@
 #include <atomic>
 
 #include "logger.h"
+#include "snmp_abstract_continuous_accumulator_table.h"
 
 #ifndef SNMP_CONTINUOUS_ACCUMULATOR_BY_SCOPE_TABLE_H
 #define SNMP_CONTINUOUS_ACCUMULATOR_BY_SCOPE_TABLE_H
@@ -64,7 +65,7 @@
 namespace SNMP
 {
 
-class ContinuousAccumulatorByScopeTable
+class ContinuousAccumulatorByScopeTable: public AbstractContinuousAccumulatorTable
 {
 public:
   virtual ~ContinuousAccumulatorByScopeTable() {};

--- a/include/snmp_continuous_accumulator_by_scope_table.h
+++ b/include/snmp_continuous_accumulator_by_scope_table.h
@@ -1,0 +1,84 @@
+/**
+ * @file snmp_continuous_accumulator_by_scope_table.h
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2016 Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed und er the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include <vector>
+#include <map>
+#include <string>
+#include <atomic>
+
+#include "logger.h"
+
+#ifndef SNMP_CONTINUOUS_ACCUMULATOR_BY_SCOPE_TABLE_H
+#define SNMP_CONTINUOUS_ACCUMULATOR_BY_SCOPE_TABLE_H
+
+// This file contains the interface for tables which:
+//   - are indexed by time period and scope (node type)
+//   - accumulate data samples over time
+//   - report a count of samples, high-water-mark and low-water-mark
+//   - report mean sample rate and variance as weighted by the proportion
+//         of time active within the time period
+//   - carry across final value as initial value for the next table
+//
+// The thing sampled should be a continiuous data set, i.e. valued across a
+// time period.
+//
+// To create an accumulator table, simply create one, and call `accumulate` on it as data comes in,
+// e.g.:
+//
+// ContinuousAccumulatorTable* token_rate_table = ContinuousAccumulatorTable::create("token_rate", ".1.2.3");
+// token_rate_table->accumulate(2000);
+
+namespace SNMP
+{
+
+class ContinuousAccumulatorByScopeTable
+{
+public:
+  virtual ~ContinuousAccumulatorByScopeTable() {};
+
+  static ContinuousAccumulatorByScopeTable* create(std::string name, std::string oid);
+
+  // Accumulate a sample into the underlying statistics.
+  virtual void accumulate(uint32_t sample) = 0;
+
+protected:
+  ContinuousAccumulatorByScopeTable() {};
+
+};
+
+}
+
+#endif

--- a/include/snmp_continuous_accumulator_table.h
+++ b/include/snmp_continuous_accumulator_table.h
@@ -40,6 +40,7 @@
 #include <atomic>
 
 #include "logger.h"
+#include "snmp_abstract_continuous_accumulator_table.h"
 
 #ifndef SNMP_CONTINUOUS_ACCUMULATOR_TABLE_H
 #define SNMP_CONTINUOUS_ACCUMULATOR_TABLE_H
@@ -64,7 +65,7 @@
 namespace SNMP
 {
 
-class ContinuousAccumulatorTable
+class ContinuousAccumulatorTable: public AbstractContinuousAccumulatorTable
 {
 public:
   virtual ~ContinuousAccumulatorTable() {};

--- a/include/snmp_counter_by_scope_table.h
+++ b/include/snmp_counter_by_scope_table.h
@@ -1,0 +1,65 @@
+/**
+ * @file snmp_counter_by_scope_table.h
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2016 Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed und er the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include <vector>
+#include <map>
+#include <string>
+
+#ifndef SNMP_COUNTER_BY_SCOPE_TABLE_H
+#define SNMP_COUNTER_BY_SCOPE_TABLE_H
+
+// This file contains the interface for tables which:
+//   - are indexed by time period and scope (node type)
+//   - increment a single counter over time
+//   - report a single column for each time period with that count
+//
+// This is defined as an interface in order not to pollute the codebase with netsnmp include files
+// (which indiscriminately #define things like READ and WRITE).
+
+namespace SNMP
+{
+class CounterByScopeTable
+{
+public:
+  static CounterByScopeTable* create(std::string name, std::string oid);
+  virtual void increment() = 0;
+  virtual ~CounterByScopeTable() {};
+
+protected:
+  CounterByScopeTable() {};
+};
+}
+#endif

--- a/include/snmp_event_accumulator_by_scope_table.h
+++ b/include/snmp_event_accumulator_by_scope_table.h
@@ -1,0 +1,82 @@
+/**
+ * @file snmp_event_accumulator_by_scope_table.h
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2016 Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed und er the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include <vector>
+#include <map>
+#include <string>
+#include <atomic>
+
+#include "logger.h"
+
+#ifndef SNMP_EVENT_ACCUMULATOR_BY_SCOPE_TABLE_H
+#define SNMP_EVENT_ACCUMULATOR_BY_SCOPE_TABLE_H
+
+// This file contains the interface for tables which:
+//   - are indexed by time period and scope (node type)
+//   - accumulate data samples over time
+//   - report a count of samples, mean sample value, variance, high-water-mark and low-water-mark
+//   - reset completely at the end of the period
+//
+// The thing sampled should be event related, i.e. size of a queue, latency
+// values
+//
+// To create an event accumulator by node type table, simply create one, and call `accumulate` on it as data comes in,
+// e.g.:
+//
+// EventAccumulatorByScopeTable* sprout_latency_table = EventAccumulatorByScopeTable::create("sprout_latency", ".1.2.3");
+// sprout_latency_table->accumulate(2000);
+
+namespace SNMP
+{
+
+class EventAccumulatorByScopeTable
+{
+public:
+  virtual ~EventAccumulatorByScopeTable() {};
+
+  static EventAccumulatorByScopeTable* create(std::string name, std::string oid);
+
+  // Accumulate a sample into the underlying statistics.
+  virtual void accumulate(uint32_t sample) = 0;
+
+protected:
+  EventAccumulatorByScopeTable() {};
+
+};
+
+}
+
+#endif

--- a/include/snmp_internal/snmp_scope_table.h
+++ b/include/snmp_internal/snmp_scope_table.h
@@ -1,0 +1,97 @@
+/**
+ * @file snmp_scope_table.h
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2016 Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed und er the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include "snmp_table.h"
+#include <vector>
+#include <map>
+#include <string>
+#include <atomic>
+#include "logger.h"
+
+#include "snmp_types.h"
+
+#ifndef SNMP_SCOPE_TABLE_H
+#define SNMP_SCOPE_TABLE_H
+
+// This file contains the base infrastructure for SNMP tables which are indexed by scope (node
+// type). It contains only abstract classes, which need to be subclassed - e.g.
+// SNMP::ScalarByScopeRow
+
+
+namespace SNMP
+{
+
+template <class T> class ScopeBasedRow : public Row
+{
+public:
+
+  class View
+  {
+  public:
+    View(T* data): _data(data) {};
+    virtual ~View() {};
+    T* get_data() { return (this->_data); }
+  protected:
+    T* _data;
+  };
+
+  ScopeBasedRow(std::string scope_index, View* view) :
+    Row(),
+    _scope_index(scope_index),
+    _view(view)
+  {
+    // Scope based rows are indexed off a single string representing the node type.
+    netsnmp_tdata_row_add_index(_row,
+                                ASN_OCTET_STR,
+                                _scope_index.c_str(),
+                                _scope_index.length());
+
+  };
+
+  virtual ~ScopeBasedRow()
+  {
+    delete(_view);
+  };
+
+  virtual ColumnData get_columns() = 0;
+
+protected:
+  std::string _scope_index;
+  View* _view;
+};
+}
+
+#endif

--- a/include/snmp_internal/snmp_time_period_and_scope_table.h
+++ b/include/snmp_internal/snmp_time_period_and_scope_table.h
@@ -1,0 +1,73 @@
+/**
+ * @file snmp_time_period_and_scope_table.h
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2016 Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed und er the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include "snmp_time_period_table.h"
+#include "snmp_node_types.h"
+
+#ifndef SNMP_TIME_PERIOD_AND_SCOPE_TABLE_H
+#define SNMP_TIME_PERIOD_AND_SCOPE_TABLE_H
+
+// This file contains the base infrastructure for SNMP tables
+// which are indexed by time period and scope (node type).
+namespace SNMP
+{
+
+template <class T> class TimeAndScopeBasedRow : public TimeBasedRow<T>
+{
+public:
+  // Constructor, takes ownership of the View*.
+  TimeAndScopeBasedRow(int time_index, std::string scope_index, typename TimeBasedRow<T>::View* view) :
+    TimeBasedRow<T>(time_index, view),
+    _scope_index(scope_index)
+  {
+    // Add the scope index (the time index is added in the base class)
+    netsnmp_tdata_row_add_index(this->_row,
+                                ASN_OCTET_STR,
+                                _scope_index.c_str(),
+                                _scope_index.length());
+  };
+
+  virtual ~TimeAndScopeBasedRow()
+  {
+  };
+
+protected:
+  std::string _scope_index;
+};
+
+}
+
+#endif

--- a/include/snmp_scalar_by_scope_table.h
+++ b/include/snmp_scalar_by_scope_table.h
@@ -37,6 +37,7 @@
 #include <vector>
 #include <map>
 #include <string>
+#include "snmp_abstract_scalar.h"
 
 #ifndef SNMP_SCALAR_BY_SCOPE_TABLE_H
 #define SNMP_SCALAR_BY_SCOPE_TABLE_H
@@ -51,11 +52,11 @@
 
 namespace SNMP
 {
-class ScalarByScopeTable
+class ScalarByScopeTable: public AbstractScalar
 {
 public:
   static ScalarByScopeTable* create(std::string name, std::string oid);
-  virtual void set_value(uint32_t value) = 0;
+  virtual void set_value(unsigned long value) = 0;
   virtual ~ScalarByScopeTable() {};
 
 protected:

--- a/include/snmp_scalar_by_scope_table.h
+++ b/include/snmp_scalar_by_scope_table.h
@@ -1,0 +1,65 @@
+/**
+ * @file snmp_scalar_by_scope__table.h
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2016 Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed und er the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include <vector>
+#include <map>
+#include <string>
+
+#ifndef SNMP_SCALAR_BY_SCOPE_TABLE_H
+#define SNMP_SCALAR_BY_SCOPE_TABLE_H
+
+// This file contains the interface for tables which:
+//   - are indexed by scope (node type)
+//   - keep track of a single value
+//   - report a single column for each scope value
+//
+// This is defined as an interface in order not to pollute the codebase with netsnmp include files
+// (which indiscriminately #define things like READ and WRITE).
+
+namespace SNMP
+{
+class ScalarByScopeTable
+{
+public:
+  static ScalarByScopeTable* create(std::string name, std::string oid);
+  virtual void set_value(uint32_t value) = 0;
+  virtual ~ScalarByScopeTable() {};
+
+protected:
+  ScalarByScopeTable() {};
+};
+}
+#endif

--- a/include/snmp_statistics_structures.h
+++ b/include/snmp_statistics_structures.h
@@ -49,6 +49,12 @@
 namespace SNMP
 {
 
+// A simple scalar statistsic
+struct Scalar
+{
+  uint32_t value;
+};
+
 // A simple counting statistic
 struct SingleCount
 {

--- a/src/load_monitor.cpp
+++ b/src/load_monitor.cpp
@@ -84,11 +84,11 @@ void TokenBucket::replenish_bucket()
 
 LoadMonitor::LoadMonitor(int init_target_latency, int max_bucket_size,
                          float init_token_rate, float init_min_token_rate,
-                         SNMP::ContinuousAccumulatorTable* token_rate_table,
-                         SNMP::U32Scalar* smoothed_latency_scalar,
-                         SNMP::U32Scalar* target_latency_scalar,
-                         SNMP::U32Scalar* penalties_scalar,
-                         SNMP::U32Scalar* token_rate_scalar)
+                         SNMP::AbstractContinuousAccumulatorTable* token_rate_table,
+                         SNMP::AbstractScalar* smoothed_latency_scalar,
+                         SNMP::AbstractScalar* target_latency_scalar,
+                         SNMP::AbstractScalar* penalties_scalar,
+                         SNMP::AbstractScalar* token_rate_scalar)
                          : bucket(max_bucket_size, init_token_rate),
                            _token_rate_table(token_rate_table),
                            _smoothed_latency_scalar(smoothed_latency_scalar),
@@ -309,15 +309,15 @@ void LoadMonitor::update_statistics()
 {
   if (_smoothed_latency_scalar != NULL)
   {
-    _smoothed_latency_scalar->value = smoothed_latency;
+    _smoothed_latency_scalar->set_value(smoothed_latency);
   }
   if (_target_latency_scalar != NULL)
   {
-    _target_latency_scalar->value = target_latency;
+    _target_latency_scalar->set_value(target_latency);
   }
   if (_penalties_scalar != NULL)
   {
-    _penalties_scalar->value = penalties;
+    _penalties_scalar->set_value(penalties);
   }
   if (_token_rate_table != NULL)
   {
@@ -325,6 +325,6 @@ void LoadMonitor::update_statistics()
   }
   if (_token_rate_scalar != NULL)
   {
-    _token_rate_scalar->value = bucket.rate;
+    _token_rate_scalar->set_value(bucket.rate);
   }
 }

--- a/src/snmp_continuous_accumulator_by_scope_table.cpp
+++ b/src/snmp_continuous_accumulator_by_scope_table.cpp
@@ -37,7 +37,7 @@
 #include "snmp_statistics_structures.h"
 #include "snmp_internal/snmp_time_period_table.h"
 #include "snmp_internal/snmp_time_period_and_scope_table.h"
-#include "snmp_continuous_accumulator_table.h"
+#include "snmp_continuous_accumulator_by_scope_table.h"
 #include "limits.h"
 
 namespace SNMP
@@ -50,13 +50,13 @@ public:
   ColumnData get_columns();
 };
 
-class ContinuousAccumulatorTableImpl: public ManagedTable<ContinuousAccumulatorRow, int>,
-                                      public ContinuousAccumulatorTable
+class ContinuousAccumulatorByScopeTableImpl: public ManagedTable<ContinuousAccumulatorByScopeRow, int>,
+                                             public ContinuousAccumulatorByScopeTable
 {
 public:
   ContinuousAccumulatorByScopeTableImpl(std::string name,
                                         std::string tbl_oid):
-                                        ManagedTable<ContinuousAccumulatorRow,int>
+                                        ManagedTable<ContinuousAccumulatorByScopeRow,int>
                                             (name,
                                             tbl_oid,
                                             3,
@@ -145,6 +145,7 @@ private:
     }
   };
 
+  int n;
 
   CurrentAndPrevious<ContinuousStatistics> five_second;
   CurrentAndPrevious<ContinuousStatistics> five_minute;

--- a/src/snmp_continuous_accumulator_by_scope_table.cpp
+++ b/src/snmp_continuous_accumulator_by_scope_table.cpp
@@ -1,0 +1,223 @@
+/**
+ * @file snmp_continuous_accumulator_by_scope_table.cpp
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2016 Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include "snmp_statistics_structures.h"
+#include "snmp_internal/snmp_time_period_table.h"
+#include "snmp_internal/snmp_time_period_and_scope_table.h"
+#include "snmp_continuous_accumulator_table.h"
+#include "limits.h"
+
+namespace SNMP
+{
+// A TimeAndScopeBasedRow that maps the data from ContinuousStatistics into the right five columns.
+class ContinuousAccumulatorByScopeRow: public TimeAndScopeBasedRow<ContinuousStatistics>
+{
+public:
+  ContinuousAccumulatorByScopeRow(int index, std::string scope_index, View* view): TimeAndScopeBasedRow<ContinuousStatistics>(index, scope_index, view) {};
+  ColumnData get_columns();
+};
+
+class ContinuousAccumulatorTableImpl: public ManagedTable<ContinuousAccumulatorRow, int>,
+                                      public ContinuousAccumulatorTable
+{
+public:
+  ContinuousAccumulatorByScopeTableImpl(std::string name,
+                                        std::string tbl_oid):
+                                        ManagedTable<ContinuousAccumulatorRow,int>
+                                            (name,
+                                            tbl_oid,
+                                            3,
+                                            7, // Columns 3-7 should be visible
+                                            { ASN_INTEGER , ASN_OCTET_STR }), // Type of the index column
+    five_second(5000),
+    five_minute(300000)
+  {
+    n = 0;
+
+    // We have a fixed number of rows, so create them in the constructor.
+    this->add(n++, new_row(scopePrevious5SecondPeriod));
+    this->add(n++, new_row(scopeCurrent5MinutePeriod));
+    this->add(n++, new_row(scopePrevious5MinutePeriod));
+  }
+
+  // Accumulate a sample into the underlying statistics.
+  void accumulate(uint32_t sample)
+  {
+    // Pass samples through to the underlying data structures
+    accumulate_internal(five_second, sample);
+    accumulate_internal(five_minute, sample);
+  }
+
+private:
+  // Map row indexes to the view of the underlying data they should expose
+  ContinuousAccumulatorByScopeRow* new_row(int index)
+  {
+    ContinuousAccumulatorByScopeRow::View* view = NULL;
+    switch (index)
+    {
+      case TimePeriodIndexes::scopePrevious5SecondPeriod:
+        view = new ContinuousAccumulatorByScopeRow::PreviousView(&five_second);
+        break;
+      case TimePeriodIndexes::scopeCurrent5MinutePeriod:
+        view = new ContinuousAccumulatorByScopeRow::CurrentView(&five_minute);
+        break;
+      case TimePeriodIndexes::scopePrevious5MinutePeriod:
+        view = new ContinuousAccumulatorByScopeRow::PreviousView(&five_minute);
+        break;
+    }
+    return new ContinuousAccumulatorByScopeRow(index, "node", view);
+  }
+
+  void accumulate_internal(CurrentAndPrevious<ContinuousStatistics>& data, uint32_t sample)
+  {
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME_COARSE, &now);
+
+    ContinuousStatistics* current_data = data.get_current(now);
+
+    TRC_DEBUG("Accumulating sample %uui into continuous accumulator statistic", sample);
+
+    current_data->count++;
+
+    // Compute the updated sum and sqsum based on the previous values, dependent on
+    // how long since an update happened. Additionally update the sum of squares as a
+    // rolling total, and update the time of the last update. Also maintain a
+    // current value held, that can be used if the period ends.
+
+    uint64_t time_since_last_update = ((now.tv_sec * 1000) + (now.tv_nsec / 1000000))
+                                     - (current_data->time_last_update_ms.load());
+    uint32_t current_value = current_data->current_value.load();
+
+    current_data->time_last_update_ms = (now.tv_sec * 1000) + (now.tv_nsec / 1000000);
+    current_data->sum += current_value * time_since_last_update;
+    current_data->sqsum += current_value * current_value * time_since_last_update;
+    current_data->current_value = sample;
+
+    // Update the low- and high-water marks.  In each case, we get the current
+    // value, decide whether a change is required and then atomically swap it
+    // if so, repeating if it was changed in the meantime.  Note that
+    // compare_exchange_weak loads the current value into the expected value
+    // parameter (lwm or hwm below) if the compare fails.
+    uint_fast64_t lwm = current_data->lwm.load();
+    while ((sample < lwm) &&
+           (!current_data->lwm.compare_exchange_weak(lwm, sample)))
+    {
+      // Do nothing.
+    }
+    uint_fast64_t hwm = current_data->hwm.load();
+    while ((sample > hwm) &&
+           (!current_data->hwm.compare_exchange_weak(hwm, sample)))
+    {
+      // Do nothing.
+    }
+  };
+
+
+  CurrentAndPrevious<ContinuousStatistics> five_second;
+  CurrentAndPrevious<ContinuousStatistics> five_minute;
+};
+
+ColumnData ContinuousAccumulatorByScopeRow::get_columns()
+{
+  struct timespec now;
+  clock_gettime(CLOCK_REALTIME_COARSE, &now);
+
+  ContinuousStatistics* accumulated = _view->get_data(now);
+  uint32_t interval_ms = _view->get_interval_ms();
+
+  uint_fast32_t count = accumulated->count.load();
+  uint_fast32_t current_value = accumulated->current_value.load();
+
+  uint_fast64_t avg = current_value;
+  uint_fast64_t variance = 0;
+  uint_fast32_t lwm = accumulated->lwm.load();
+  // If LWM is still ULONG_MAX, then report as 0, as no results
+  // have been entered (and HWM will be reported as 0)
+  if (lwm == ULONG_MAX)
+  {
+    lwm = 0;
+  }
+  uint_fast32_t hwm = accumulated->hwm.load();
+  uint_fast64_t time_last_update_ms = accumulated->time_last_update_ms.load();
+  uint_fast64_t time_period_start_ms = accumulated->time_period_start_ms.load();
+  uint_fast64_t sum = accumulated->sum.load();
+  uint_fast64_t sqsum = accumulated->sqsum.load();
+
+  // We need to know how long it has been since we've last updated.
+  // We must distinguish between the case that we have moved onto the
+  // next period though, which we do by comparing the calculated end of period
+  // with the current time. We should use the smaller value to accumulate with,
+  // to stop us from updating periods that are now out of date.
+  uint64_t time_now_ms = (now.tv_sec * 1000) + (now.tv_nsec / 1000000);
+
+  // As a time period might not begin on a boundary, we must synchronize
+  // the end of the period with a boundary which is why the following line
+  // requires so many interval_ms!
+  uint64_t time_period_end_ms = ((time_period_start_ms + interval_ms) / interval_ms) * interval_ms;
+  uint64_t time_comes_first_ms = std::min(time_period_end_ms, time_now_ms);
+
+  uint64_t time_since_last_update_ms = time_comes_first_ms - time_last_update_ms;
+  accumulated->time_last_update_ms.store(time_comes_first_ms);
+  uint64_t period_count = (time_comes_first_ms - time_period_start_ms);
+
+  if (period_count > 0)
+  {
+    // Calculate the average and the variance from the stored average/time of last updated
+    // and sum-of-squares.
+    sum += time_since_last_update_ms * current_value;
+    accumulated->sum.store(sum);
+    sqsum += time_since_last_update_ms * current_value * current_value;
+    accumulated->sqsum.store(sqsum);
+    avg = sum / period_count;
+    variance = ((sqsum * period_count) - (sum * sum)) / (period_count * period_count);
+  }
+
+  // Construct and return a ColumnData with the appropriate values
+  ColumnData ret;
+  ret[3] = Value::uint(avg);
+  ret[4] = Value::uint(variance);
+  ret[5] = Value::uint(hwm);
+  ret[6] = Value::uint(lwm);
+  ret[7] = Value::uint(count);
+  return ret;
+}
+
+ContinuousAccumulatorByScopeTable* ContinuousAccumulatorByScopeTable::create(std::string name,
+                                                                             std::string oid)
+{
+  return new ContinuousAccumulatorByScopeTableImpl(name, oid);
+}
+}

--- a/src/snmp_counter_by_scope_table.cpp
+++ b/src/snmp_counter_by_scope_table.cpp
@@ -1,0 +1,127 @@
+/**
+ * @file snmp_counter_by_scope_table.cpp
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2016 Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include "snmp_counter_table.h"
+#include "snmp_counter_by_scope_table.h"
+#include "snmp_statistics_structures.h"
+#include "snmp_internal/snmp_includes.h"
+#include "snmp_internal/snmp_time_period_table.h"
+#include "snmp_internal/snmp_time_period_and_scope_table.h"
+#include "logger.h"
+
+namespace SNMP
+{
+
+// A TimeAndScopeBasedRow that maps the data from SingleCount into the right column.
+class CounterByScopeRow: public TimeAndScopeBasedRow<SingleCount>
+{
+public:
+  CounterByScopeRow(int index, std::string scope_index, View* view):
+    TimeAndScopeBasedRow<SingleCount>(index, scope_index, view) {};
+  ColumnData get_columns()
+  {
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME_COARSE, &now);
+
+    SingleCount accumulated = *(this->_view->get_data(now));
+
+    // Construct and return a ColumnData with the appropriate values
+    ColumnData ret;
+    ret[3] = Value::uint(accumulated.count);
+    return ret;
+  }
+};
+
+class CounterTableByScopeImpl: public ManagedTable<CounterByScopeRow, int>, public CounterByScopeTable
+{
+public:
+  CounterTableByScopeImpl(std::string name,
+                          std::string tbl_oid):
+    ManagedTable<CounterByScopeRow, int>(name,
+                                         tbl_oid,
+                                         3,
+                                         3, // Only column 3 should be visible
+                                         { ASN_INTEGER , ASN_OCTET_STR }), // Type of the index column
+    five_second(5000),
+    five_minute(300000)
+  {
+    // We have a fixed number of rows, so create them in the constructor.
+    n = 0;
+
+    this->add(n++, new_row(scopePrevious5SecondPeriod));
+    this->add(n++, new_row(scopeCurrent5MinutePeriod));
+    this->add(n++, new_row(scopePrevious5MinutePeriod));
+  }
+
+  void increment()
+  {
+    // Increment each underlying set of data.
+    five_second.get_current()->count++;
+    five_minute.get_current()->count++;
+  }
+
+private:
+  // Map row indexes to the view of the underlying data they should expose
+  CounterByScopeRow* new_row(int index)
+  {
+    CounterByScopeRow::View* view = NULL;
+    switch (index)
+    {
+      case TimePeriodIndexes::scopePrevious5SecondPeriod:
+        view = new CounterByScopeRow::PreviousView(&five_second);
+        break;
+      case TimePeriodIndexes::scopeCurrent5MinutePeriod:
+        view = new CounterByScopeRow::CurrentView(&five_minute);
+        break;
+      case TimePeriodIndexes::scopePrevious5MinutePeriod:
+        view = new CounterByScopeRow::PreviousView(&five_minute);
+        break;
+    }
+    return new CounterByScopeRow(index, "node", view);
+  }
+
+  int n;
+
+  CurrentAndPrevious<SingleCount> five_second;
+  CurrentAndPrevious<SingleCount> five_minute;
+};
+
+CounterByScopeTable* CounterByScopeTable::create(std::string name, std::string oid)
+{
+  return new CounterTableByScopeImpl(name, oid);
+}
+
+}

--- a/src/snmp_event_accumulator_by_scope_table.cpp
+++ b/src/snmp_event_accumulator_by_scope_table.cpp
@@ -1,0 +1,194 @@
+/**
+ * @file snmp_event_accumulator_by_scope_table.cpp
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2016 Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include "snmp_internal/snmp_time_period_table.h"
+#include "snmp_internal/snmp_time_period_and_scope_table.h"
+#include "snmp_event_accumulator_table.h"
+#include "snmp_event_accumulator_by_scope_table.h"
+#include "limits.h"
+
+namespace SNMP
+{
+
+// Storage for the underlying data
+struct EventStatistics
+{
+  std::atomic_uint_fast64_t count;
+  std::atomic_uint_fast64_t sum;
+  std::atomic_uint_fast64_t sqsum;
+  std::atomic_uint_fast64_t hwm;
+  std::atomic_uint_fast64_t lwm;
+
+  void reset(uint64_t periodstart, EventStatistics* previous = NULL);
+};
+
+// A TimeAndScopeBasedRow that maps the data from EventStatistics into the right five columns.
+class EventAccumulatorByScopeRow: public TimeAndScopeBasedRow<EventStatistics>
+{
+public:
+  EventAccumulatorByScopeRow(int time_index, std::string scope_index, View* view): TimeAndScopeBasedRow<EventStatistics>(time_index, scope_index, view) {};
+  ColumnData get_columns();
+};
+
+class EventAccumulatorByScopeTableImpl: public ManagedTable<EventAccumulatorByScopeRow, int>, public EventAccumulatorByScopeTable
+{
+public:
+  EventAccumulatorByScopeTableImpl(std::string name,
+                                   std::string tbl_oid):
+    ManagedTable<EventAccumulatorByScopeRow, int>(name,
+                                                  tbl_oid,
+                                                  3,
+                                                  7, // Columns 3-7 should be visible
+                                                  { ASN_INTEGER , ASN_OCTET_STR }), // Type of the index column
+    five_second(5000),
+    five_minute(300000)
+  {
+    // We have a fixed number of rows, so create them in the constructor.
+    n = 0;
+
+    this->add(n++, new_row(scopePrevious5SecondPeriod));
+    this->add(n++, new_row(scopeCurrent5MinutePeriod));
+    this->add(n++, new_row(scopePrevious5MinutePeriod));
+  }
+
+  // Accumulate a sample into the underlying statistics.
+  void accumulate(uint32_t sample)
+  {
+    // Pass samples through to the underlying data structures
+    accumulate_internal(five_second, sample);
+    accumulate_internal(five_minute, sample);
+  }
+
+private:
+  // Map row indexes to the view of the underlying data they should expose
+  EventAccumulatorByScopeRow* new_row(int index)
+  {
+    EventAccumulatorByScopeRow::View* view = NULL;
+    switch (index)
+    {
+      case TimePeriodIndexes::scopePrevious5SecondPeriod:
+        view = new EventAccumulatorByScopeRow::PreviousView(&five_second);
+        break;
+      case TimePeriodIndexes::scopeCurrent5MinutePeriod:
+        view = new EventAccumulatorByScopeRow::CurrentView(&five_minute);
+        break;
+      case TimePeriodIndexes::scopePrevious5MinutePeriod:
+        view = new EventAccumulatorByScopeRow::PreviousView(&five_minute);
+        break;
+    }
+
+    return new EventAccumulatorByScopeRow(index, "node", view);
+  }
+
+  void accumulate_internal(CurrentAndPrevious<EventStatistics>& data, uint32_t sample)
+  {
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME_COARSE, &now);
+
+    EventStatistics* current = data.get_current(now);
+
+    current->count++;
+
+    // Just keep a running total as we go along, so we can calculate the average and variance on
+    // request
+    current->sum += sample;
+    current->sqsum += (sample * sample);
+
+    // Update the low- and high-water marks.  In each case, we get the current
+    // value, decide whether a change is required and then atomically swap it
+    // if so, repeating if it was changed in the meantime.  Note that
+    // compare_exchange_weak loads the current value into the expected value
+    // parameter (lwm or hwm below) if the compare fails.
+    uint_fast64_t lwm = current->lwm.load();
+    while ((sample < lwm) &&
+           (!current->lwm.compare_exchange_weak(lwm, sample)))
+    {
+      // Do nothing.
+    }
+    uint_fast64_t hwm = current->hwm.load();
+    while ((sample > hwm) &&
+           (!current->hwm.compare_exchange_weak(hwm, sample)))
+    {
+      // Do nothing.
+    }
+  };
+
+  int n;
+
+  CurrentAndPrevious<EventStatistics> five_second;
+  CurrentAndPrevious<EventStatistics> five_minute;
+};
+
+ColumnData EventAccumulatorByScopeRow::get_columns()
+{
+  struct timespec now;
+  clock_gettime(CLOCK_REALTIME_COARSE, &now);
+
+  EventStatistics* accumulated = _view->get_data(now);
+  uint_fast32_t count = accumulated->count.load();
+
+  uint_fast32_t avg = 0;
+  uint_fast32_t variance = 0;
+  uint_fast32_t lwm = 0;
+  uint_fast32_t hwm = 0;
+
+  if (count > 0)
+  {
+    uint_fast64_t sum = accumulated->sum.load();
+    uint_fast64_t sumsq = accumulated->sqsum.load();
+    // Calculate the average and the variance from the stored sum and sum-of-squares.
+    avg = sum/count;
+    variance = ((sumsq * count) - (sum * sum)) / (count * count);
+    hwm = accumulated->hwm.load();
+    lwm = accumulated->lwm.load();
+  }
+
+  // Construct and return a ColumnData with the appropriate values
+  ColumnData ret;
+  ret[3] = Value::uint(avg);
+  ret[4] = Value::uint(variance);
+  ret[5] = Value::uint(hwm);
+  ret[6] = Value::uint(lwm);
+  ret[7] = Value::uint(count);
+  return ret;
+}
+
+EventAccumulatorByScopeTable* EventAccumulatorByScopeTable::create(std::string name, std::string oid)
+{
+  return new EventAccumulatorByScopeTableImpl(name, oid);
+}
+
+}

--- a/src/snmp_scalar.cpp
+++ b/src/snmp_scalar.cpp
@@ -64,4 +64,9 @@ U32Scalar::~U32Scalar()
   // Call into netsnmp to unregister this OID.
   unregister_mib(parsed_oid, oid_len);
 }
+
+void U32Scalar::set_value(unsigned long val)
+{
+  value = val;
+}
 }

--- a/src/snmp_scalar_by_scope_table.cpp
+++ b/src/snmp_scalar_by_scope_table.cpp
@@ -1,0 +1,100 @@
+/**
+ * @file snmp_scalar_by_scope_table.cpp
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2016 Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include "snmp_scalar_by_scope_table.h"
+#include "snmp_statistics_structures.h"
+#include "snmp_internal/snmp_includes.h"
+#include "snmp_internal/snmp_scope_table.h"
+#include "logger.h"
+
+namespace SNMP
+{
+
+// A ScopeBasedRow that maps the data from Scalar into the right column.
+class ScalarByScopeRow: public ScopeBasedRow<Scalar>
+{
+public:
+  ScalarByScopeRow(std::string scope_index, View* view):
+    ScopeBasedRow<Scalar>(scope_index, view) {};
+  ColumnData get_columns()
+  {
+    Scalar scalar = *(this->_view->get_data());
+
+    // Construct and return a ColumnData with the appropriate values
+    ColumnData ret;
+    ret[2] = Value::uint(scalar.value);
+    return ret;
+  }
+};
+
+class ScalarByScopeTableImpl: public ManagedTable<ScalarByScopeRow, std::string>, public ScalarByScopeTable
+{
+public:
+  ScalarByScopeTableImpl(std::string name,
+                         std::string tbl_oid):
+    ManagedTable<ScalarByScopeRow, std::string>(name,
+                                                tbl_oid,
+                                                2,
+                                                2, // Only column 2 should be visible
+                                                { ASN_OCTET_STR }) // Type of the index column
+  {
+    // We have a fixed number of rows, so create them in the constructor.
+    scalar.value = 0;
+    add("node");
+  }
+
+  void set_value(uint32_t value)
+  {
+    scalar.value = value;
+  }
+
+private:
+  // Map row indexes to the view of the underlying data they should expose
+  ScalarByScopeRow* new_row(std::string scope_index)
+  {
+    ScalarByScopeRow::View* view = new ScalarByScopeRow::View(&scalar);
+    return new ScalarByScopeRow(scope_index, view);
+  }
+
+  Scalar scalar;
+};
+
+ScalarByScopeTable* ScalarByScopeTable::create(std::string name, std::string oid)
+{
+  return new ScalarByScopeTableImpl(name, oid);
+}
+
+}

--- a/src/snmp_scalar_by_scope_table.cpp
+++ b/src/snmp_scalar_by_scope_table.cpp
@@ -76,7 +76,7 @@ public:
     add("node");
   }
 
-  void set_value(uint32_t value)
+  void set_value(unsigned long value)
   {
     scalar.value = value;
   }


### PR DESCRIPTION
This adds two new tables that are indexed by time period and scope (node type):
`EventAccumulatorByScopeTable`
`CounterByScopeTable`

These depend on the new time and scope based row:
`TimeAndScopeBasedRow`

See the sprout pull request for the testing that I've done.