### PR TITLE
Made the error cases in get_x_real_ip_port clearer

### DIFF
--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -479,6 +479,8 @@ bool HttpStack::Request::get_x_real_ip_port(std::string& ip, unsigned short& por
     ip = real_ip;
     std::string port_s = header("X-Real-Port");
     int port_i;
+    // We have a real IP, if we cannot get a real port we fail softly
+    port = 0;
 
     if (port_s != "" && (std::all_of(port_s.begin(), port_s.end(), ::isdigit)))
     {
@@ -488,15 +490,11 @@ bool HttpStack::Request::get_x_real_ip_port(std::string& ip, unsigned short& por
       }
       catch (...)
       {
-        port_i = 0;
+        port_i = -1;
       }
-      if (port_i > 0 && port_i < USHRT_MAX)
+      if (port_i >= 0 && port_i < USHRT_MAX)
       {
         port = (short)port_i;
-      }
-      else
-      {
-        port = 0;
       }
     }
   }

--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -487,14 +487,14 @@ bool HttpStack::Request::get_x_real_ip_port(std::string& ip, unsigned short& por
       try
       {
         port_i = std::stoi(port_s);
+        if (port_i >= 0 && port_i <= USHRT_MAX)
+        {
+          port = (short)port_i;
+        }
       }
       catch (...)
       {
-        port_i = -1;
-      }
-      if (port_i >= 0 && port_i < USHRT_MAX)
-      {
-        port = (short)port_i;
+        // port is already set to 0, so do nothing here.
       }
     }
   }


### PR DESCRIPTION
Not really a bug fix, but these modifications make it a lot clearer what happens when proxied_sas_logger receives a request with an x-real-ip header, but missing an x-real-port header. 

The previous implementation relied on the default value of shorts being 0, which works, but hides what the error handling is doing.