### PR TITLE
Update SAS datestamp to 20170203

### DIFF
--- a/include/sasevent.h
+++ b/include/sasevent.h
@@ -41,7 +41,7 @@
 #include "sas.h"
 
 namespace SASEvent {
-  const std::string CURRENT_RESOURCE_BUNDLE_DATESTAMP = "20170123";
+  const std::string CURRENT_RESOURCE_BUNDLE_DATESTAMP = "20170203";
   const std::string RESOURCE_BUNDLE_NAME = "org.projectclearwater";
   const std::string CURRENT_RESOURCE_BUNDLE =
                  RESOURCE_BUNDLE_NAME + "." + CURRENT_RESOURCE_BUNDLE_DATESTAMP;


### PR DESCRIPTION
No reviewer, as this is a datestamp change.

Updating datestamp for Metaswitch/clearwater-sas-resources#132. Both this PR and the linked PR will be merged into both release-114-fixes and master.