### PR TITLE
[No reviewer] Remove unnecessary ENT log

### DIFF
--- a/include/cpp_common_pd_definitions.h
+++ b/include/cpp_common_pd_definitions.h
@@ -71,19 +71,6 @@ static const PDLog CL_DIAMETER_INIT_CMPL
   "None."
 );
 
-static const PDLog1<const char*> CL_DIAMETER_CONN_ERR
-(
-  PDLogBase::CL_CPP_COMMON_ID + 4,
-  LOG_ERR,
-  "Failed to make a Diameter connection to host %s.",
-  "A Diameter connection attempt failed to the specified host.",
-  "This impacts the ability to register, subscribe, or make a call.",
-  "(1). Check the Diameter host configuration. "
-  "(2). Check to see that there is a route to the destination host. "
-  "(3). Check for IP connectivity on the Diameter interface using ping. "
-  "(4). Wireshark the interface on Diameter interface."
-);
-
 static const PDLog2<int, const char*> CL_MEMCACHED_CLUSTER_UPDATE_STABLE
 (
   PDLogBase::CL_CPP_COMMON_ID + 6,

--- a/src/realmmanager.cpp
+++ b/src/realmmanager.cpp
@@ -138,7 +138,6 @@ void RealmManager::peer_connection_cb(bool connection_success,
     }
     else
     {
-      CL_DIAMETER_CONN_ERR.log(host.c_str());
       TRC_ERROR("Failed to connect to %s", host.c_str());
       _resolver->blacklist(peer->addr_info());
       pthread_rwlock_unlock(&_peers_lock);


### PR DESCRIPTION
Remove an ENT log as it doesn't provide any information that isn't more helpfully provided by the communication monitor. Fixes issue https://github.com/Metaswitch/homestead/issues/410.