### PR TITLE
[Reviewer: Matt] Thread safer stats

### DIFF
--- a/src/snmp_continuous_increment_table.cpp
+++ b/src/snmp_continuous_increment_table.cpp
@@ -40,7 +40,6 @@
 #include "snmp_internal/snmp_time_period_table.h"
 #include "snmp_continuous_increment_table.h"
 #include "limits.h"
-std::mutex _mutex;
 
 std::mutex _cont_inc_mutex;
 
@@ -188,7 +187,6 @@ ColumnData ContinuousAccumulatorRow::get_columns()
   struct timespec now;
   clock_gettime(CLOCK_REALTIME_COARSE, &now);
 
-  _mutex.lock();
   ContinuousStatistics* accumulated = _view->get_data(now);
   uint32_t interval_ms = _view->get_interval_ms();
 
@@ -238,7 +236,6 @@ ColumnData ContinuousAccumulatorRow::get_columns()
     avg = sum / period_count;
     variance = ((sqsum * period_count) - (sum * sum)) / (period_count * period_count);
   }
-  _mutex.unlock();
 
   // Construct and return a ColumnData with the appropriate values
   ColumnData ret;

--- a/src/snmp_continuous_increment_table.cpp
+++ b/src/snmp_continuous_increment_table.cpp
@@ -42,6 +42,8 @@
 #include "limits.h"
 std::mutex _mutex;
 
