### PR TITLE
[Reviewer: AJH] Rename path to url_tail

### DIFF
--- a/include/httpconnection.h
+++ b/include/httpconnection.h
@@ -94,8 +94,9 @@ public:
 
   /// Sends a HTTP GET request to _server with the specified parameters
   ///
-  /// @param path           Absolute path to request from server - must start
-  ///                       with "/"
+  /// @param url_tail       Everything after the server part of the URL - must
+  ///                       start with "/" and can contain path, query and
+  ///                       fragment parts.
   /// @param headers        Location to store the header part of the retrieved
   ///                       data
   /// @param response       Location to store retrieved data
@@ -105,17 +106,17 @@ public:
   /// @param trail          SAS trail to use
   ///
   /// @returns              HTTP code representing outcome of request
-  virtual long send_get(const std::string& path,
+  virtual long send_get(const std::string& url_tail,
                         std::map<std::string, std::string>& headers,
                         std::string& response,
                         const std::string& username,
                         std::vector<std::string> headers_to_add,
                         SAS::TrailId trail);
-  virtual long send_get(const std::string& path,
+  virtual long send_get(const std::string& url_tail,
                         std::string& response,
                         const std::string& username,
                         SAS::TrailId trail);
-  virtual long send_get(const std::string& path,
+  virtual long send_get(const std::string& url_tail,
                         std::map<std::string, std::string>& headers,
                         std::string& response,
                         const std::string& username,
@@ -123,8 +124,9 @@ public:
 
   /// Sends a HTTP DELETE request to _server with the specified parameters
   ///
-  /// @param path     Absolute path to request from server - must start
-  ///                 with "/"
+  /// @param url_tail Everything after the server part of the URL - must
+  ///                 start with "/". Contains path, query and fragment
+  ///                 parts.
   /// @param headers  Location to store the header part of the retrieved
   ///                 data
   /// @param response Location to store retrieved data
@@ -134,24 +136,25 @@ public:
   ///                 ignored
   ///
   /// @returns        HTTP code representing outcome of request
-  virtual long send_delete(const std::string& path,
+  virtual long send_delete(const std::string& url_tail,
                            std::map<std::string, std::string>& headers,
                            std::string& response,
                            SAS::TrailId trail,
                            const std::string& body = "",
                            const std::string& username = "");
-  virtual long send_delete(const std::string& path,
+  virtual long send_delete(const std::string& url_tail,
                            SAS::TrailId trail,
                            const std::string& body = "");
-  virtual long send_delete(const std::string& path,
+  virtual long send_delete(const std::string& url_tail,
                            SAS::TrailId trail,
                            const std::string& body,
                            std::string& response);
 
   /// Sends a HTTP PUT request to _server with the specified parameters
   ///
-  /// @param path              Absolute path to request from server - must start
-  ///                          with "/"
+  /// @param url_tail          Everything after the server part of the URL - must
+  ///                          start with "/" and can contain path, query and
+  ///                          fragment parts
   /// @param headers           Location to store the header part of the retrieved
   ///                          data
   /// @param response          Location to store retrieved data
@@ -162,7 +165,7 @@ public:
   ///                          ignored
   ///
   /// @returns                 HTTP code representing outcome of request
-  virtual long send_put(const std::string& path,
+  virtual long send_put(const std::string& url_tail,
                         std::map<std::string, std::string>& headers,
                         std::string& response,
                         const std::string& body,
@@ -170,16 +173,16 @@ public:
                         SAS::TrailId trail,
                         const std::string& username = "");
 
-  virtual long send_put(const std::string& path,
+  virtual long send_put(const std::string& url_tail,
                         const std::string& body,
                         SAS::TrailId trail,
                         const std::string& username = "");
-  virtual long send_put(const std::string& path,
+  virtual long send_put(const std::string& url_tail,
                         std::string& response,
                         const std::string& body,
                         SAS::TrailId trail,
                         const std::string& username = "");
-  virtual long send_put(const std::string& path,
+  virtual long send_put(const std::string& url_tail,
                         std::map<std::string, std::string>& headers,
                         const std::string& body,
                         SAS::TrailId trail,
@@ -187,8 +190,9 @@ public:
 
   /// Sends a HTTP POST request to _server with the specified parameters
   ///
-  /// @param path     Absolute path to request from server - must start
-  ///                 with "/"
+  /// @param url_tail Everything after the server part of the URL - must
+  ///                 start with "/" and can contain path, query and
+  ///                 fragment parts
   /// @param headers  Location to store the header part of the retrieved
   ///                 data
   /// @param response Location to store retrieved data
@@ -198,14 +202,14 @@ public:
   ///                 ignored
   ///
   /// @returns        HTTP code representing outcome of request
-  virtual long send_post(const std::string& path,
+  virtual long send_post(const std::string& url_tail,
                          std::map<std::string, std::string>& headers,
                          std::string& response,
                          const std::string& body,
                          SAS::TrailId trail,
                          const std::string& username = "");
 
-  virtual long send_post(const std::string& path,
+  virtual long send_post(const std::string& url_tail,
                          std::map<std::string, std::string>& headers,
                          const std::string& body,
                          SAS::TrailId trail,

--- a/src/httpconnection.cpp
+++ b/src/httpconnection.cpp
@@ -36,34 +36,34 @@
 
 #include "httpconnection.h"
 
-HTTPCode HttpConnection::send_delete(const std::string& path,
+HTTPCode HttpConnection::send_delete(const std::string& url_tail,
                                      SAS::TrailId trail,
                                      const std::string& body)
 {
-  return _client.send_delete(_scheme + "://" + _server + path,
+  return _client.send_delete(_scheme + "://" + _server + url_tail,
                              trail,
                              body);
 }
 
-HTTPCode HttpConnection::send_delete(const std::string& path,
+HTTPCode HttpConnection::send_delete(const std::string& url_tail,
                                      SAS::TrailId trail,
                                      const std::string& body,
                                      std::string& response)
 {
-  return _client.send_delete(_scheme + "://" + _server + path,
+  return _client.send_delete(_scheme + "://" + _server + url_tail,
                              trail,
                              body,
                              response);
 }
 
-HTTPCode HttpConnection::send_delete(const std::string& path,
+HTTPCode HttpConnection::send_delete(const std::string& url_tail,
                                      std::map<std::string, std::string>& headers,
                                      std::string& response,
                                      SAS::TrailId trail,
                                      const std::string& body,
                                      const std::string& username)
 {
-  return _client.send_delete(_scheme + "://" + _server + path,
+  return _client.send_delete(_scheme + "://" + _server + url_tail,
                              headers,
                              response,
                              trail,
@@ -71,44 +71,44 @@ HTTPCode HttpConnection::send_delete(const std::string& path,
                              username);
 }
 
-HTTPCode HttpConnection::send_put(const std::string& path,
+HTTPCode HttpConnection::send_put(const std::string& url_tail,
                                   const std::string& body,
                                   SAS::TrailId trail,
                                   const std::string& username)
 {
-  return _client.send_put(_scheme + "://" + _server + path,
+  return _client.send_put(_scheme + "://" + _server + url_tail,
                           body,
                           trail,
                           username);
 }
 
-HTTPCode HttpConnection::send_put(const std::string& path,
+HTTPCode HttpConnection::send_put(const std::string& url_tail,
                                   std::string& response,
                                   const std::string& body,
                                   SAS::TrailId trail,
                                   const std::string& username)
 {
-  return _client.send_put(_scheme + "://" + _server + path,
+  return _client.send_put(_scheme + "://" + _server + url_tail,
                           response,
                           body,
                           trail,
                           username);
 }
 
-HTTPCode HttpConnection::send_put(const std::string& path,
+HTTPCode HttpConnection::send_put(const std::string& url_tail,
                                   std::map<std::string, std::string>& headers,
                                   const std::string& body,
                                   SAS::TrailId trail,
                                   const std::string& username)
 {
-  return _client.send_put(_scheme + "://" + _server + path,
+  return _client.send_put(_scheme + "://" + _server + url_tail,
                           headers,
                           body,
                           trail,
                           username);
 }
 
-HTTPCode HttpConnection::send_put(const std::string& path,
+HTTPCode HttpConnection::send_put(const std::string& url_tail,
                                   std::map<std::string, std::string>& headers,
                                   std::string& response,
                                   const std::string& body,
@@ -116,7 +116,7 @@ HTTPCode HttpConnection::send_put(const std::string& path,
                                   SAS::TrailId trail,
                                   const std::string& username)
 {
-  return _client.send_put(_scheme + "://" + _server + path,
+  return _client.send_put(_scheme + "://" + _server + url_tail,
                           headers,
                           response,
                           body,
@@ -125,27 +125,27 @@ HTTPCode HttpConnection::send_put(const std::string& path,
                           username);
 }
 
-HTTPCode HttpConnection::send_post(const std::string& path,
+HTTPCode HttpConnection::send_post(const std::string& url_tail,
                                    std::map<std::string, std::string>& headers,
                                    const std::string& body,
                                    SAS::TrailId trail,
                                    const std::string& username)
 {
-  return _client.send_post(_scheme + "://" + _server + path,
+  return _client.send_post(_scheme + "://" + _server + url_tail,
                            headers,
                            body,
                            trail,
                            username);
 }
 
-HTTPCode HttpConnection::send_post(const std::string& path,
+HTTPCode HttpConnection::send_post(const std::string& url_tail,
                                    std::map<std::string, std::string>& headers,
                                    std::string& response,
                                    const std::string& body,
                                    SAS::TrailId trail,
                                    const std::string& username)
 {
-  return _client.send_post(_scheme + "://" + _server + path,
+  return _client.send_post(_scheme + "://" + _server + url_tail,
                            headers,
                            response,
                            body,
@@ -154,25 +154,25 @@ HTTPCode HttpConnection::send_post(const std::string& path,
 }
 
 /// Get data; return a HTTP return code
-HTTPCode HttpConnection::send_get(const std::string& path,
+HTTPCode HttpConnection::send_get(const std::string& url_tail,
                                   std::string& response,
                                   const std::string& username,
                                   SAS::TrailId trail)
 {
-  return _client.send_get(_scheme + "://" + _server + path,
+  return _client.send_get(_scheme + "://" + _server + url_tail,
                           response,
                           username,
                           trail);
 }
 
 /// Get data; return a HTTP return code
-HTTPCode HttpConnection::send_get(const std::string& path,
+HTTPCode HttpConnection::send_get(const std::string& url_tail,
                                   std::map<std::string, std::string>& headers,
                                   std::string& response,
                                   const std::string& username,
                                   SAS::TrailId trail)
 {
-  return _client.send_get(_scheme + "://" + _server + path,
+  return _client.send_get(_scheme + "://" + _server + url_tail,
                           headers,
                           response,
                           username,
@@ -180,14 +180,14 @@ HTTPCode HttpConnection::send_get(const std::string& path,
 }
 
 /// Get data; return a HTTP return code
-HTTPCode HttpConnection::send_get(const std::string& path,
+HTTPCode HttpConnection::send_get(const std::string& url_tail,
                                   std::map<std::string, std::string>& headers,
                                   std::string& response,
                                   const std::string& username,
                                   std::vector<std::string> headers_to_add,
                                   SAS::TrailId trail)
 {
-  return _client.send_get(_scheme + "://" + _server + path,
+  return _client.send_get(_scheme + "://" + _server + url_tail,
                           headers,
                           response,
                           username,


### PR DESCRIPTION
This path variable can contain the path, query and fragment parts, so it is more correct to call it the url_tail.