### PR TITLE
Https support

### DIFF
--- a/include/httpconnection.h
+++ b/include/httpconnection.h
@@ -80,13 +80,15 @@ public:
                  SNMP::IPCountTable* stat_table,
                  LoadMonitor* load_monitor,
                  SASEvent::HttpLogLevel,
-                 BaseCommunicationMonitor* comm_monitor);
+                 BaseCommunicationMonitor* comm_monitor,
+                 const std::string& scheme = "http");
 
   HttpConnection(const std::string& server,
                  bool assert_user,
                  HttpResolver* resolver,
                  SASEvent::HttpLogLevel,
-                 BaseCommunicationMonitor* comm_monitor);
+                 BaseCommunicationMonitor* comm_monitor,
+                 const std::string& scheme = "http");
 
   virtual ~HttpConnection();
 
@@ -295,6 +297,7 @@ private:
 
   std::string _server;
   std::string _host;
+  std::string _scheme;
   int _port;
   const bool _assert_user;
   pthread_key_t _curl_thread_local;

--- a/src/httpconnection.cpp
+++ b/src/httpconnection.cpp
@@ -92,9 +92,11 @@ HttpConnection::HttpConnection(const std::string& server,
                                SNMP::IPCountTable* stat_table,
                                LoadMonitor* load_monitor,
                                SASEvent::HttpLogLevel sas_log_level,
-                               BaseCommunicationMonitor* comm_monitor) :
+                               BaseCommunicationMonitor* comm_monitor,
+                               const std::string& scheme) :
   _server(server),
   _host(host_from_server(server)),
+  _scheme(scheme),
   _port(port_from_server(server)),
   _assert_user(assert_user),
   _resolver(resolver),
@@ -127,9 +129,11 @@ HttpConnection::HttpConnection(const std::string& server,
                                bool assert_user,
                                HttpResolver* resolver,
                                SASEvent::HttpLogLevel sas_log_level,
-                               BaseCommunicationMonitor* comm_monitor) :
+                               BaseCommunicationMonitor* comm_monitor,
+                               const std::string& scheme) :
   _server(server),
   _host(host_from_server(server)),
+  _scheme(scheme),
   _port(port_from_server(server)),
   _assert_user(assert_user),
   _resolver(resolver),