+std::mutex _cont_inc_mutex;
+
 namespace SNMP
 {
 // Just a TimeBasedRow that maps the data from ContinuousStatistics into the right five columns.
@@ -76,19 +78,19 @@ public:
   void increment(uint32_t value)
   {
     // Pass value as increment through to value adjusting structure.
-    _mutex.lock();
+    _cont_inc_mutex.lock();
     count_internal(five_second, value, TRUE);
     count_internal(five_minute, value, TRUE);
-    _mutex.unlock();
+    _cont_inc_mutex.unlock();
   }
 
   void decrement(uint32_t value)
   {
     // Pass value as decrement through to value adjusting structure.
-    _mutex.lock();
+    _cont_inc_mutex.lock();
     count_internal(five_second, value, FALSE);
     count_internal(five_minute, value, FALSE);
-    _mutex.unlock();
+    _cont_inc_mutex.unlock();
   }
 
 private:

--- a/src/snmp_infinite_scalar_table.cpp
+++ b/src/snmp_infinite_scalar_table.cpp
@@ -37,7 +37,7 @@
 #include <string>
 #include <algorithm>
 #include <memory>
-#include <atomic>
+#include <mutex>
 
 #include "snmp_infinite_scalar_table.h"
 #include "snmp_row.h"
@@ -45,6 +45,7 @@
 
 #include "log.h"
 #include "logger.h"
+
 
 namespace SNMP
 {
@@ -59,22 +60,31 @@ namespace SNMP
     
     void increment(std::string tag, uint32_t count)
     {
+      _mutex.lock();
       _scalar_counters[tag] += count;
+      _mutex.unlock();
     }
 
     void decrement(std::string tag, uint32_t count)
     {
       // Ensure scalar value does not become negative
+      _mutex.lock();
       if (_scalar_counters[tag] > count)
-        _scalar_counters[tag] -= count;
+        {
+          _scalar_counters[tag] -= count;
+        }
       else
-        _scalar_counters[tag] = 0;
+        {
+          _scalar_counters[tag] = 0;
+        }
+      _mutex.unlock();
     }
 
   protected:
     static const uint32_t max_row = 1;
     static const uint32_t max_column = 2;
-    std::map<std::string, std::atomic<std::uint32_t>> _scalar_counters;
+    std::map<std::string, uint32_t> _scalar_counters;
+    std::mutex _mutex;
 
   private:
     Value get_value(std::string tag,
@@ -92,10 +102,12 @@ namespace SNMP
         return Value::uint(0);
       }
 
+      _mutex.lock();
       if (_scalar_counters.count(tag) > 0)
       {
         result = Value::uint(_scalar_counters[tag]);
       }
+      _mutex.unlock();
 
       TRC_DEBUG("Got value %u for tag %s cell (%d, %d)",
                 *result.value, tag.c_str(), row, column);

--- a/src/snmp_infinite_scalar_table.cpp
+++ b/src/snmp_infinite_scalar_table.cpp
@@ -37,6 +37,7 @@
 #include <string>
 #include <algorithm>
 #include <memory>
+#include <atomic>
 
 #include "snmp_infinite_scalar_table.h"
 #include "snmp_row.h"
@@ -51,7 +52,7 @@ namespace SNMP
   {
   public:
     InfiniteScalarTableImpl(std::string name, // Name of this table, for logging
-                                std::string tbl_oid):// Root OID of this table
+                            std::string tbl_oid):// Root OID of this table
     InfiniteBaseTable(name, tbl_oid, max_row, max_column){}
 
     virtual ~InfiniteScalarTableImpl(){};
@@ -73,7 +74,7 @@ namespace SNMP
   protected:
     static const uint32_t max_row = 1;
     static const uint32_t max_column = 2;
-    std::map<std::string, uint32_t> _scalar_counters;
+    std::map<std::string, std::atomic<std::uint32_t>> _scalar_counters;
 
   private:
     Value get_value(std::string tag,

--- a/src/snmp_infinite_timer_count_table.cpp
+++ b/src/snmp_infinite_timer_count_table.cpp
@@ -37,6 +37,7 @@
 #include <string>
 #include <algorithm>
 #include <memory>
+#include <mutex>
 
 #include "snmp_statistics_structures.h"
 #include "snmp_infinite_timer_count_table.h"
@@ -60,18 +61,23 @@ namespace SNMP
     
     void increment(std::string tag, uint32_t count)
     {
+      _mutex.lock();
       _timer_counters[tag].increment(count);
+      _mutex.unlock();
     }
 
     void decrement(std::string tag, uint32_t count)
     {
+      _mutex.lock();
       _timer_counters[tag].decrement(count);
+      _mutex.unlock();
     }
 
   protected:
     static const uint32_t max_row = 3;
     static const uint32_t max_column = 5;
     std::map<std::string, TimerCounter> _timer_counters;
+    std::mutex _mutex;
 
   private:
     Value get_value(std::string tag,
@@ -82,8 +88,10 @@ namespace SNMP
       SimpleStatistics stats;
       Value result = Value::uint(0);
       // Update and obtain the relevants statistics structure
+      _mutex.lock();
       _timer_counters[tag].get_statistics(row, now, &stats);
-      
+      _mutex.unlock();
+
       // Calculate the appropriate value - i.e. avg, var, hwm or lwm
       result = read_column(&stats, tag, column, now);
       TRC_DEBUG("Got value %u for tag %s cell (%d, %d)",

--- a/src/snmp_infinite_timer_count_table.cpp
+++ b/src/snmp_infinite_timer_count_table.cpp
@@ -37,7 +37,6 @@
 #include <string>
 #include <algorithm>
 #include <memory>
-#include <mutex>
 
 #include "snmp_statistics_structures.h"
 #include "snmp_infinite_timer_count_table.h"
@@ -61,23 +60,18 @@ namespace SNMP
     
     void increment(std::string tag, uint32_t count)
     {
-      _mutex.lock();
       _timer_counters[tag].increment(count);
-      _mutex.unlock();
     }
 
     void decrement(std::string tag, uint32_t count)
     {
-      _mutex.lock();
       _timer_counters[tag].decrement(count);
-      _mutex.unlock();
     }
 
   protected:
     static const uint32_t max_row = 3;
     static const uint32_t max_column = 5;
     std::map<std::string, TimerCounter> _timer_counters;
-    std::mutex _mutex;
 
   private:
     Value get_value(std::string tag,
@@ -88,9 +82,7 @@ namespace SNMP
       SimpleStatistics stats;
       Value result = Value::uint(0);
       // Update and obtain the relevants statistics structure
-      _mutex.lock();
       _timer_counters[tag].get_statistics(row, now, &stats);
-      _mutex.unlock();
 
       // Calculate the appropriate value - i.e. avg, var, hwm or lwm
       result = read_column(&stats, tag, column, now);

--- a/src/timer_counter.cpp
+++ b/src/timer_counter.cpp
@@ -135,16 +135,17 @@ void TimerCounter::write_statistics(SNMP::ContinuousStatistics* data, int value_
   // using the new current value.
   do
   {
-    new_value = 0;
-
     // Ensure value_delta is less than or equal to the current value if negative.
     // If value_delta would cause new_value to underflow, leave new_value as 0.
-    if ((value_delta > 0) || ((uint64_t)abs(value_delta) <= current_value))
+    if ((value_delta > 0) || ((uint64_t)-value_delta <= current_value))
     {
       new_value = current_value + value_delta;
     }
-
-  }while(!data->current_value.compare_exchange_weak(current_value, new_value));
+    else
+    {
+      new_value = 0;
+    }
+  } while (!data->current_value.compare_exchange_weak(current_value, new_value));
 
   // Update the low- and high-water marks.  In each case, we get the current
   // value, decide whether a change is required and then atomically swap it


### PR DESCRIPTION
All the areas we discussed, and rested with locks, are now using atomic functions to ensure we set the right value, or re-do the calculation with a new starting point.

In the continuous increment table, to do this, I have moved where we set the new value for `current_value` up to before all of the average, sum etc. calculations, which occur at the top of `accumulate_internal`. This means that they will be calculated using the new `current_value` rather than the old `current_value`. 
I'm not sure if this is a big issue for the statistics, are you able to comment at all on that?

In testing, this now appears to resolve the three Chronos stats issues:
https://github.com/Metaswitch/chronos/issues/328
https://github.com/Metaswitch/chronos/issues/329
https://github.com/Metaswitch/chronos/issues/330

