### PR TITLE
[Reviewer: Ellie] Don't convert alarm names to title case

### DIFF
--- a/include/json_alarms.h
+++ b/include/json_alarms.h
@@ -75,10 +75,6 @@ namespace JSONAlarms
                                  std::string& error,
                                  std::vector<AlarmDef::AlarmDefinition>& alarms);
 
-  // Processes the name of an alarm into a human readable format, for example
-  // "SPROUT_PROCESS_FAILURE" becomes "Sprout process failure"
-  std::string process_alarm_name(std::string raw_name);
-
   // Prepares a string that can be used to report the error that a specific
   // field has exceeded the character limit
   std::string exceeded_character_limit_error(std::string field, int max_length, int index);

--- a/src/json_alarms.cpp
+++ b/src/json_alarms.cpp
@@ -267,7 +267,7 @@ namespace JSONAlarms
         else 
         {
           // Here we use the human readable form of the alarm's name
-          AlarmDef::AlarmDefinition ad = {process_alarm_name(name),
+          AlarmDef::AlarmDefinition ad = {name,
                                           index,
                                           e_cause,
                                           severity_vec};
@@ -284,17 +284,6 @@ namespace JSONAlarms
     }
 
     return true;
-  }
-
-  // Function to transform the name of each alarm from e.g.
-  // "SPROUT_PROCESS_FAILURE" to a human readable format e.g. "Sprout process
-  // failure"
-  std::string process_alarm_name(std::string name)
-  {
-    std::replace(name.begin(), name.end(), '_', ' ');
-    std::transform(name.begin(), name.end(), name.begin(), ::tolower);
-    name[0] = toupper(name[0]);
-    return name;
   }
 
   std::string exceeded_character_limit_error(std::string field, int max_length, int index)


### PR DESCRIPTION
Fixes https://github.com/Metaswitch/clearwater-snmp-handlers/issues/167

Since I'm recirculating the MIBs spec and updating the docs to fix https://github.com/Metaswitch/clearwater-snmp-handlers/issues/170, it seemed efficient to do this too.