@@ -484,7 +488,7 @@ HTTPCode HttpConnection::send_request(const std::string& path,                 /
                                       std::vector<std::string> headers_to_add, //< Extra headers to add to the request
                                       CURL* curl)
 {
-  std::string url = "http://" + _server + path;
+  std::string url = _scheme + "://" + _server + path;
   struct curl_slist *extra_headers = NULL;
   PoolEntry* entry;
   CURLcode rc = curl_easy_getinfo(curl, CURLINFO_PRIVATE, (char**)&entry);
@@ -590,22 +594,58 @@ HTTPCode HttpConnection::send_request(const std::string& path,                 /
        i != targets.end();
        ++i)
   {
+    TRC_DEBUG("recycle_conn: %d", recycle_conn);
     curl_easy_setopt(curl, CURLOPT_FRESH_CONNECT, recycle_conn ? 1L : 0L);
 
-    // Convert the target IP address into a string and fix up the URL.  It
-    // would be nice to use curl_easy_setopt(CURL_RESOLVE) here, but its
-    // implementation is incomplete.
+    std::string ip_url;
+    struct curl_slist *host_resolve_add_addr = NULL;
+    struct curl_slist *host_resolve_remove_addr = NULL;
+
     char buf[100];
     remote_ip = inet_ntop(i->address.af, &i->address.addr, buf, sizeof(buf));
-    std::string ip_url;
-    if (i->address.af == AF_INET6)
+
+    if (_scheme == "http")
     {
-      ip_url = "http://[" + std::string(remote_ip) + "]:" + std::to_string(i->port) + path;
+      TRC_DEBUG("scheme == http");
+
+      // Convert the target IP address into a string and fix up the URL.  It
+      // would be nice to use curl_easy_setopt(CURL_RESOLVE) here, but its
+      // implementation is incomplete.
+      if (i->address.af == AF_INET6)
+      {
+        ip_url = "http://[" + std::string(remote_ip) + "]:" + std::to_string(i->port) + path;
+      }
+      else
+      {
+        ip_url = "http://" + std::string(remote_ip) + ":" + std::to_string(i->port) + path;
+      }
     }
     else
     {
-      ip_url = "http://" + std::string(remote_ip) + ":" + std::to_string(i->port) + path;
+      TRC_DEBUG("scheme == https");
+
+      // https
+      ip_url = "https://" + _host + ":" + std::to_string(i->port) + path;
+      TRC_DEBUG("ip_url: %s", ip_url.c_str());
+
+      std::string resolve_addr =
+        _host + ":" + std::to_string(i->port) + ":" + remote_ip;
+      TRC_DEBUG("resolve_addr: %s", resolve_addr.c_str());
+
+      host_resolve_add_addr = curl_slist_append(
+        host_resolve_add_addr,
+        resolve_addr.c_str());
+      TRC_DEBUG("Created host_resolve_add_addr");
+
+      host_resolve_remove_addr = curl_slist_append(
+        host_resolve_remove_addr,
+        (std::string("-") + _host + ":" + std::to_string(i->port)).c_str());
+      TRC_DEBUG("Created host_resolve_remove_addr");
+
+      TRC_DEBUG("Set CURLOPT_RESOLVE: %s", resolve_addr.c_str());
+      curl_easy_setopt(curl, CURLOPT_RESOLVE, host_resolve_add_addr);
     }
+    TRC_DEBUG("Set CURLOPT_URL: %s", ip_url.c_str());
     curl_easy_setopt(curl, CURLOPT_URL, ip_url.c_str());
 
     // Create and register an object to record the HTTP transaction.
@@ -627,6 +667,19 @@ HTTPCode HttpConnection::send_request(const std::string& path,                 /
     if (recorder.request.length() > 0)
     {
       sas_log_http_req(trail, curl, method_str, url, recorder.request, req_timestamp, 0);
+    }
+
+    if (host_resolve_add_addr)
+    {
+      curl_slist_free_all(host_resolve_add_addr);
+      host_resolve_add_addr = NULL;
+    }
+
+    if (host_resolve_remove_addr)
+    {
+      curl_easy_setopt(curl, CURLOPT_RESOLVE, host_resolve_remove_addr);
+      curl_slist_free_all(host_resolve_remove_addr);
+      host_resolve_remove_addr = NULL;
     }
 
     // Log the result of the request.

--- a/src/httpconnection.cpp
+++ b/src/httpconnection.cpp
@@ -604,47 +604,26 @@ HTTPCode HttpConnection::send_request(const std::string& path,                 /
     char buf[100];
     remote_ip = inet_ntop(i->address.af, &i->address.addr, buf, sizeof(buf));
 
-    if (_scheme == "http")
-    {
-      TRC_DEBUG("scheme == http");
+    ip_url = _scheme + "://" + _host + ":" + std::to_string(i->port) + path;
+    TRC_DEBUG("ip_url: %s", ip_url.c_str());
 
-      // Convert the target IP address into a string and fix up the URL.  It
-      // would be nice to use curl_easy_setopt(CURL_RESOLVE) here, but its
-      // implementation is incomplete.
-      if (i->address.af == AF_INET6)
-      {
-        ip_url = "http://[" + std::string(remote_ip) + "]:" + std::to_string(i->port) + path;
-      }
-      else
-      {
-        ip_url = "http://" + std::string(remote_ip) + ":" + std::to_string(i->port) + path;
-      }
-    }
-    else
-    {
-      TRC_DEBUG("scheme == https");
+    std::string resolve_addr =
+      _host + ":" + std::to_string(i->port) + ":" + remote_ip;
+    TRC_DEBUG("resolve_addr: %s", resolve_addr.c_str());
 
-      // https
-      ip_url = "https://" + _host + ":" + std::to_string(i->port) + path;
-      TRC_DEBUG("ip_url: %s", ip_url.c_str());
+    host_resolve_add_addr = curl_slist_append(
+      host_resolve_add_addr,
+      resolve_addr.c_str());
+    TRC_DEBUG("Created host_resolve_add_addr");
 
-      std::string resolve_addr =
-        _host + ":" + std::to_string(i->port) + ":" + remote_ip;
-      TRC_DEBUG("resolve_addr: %s", resolve_addr.c_str());
+    host_resolve_remove_addr = curl_slist_append(
+      host_resolve_remove_addr,
+      (std::string("-") + _host + ":" + std::to_string(i->port)).c_str());
+    TRC_DEBUG("Created host_resolve_remove_addr");
 
-      host_resolve_add_addr = curl_slist_append(
-        host_resolve_add_addr,
-        resolve_addr.c_str());
-      TRC_DEBUG("Created host_resolve_add_addr");
+    TRC_DEBUG("Set CURLOPT_RESOLVE: %s", resolve_addr.c_str());
+    curl_easy_setopt(curl, CURLOPT_RESOLVE, host_resolve_add_addr);
 
-      host_resolve_remove_addr = curl_slist_append(
-        host_resolve_remove_addr,
-        (std::string("-") + _host + ":" + std::to_string(i->port)).c_str());
-      TRC_DEBUG("Created host_resolve_remove_addr");
-
-      TRC_DEBUG("Set CURLOPT_RESOLVE: %s", resolve_addr.c_str());
-      curl_easy_setopt(curl, CURLOPT_RESOLVE, host_resolve_add_addr);
-    }
     TRC_DEBUG("Set CURLOPT_URL: %s", ip_url.c_str());
     curl_easy_setopt(curl, CURLOPT_URL, ip_url.c_str());
 

--- a/test_utils/curl_interposer.cpp
+++ b/test_utils/curl_interposer.cpp
@@ -358,6 +358,30 @@ CURLcode curl_easy_setopt(CURL* handle, CURLoption option, ...)
     curl->_verbose = (verbose_flag != 0);
   }
   break;
+  case CURLOPT_RESOLVE:
+  {
+    struct curl_slist* hosts = va_arg(args, struct curl_slist*);
+    std::list<std::string>* truelist = (std::list<std::string>*)hosts;
+    for (std::list<std::string>::iterator it = truelist->begin(); it != truelist->end(); ++it)
+    {
+      std::string mapping = *it;
+      if (mapping.at(0) == '-')
+      {
+        mapping.erase(0, 1);
+        curl->_resolves.erase(mapping);
+      }
+      else
+      {
+        size_t first_colon = mapping.find(':');
+        size_t second_colon = mapping.find(':', first_colon + 1);
+        std::string host = mapping.substr(0, first_colon);
+        std::string colon_and_port = mapping.substr(first_colon, second_colon - first_colon);
+        std::string ip = mapping.substr(second_colon + 1);
+        curl->_resolves[host + colon_and_port] = ip + colon_and_port;
+      }
+    }
+  }
+  break;
   case CURLOPT_MAXCONNECTS:
   case CURLOPT_TIMEOUT_MS:
   case CURLOPT_CONNECTTIMEOUT_MS:

--- a/test_utils/fakecurl.cpp
+++ b/test_utils/fakecurl.cpp
@@ -65,9 +65,20 @@ CURLcode FakeCurl::easy_perform(FakeCurl* curl)
 
   fakecurl_requests[_url] = req;
 
+  // If we've been told how to resolve this URL, do so.
+  std::string resolved = _url;
+  size_t slash_slash_pos = _url.find("//");
+  size_t slash_pos = _url.find('/', slash_slash_pos + 2);
+  std::string host_and_port = _url.substr(slash_slash_pos + 2, slash_pos - (slash_slash_pos + 2));
+  std::map<std::string, std::string>::iterator it = _resolves.find(host_and_port);
+  if (it != _resolves.end())
+  {
+    resolved = _url.replace(slash_slash_pos + 2, host_and_port.length(), it->second);
+  }
+
   // Check if there's a response ready.
-  auto iter = fakecurl_responses.find(_url);
-  auto iter2 = fakecurl_responses_with_body.find(pair<string, string>(_url, _body));
+  auto iter = fakecurl_responses.find(resolved);
+  auto iter2 = fakecurl_responses_with_body.find(pair<string, string>(resolved, _body));
 
   Response* resp;
   if (iter != fakecurl_responses.end())

--- a/test_utils/fakecurl.hpp
+++ b/test_utils/fakecurl.hpp
@@ -145,6 +145,10 @@ public:
   std::string _password;
   bool _fresh;
 
+  // Map of hostname + port -> IP address + port, as configured with
+  // CURLOPT_RESOLVE.
+  std::map<std::string, std::string> _resolves;
+
   datafn_ty _readfn;
   void* _readdata; //^ user data; not owned by this object
 


### PR DESCRIPTION
Add support for querying https servers.

There are two commits here:

- the first is John's original, in which the handling of http queries is untouched, and is what we're currently actually running with
- but the asymmetry between http and https here bothered me, so the second re-unifies them
  -  not sure what the original code was getting at when it claimed that the `CURL_RESOLVE` implementation is 'incomplete' - maybe I've missed something?

I think that the general principle here should be uncontroversial; I'd be happy if you'd take either the one-commit or two-commit version of the fix.

If you take the two-commit version there are some (very minor) UT changes needed to accompany it in sprout and memento (requests now go to hostname rather than to IP address, which a handful of scripts notice).  I have those ready to go but won't submit pull requests until we agree that this is the right plan.