### PR TITLE
[Reviewer: Ellie] Cassandra Connection pool changes

### DIFF
--- a/include/connection_pool.h
+++ b/include/connection_pool.h
@@ -282,7 +282,8 @@ void ConnectionPool<T>::release_connection(ConnectionInfo<T>* conn_info_ptr,
   {
     if (_free_on_error)
     {
-      // Need to destroy all connections for the same target
+      // Need to destroy all connections for the same target that are currently
+      // in the pool
       pthread_mutex_lock(&_conn_pool_lock);
 
       typename Pool::iterator slot_it = _conn_pool.find(conn_info_ptr->target);
@@ -301,7 +302,8 @@ void ConnectionPool<T>::release_connection(ConnectionInfo<T>* conn_info_ptr,
       pthread_mutex_unlock(&_conn_pool_lock);
     }
 
-    // Safely destroy the connection and its associated ConnectionInfo
+    // Now safely destroy the connection and its associated ConnectionInfo
+    // (which isn't in the pool, and hence wasn't destroyed above)
     destroy_connection(conn_info_ptr->target, conn_info_ptr->conn);
     delete conn_info_ptr; conn_info_ptr = NULL;
   }

--- a/include/connection_pool.h
+++ b/include/connection_pool.h
@@ -99,7 +99,7 @@ class ConnectionPool
   using Pool = std::map<AddrInfo, Slot>;
 
 public:
-  ConnectionPool(time_t max_idle_time_s);
+  ConnectionPool(time_t max_idle_time_s, bool free_on_error = false);
 
   /// The pool cannot be safely emptied in this destructor, as an implementation
   /// of the destroy_connection method is required to safely destroy type T
@@ -138,6 +138,10 @@ private:
   Pool _conn_pool;
   pthread_mutex_t _conn_pool_lock;
   time_t _max_idle_time_s;
+
+  // Whether one dead connection should trigger cleanup of any others to the
+  // same target
+  bool _free_on_error;
 };
 
 /// Template class storing a connection in a ConnectionInfo object. On
@@ -185,8 +189,9 @@ private:
 };
 
 template<typename T>
-ConnectionPool<T>::ConnectionPool(time_t max_idle_time_s) :
-  _max_idle_time_s(max_idle_time_s)
+ConnectionPool<T>::ConnectionPool(time_t max_idle_time_s, bool free_on_error) :
+  _max_idle_time_s(max_idle_time_s),
+  _free_on_error(free_on_error)
 {
   pthread_mutex_init(&_conn_pool_lock, NULL);
 }
@@ -275,6 +280,27 @@ void ConnectionPool<T>::release_connection(ConnectionInfo<T>* conn_info_ptr,
   }
   else
   {
+    if (_free_on_error)
+    {
+      // Need to destroy all connections for the same target
+      pthread_mutex_lock(&_conn_pool_lock);
+
+      typename Pool::iterator slot_it = _conn_pool.find(conn_info_ptr->target);
+      if (slot_it != _conn_pool.end())
+      {
+        TRC_DEBUG("Freeing %d other connections", slot_it->second.size());
+        while (!slot_it->second.empty())
+        {
+          ConnectionInfo<T>* conn_info = slot_it->second.front();
+          slot_it->second.pop_front();
+          destroy_connection(conn_info->target, conn_info->conn);
+          delete conn_info; conn_info = NULL;
+        }
+      }
+
+      pthread_mutex_unlock(&_conn_pool_lock);
+    }
+
     // Safely destroy the connection and its associated ConnectionInfo
     destroy_connection(conn_info_ptr->target, conn_info_ptr->conn);
     delete conn_info_ptr; conn_info_ptr = NULL;

--- a/src/cassandra_connection_pool.cpp
+++ b/src/cassandra_connection_pool.cpp
@@ -49,7 +49,7 @@ static const double MAX_IDLE_TIME_S = 60;
 
 // LCOV_EXCL_START - UTs do not cover the creation/deletion on Clients
 CassandraConnectionPool::CassandraConnectionPool() :
-  ConnectionPool<Client*>(MAX_IDLE_TIME_S)
+  ConnectionPool<Client*>(MAX_IDLE_TIME_S, true)
 {
 }
 

--- a/test_utils/testable_connection_pool.h
+++ b/test_utils/testable_connection_pool.h
@@ -47,6 +47,11 @@ public:
     destroy_connection_pool();
   }
 
+  void set_free_on_error(bool free_on_error)
+  {
+    _free_on_error = free_on_error;
+  }
+
 protected:
   MOCK_METHOD1(create_connection, int(AddrInfo target));
   MOCK_METHOD2(destroy_connection, void(AddrInfo target, int conn));


### PR DESCRIPTION
If the cassandra process goes down and comes back up, connections to that
process are no longer valid and should be torn down and recreated.

So this commit adds a member variable to the connection pool. If true, when a
connection is released but marked not to be returned to the pool, then all
existing connections in the pool for the same target are destroyed too.

This is false by default, and only true for the CassandraConnectionPool. This
means that when one bad Cassandra connection is found, the others are
proactively destroyed.

**Testing done**
- UTs (see the cpp-common-test branch)
- live tests