### PR TITLE
[Reviewer: CJR] Update to datestamp for SAS resource bundle

### DIFF
--- a/include/sasevent.h
+++ b/include/sasevent.h
@@ -42,7 +42,7 @@
 
 namespace SASEvent {
 
-  const std::string CURRENT_RESOURCE_BUNDLE_DATESTAMP = "20161025";
+  const std::string CURRENT_RESOURCE_BUNDLE_DATESTAMP = "20161103";
   const std::string RESOURCE_BUNDLE_NAME = "org.projectclearwater";
   const std::string CURRENT_RESOURCE_BUNDLE =
                  RESOURCE_BUNDLE_NAME + "." + CURRENT_RESOURCE_BUNDLE_DATESTAMP;


### PR DESCRIPTION
SAS resource bundle has been updated with a new datestamp, changing sasevent.h to use this new datestamp.