### PR TITLE
[No reviewer] Update sas datestamp in release-114-fixes

### DIFF
--- a/include/sasevent.h
+++ b/include/sasevent.h
@@ -41,7 +41,7 @@
 #include "sas.h"
 
 namespace SASEvent {
-  const std::string CURRENT_RESOURCE_BUNDLE_DATESTAMP = "20170109";
+  const std::string CURRENT_RESOURCE_BUNDLE_DATESTAMP = "20170123";
   const std::string RESOURCE_BUNDLE_NAME = "org.projectclearwater";
   const std::string CURRENT_RESOURCE_BUNDLE =
                  RESOURCE_BUNDLE_NAME + "." + CURRENT_RESOURCE_BUNDLE_DATESTAMP;


### PR DESCRIPTION
Merge updated SAS datestamp into release-114-fixes, for Metaswitch/clearwater-sas-resources#130

This merge is being done while in dev/master code freeze, so it will not be merged into dev/master at this time. cpp-common references will be updated on release-114-fixes only until the code is unfrozen