### PR TITLE
Optionally obscure Http bodies in SAS logs

### DIFF
--- a/include/httpclient.h
+++ b/include/httpclient.h
@@ -318,6 +318,9 @@ private:
   void sas_add_ip_addrs_and_ports(SAS::Event& event,
                                   CURL* curl);
 
+  // Check if the message has a body and obscure it if so.
+  std::string get_obscured_message_to_log(const std::string& message);
+
   void sas_log_http_req(SAS::TrailId trail,
                         CURL* curl,
                         const std::string& method_str,

--- a/include/httpclient.h
+++ b/include/httpclient.h
@@ -324,7 +324,16 @@ private:
                      const std::string& request_bytes,
                      SAS::Timestamp timestamp,
                      uint32_t instance_id,
-                     bool omit_body = true);
+                     bool omit_body = false);
+
+    void log_rsp_event(SAS::TrailId trail,
+                       CURL* curl,
+                       long http_rc,
+                       const std::string& method_str,
+                       const std::string& url,
+                       const std::string& response_bytes,
+                       uint32_t instance_id,
+                       bool omit_body = false);
 
   void sas_log_http_req(SAS::TrailId trail,
                         CURL* curl,

--- a/include/httpclient.h
+++ b/include/httpclient.h
@@ -85,7 +85,8 @@ public:
              SNMP::IPCountTable* stat_table,
              LoadMonitor* load_monitor,
              SASEvent::HttpLogLevel sas_log_level,
-             BaseCommunicationMonitor* comm_monitor);
+             BaseCommunicationMonitor* comm_monitor,
+             bool should_omit_body = false);
 
   HttpClient(bool assert_user,
              HttpResolver* resolver,
@@ -317,24 +318,6 @@ private:
   void sas_add_ip_addrs_and_ports(SAS::Event& event,
                                   CURL* curl);
 
-  void log_req_event(SAS::TrailId trail,
-                     CURL* curl,
-                     const std::string& method_str,
-                     const std::string& url,
-                     const std::string& request_bytes,
-                     SAS::Timestamp timestamp,
-                     uint32_t instance_id,
-                     bool omit_body = false);
-
-    void log_rsp_event(SAS::TrailId trail,
-                       CURL* curl,
-                       long http_rc,
-                       const std::string& method_str,
-                       const std::string& url,
-                       const std::string& response_bytes,
-                       uint32_t instance_id,
-                       bool omit_body = false);
-
   void sas_log_http_req(SAS::TrailId trail,
                         CURL* curl,
                         const std::string& method_str,
@@ -397,4 +380,5 @@ private:
   BaseCommunicationMonitor* _comm_monitor;
   SNMP::IPCountTable* _stat_table;
   HttpConnectionPool _conn_pool;
+  bool _should_omit_body;
 };

--- a/include/httpclient.h
+++ b/include/httpclient.h
@@ -72,6 +72,9 @@ static const long HTTP_BAD_GATEWAY = 502;
 static const long HTTP_SERVER_UNAVAILABLE = 503;
 static const long HTTP_GATEWAY_TIMEOUT = 504;
 
+static const std::string HEADERS_END = "\r\n\r\n";
+static const std::string BODY_OMITTED = "\r\n\r\n<Body present but not logged>";
+
 /// Issues HTTP requests, supporting round-robin DNS load balancing.
 ///
 class HttpClient

--- a/include/httpclient.h
+++ b/include/httpclient.h
@@ -317,6 +317,15 @@ private:
   void sas_add_ip_addrs_and_ports(SAS::Event& event,
                                   CURL* curl);
 
+  void log_req_event(SAS::TrailId trail,
+                     CURL* curl,
+                     const std::string& method_str,
+                     const std::string& url,
+                     const std::string& request_bytes,
+                     SAS::Timestamp timestamp,
+                     uint32_t instance_id,
+                     bool omit_body = true);
+
   void sas_log_http_req(SAS::TrailId trail,
                         CURL* curl,
                         const std::string& method_str,

--- a/include/httpconnection.h
+++ b/include/httpconnection.h
@@ -60,7 +60,8 @@ public:
                  LoadMonitor* load_monitor,
                  SASEvent::HttpLogLevel sas_log_level,
                  BaseCommunicationMonitor* comm_monitor,
-                 const std::string& scheme = "http") :
+                 const std::string& scheme = "http",
+                 bool should_omit_body = false) :
     _scheme(scheme),
     _server(server),
     _client(assert_user,
@@ -68,7 +69,8 @@ public:
             stat_table,
             load_monitor,
             sas_log_level,
-            comm_monitor)
+            comm_monitor,
+            should_omit_body)
   {
     TRC_STATUS("Configuring HTTP Connection");
     TRC_STATUS("  Connection created for server %s", _server.c_str());

--- a/include/httpstack.h
+++ b/include/httpstack.h
@@ -309,7 +309,8 @@ public:
     void log_req_event(SAS::TrailId trail,
                        Request& req,
                        uint32_t instance_id,
-                       SASEvent::HttpLogLevel level = SASEvent::HttpLogLevel::PROTOCOL);
+                       SASEvent::HttpLogLevel level = SASEvent::HttpLogLevel::PROTOCOL,
+                       bool omit_body = false);
 
     // Log that a response has been sent using the normal SAS event IDs.
     void log_rsp_event(SAS::TrailId trail,
@@ -355,10 +356,17 @@ public:
   };
 
   /// SAS logger for http-stacks behind nginx reverse proxies.
-  class ProxiedSasLogger : public DefaultSasLogger
+  class ProxiedPrivateSasLogger : public DefaultSasLogger
   {
   protected:
     void add_ip_addrs_and_ports(SAS::Event& event, Request& req);
+    void sas_log_rx_http_req(SAS::TrailId trail,
+                             Request& req,
+                             uint32_t instance_id = 0);
+    void sas_log_tx_http_rsp(SAS::TrailId trail,
+                             Request& req,
+                             int rc,
+                             uint32_t instance_id = 0);
   };
 
   /// "Null" SAS Logger.  Does not log.
@@ -444,7 +452,7 @@ public:
   };
 
   static DefaultSasLogger DEFAULT_SAS_LOGGER;
-  static ProxiedSasLogger PROXIED_SAS_LOGGER;
+  static ProxiedPrivateSasLogger PROXIED_PRIVATE_SAS_LOGGER;
   static NullSasLogger NULL_SAS_LOGGER;
 
 private:

--- a/src/httpclient.cpp
+++ b/src/httpclient.cpp
@@ -902,7 +902,7 @@ void HttpClient::sas_add_ip_addrs_and_ports(SAS::Event& event,
 std::string HttpClient::get_obscured_message_to_log(const std::string& message)
 {
   std::string message_to_log;
-  std::size_t body_pos = message.find("\r\n\r\n");
+  std::size_t body_pos = message.find(HEADERS_END);
   std::string headers = message.substr(0, body_pos);
 
   if (body_pos + 4 == message.length())

--- a/src/httpclient.cpp
+++ b/src/httpclient.cpp
@@ -50,9 +50,6 @@
 /// Maximum number of targets to try connecting to.
 static const int MAX_TARGETS = 5;
 
-const std::string HEADERS_END = "\r\n\r\n";
-const std::string BODY_OMITTED = "\r\n\r\n<Body present but not logged>";
-
 /// Create an HTTP client object.
 ///
 /// @param assert_user Assert user in header?

--- a/src/httpclient.cpp
+++ b/src/httpclient.cpp
@@ -906,7 +906,6 @@ void HttpClient::sas_log_http_req(SAS::TrailId trail,
 {
   if (_sas_log_level != SASEvent::HttpLogLevel::NONE)
   {
-    TRC_STATUS("!!!%s", request_bytes.c_str());
     int event_id = ((_sas_log_level == SASEvent::HttpLogLevel::PROTOCOL) ?
                     SASEvent::TX_HTTP_REQ : SASEvent::TX_HTTP_REQ_DETAIL);
     SAS::Event event(trail, event_id, instance_id);
@@ -919,13 +918,11 @@ void HttpClient::sas_log_http_req(SAS::TrailId trail,
     }
     else
     {
-      TRC_STATUS("!!!Should omit body");
       std::size_t body_pos = request_bytes.find("\r\n\r\n");
       std::string headers = request_bytes.substr(0, body_pos);
 
       if (body_pos + 4 == request_bytes.length())
       {
-        TRC_STATUS("!!!No body found");
         // No body, we can just log the request as normal.
         event.add_compressed_param(request_bytes, &SASEvent::PROFILE_HTTP);
       }

--- a/src/httpclient.cpp
+++ b/src/httpclient.cpp
@@ -50,6 +50,9 @@
 /// Maximum number of targets to try connecting to.
 static const int MAX_TARGETS = 5;
 
+const std::string HEADERS_END = "\r\n\r\n";
+const std::string BODY_OMITTED = "\r\n\r\n<Body present but not logged>";
+
 /// Create an HTTP client object.
 ///
 /// @param assert_user Assert user in header?
@@ -909,7 +912,7 @@ std::string HttpClient::get_obscured_message_to_log(const std::string& message)
   }
   else
   {
-    message_to_log = headers + "\r\n\r\n<Body present but not logged>";
+    message_to_log = headers + BODY_OMITTED;
   }
 
   return message_to_log;

--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -43,7 +43,7 @@
 
 bool HttpStack::_ev_using_pthreads = false;
 HttpStack::DefaultSasLogger HttpStack::DEFAULT_SAS_LOGGER;
-HttpStack::ProxiedSasLogger HttpStack::PROXIED_SAS_LOGGER;
+HttpStack::ProxiedPrivateSasLogger HttpStack::PROXIED_PRIVATE_SAS_LOGGER;
 HttpStack::NullSasLogger HttpStack::NULL_SAS_LOGGER;
 
 HttpStack::HttpStack(int num_threads,
@@ -543,7 +543,8 @@ void HttpStack::SasLogger::log_correlator(SAS::TrailId trail,
 void HttpStack::SasLogger::log_req_event(SAS::TrailId trail,
                                          Request& req,
                                          uint32_t instance_id,
-                                         SASEvent::HttpLogLevel level)
+                                         SASEvent::HttpLogLevel level,
+                                         bool omit_body)
 {
   int event_id = ((level == SASEvent::HttpLogLevel::PROTOCOL) ?
                   SASEvent::RX_HTTP_REQ : SASEvent::RX_HTTP_REQ_DETAIL);
@@ -552,7 +553,31 @@ void HttpStack::SasLogger::log_req_event(SAS::TrailId trail,
   add_ip_addrs_and_ports(event, req);
   event.add_static_param(req.method());
   event.add_var_param(req.full_path());
-  event.add_compressed_param(req.get_rx_message(), &SASEvent::PROFILE_HTTP);
+
+  if (!omit_body)
+  {
+    event.add_compressed_param(req.get_rx_message(), &SASEvent::PROFILE_HTTP);
+  }
+  else
+  {
+    TRC_STATUS("omit_body was true!!!");
+    // LCOV_EXCL_START
+    if (req.get_rx_body().empty())
+    {
+      // We are omitting the body but there wasn't one in the messaage. Just log
+      // the header.
+      event.add_compressed_param(req.get_rx_header(), &SASEvent::PROFILE_HTTP);
+    }
+    else
+    {
+      TRC_STATUS("Body present!!!");
+      // There was a body that we need to omit. Add a fake body to the header
+      // explaining that the body was intentionally not logged.
+      event.add_compressed_param(req.get_rx_header() + "<Body present but not logged>",
+                                 &SASEvent::PROFILE_HTTP);
+    }
+    // LCOV_EXCL_STOP
+  }
 
   SAS::report_event(event);
 }
@@ -564,6 +589,7 @@ void HttpStack::SasLogger::log_rsp_event(SAS::TrailId trail,
                                          SASEvent::HttpLogLevel level,
                                          bool omit_body)
 {
+  TRC_STATUS("log_rsp_event!!!");
   int event_id = ((level == SASEvent::HttpLogLevel::PROTOCOL) ?
                   SASEvent::TX_HTTP_RSP : SASEvent::TX_HTTP_RSP_DETAIL);
   SAS::Event event(trail, event_id, instance_id);
@@ -579,6 +605,7 @@ void HttpStack::SasLogger::log_rsp_event(SAS::TrailId trail,
   }
   else
   {
+    TRC_STATUS("omit_body was true!!!");
     // LCOV_EXCL_START
     if (req.get_tx_body().empty())
     {
@@ -588,6 +615,7 @@ void HttpStack::SasLogger::log_rsp_event(SAS::TrailId trail,
     }
     else
     {
+      TRC_STATUS("Body present!!!");
       // There was a body that we need to omit. Add a fake body to the header
       // explaining that the body was intentionally not logged.
       event.add_compressed_param(req.get_tx_header(rc) + "<Body present but not logged>",
@@ -689,7 +717,7 @@ void HttpStack::DefaultSasLogger::sas_log_overload(SAS::TrailId trail,
 // ProxiedSasLogger methods.
 //
 
-void HttpStack::ProxiedSasLogger::add_ip_addrs_and_ports(SAS::Event& event, Request& req)
+void HttpStack::ProxiedPrivateSasLogger::add_ip_addrs_and_ports(SAS::Event& event, Request& req)
 {
   std::string ip;
   unsigned short port;
@@ -726,4 +754,20 @@ void HttpStack::ProxiedSasLogger::add_ip_addrs_and_ports(SAS::Event& event, Requ
     event.add_static_param(0);
     // LCOV_EXCL_STOP
   }
+}
+
+void HttpStack::ProxiedPrivateSasLogger::sas_log_rx_http_req(SAS::TrailId trail,
+                                                      HttpStack::Request& req,
+                                                      uint32_t instance_id)
+{
+  log_correlator(trail, req, instance_id);
+  log_req_event(trail, req, instance_id, SASEvent::HttpLogLevel::PROTOCOL, true);
+}
+
+void HttpStack::ProxiedPrivateSasLogger::sas_log_tx_http_rsp(SAS::TrailId trail,
+                                                             HttpStack::Request& req,
+                                                             int rc,
+                                                             uint32_t instance_id)
+{
+  log_rsp_event(trail, req, rc, instance_id, SASEvent::HttpLogLevel::PROTOCOL, true);
 }

--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -560,7 +560,6 @@ void HttpStack::SasLogger::log_req_event(SAS::TrailId trail,
   }
   else
   {
-    TRC_STATUS("omit_body was true!!!");
     // LCOV_EXCL_START
     if (req.get_rx_body().empty())
     {
@@ -570,7 +569,6 @@ void HttpStack::SasLogger::log_req_event(SAS::TrailId trail,
     }
     else
     {
-      TRC_STATUS("Body present!!!");
       // There was a body that we need to omit. Add a fake body to the header
       // explaining that the body was intentionally not logged.
       event.add_compressed_param(req.get_rx_header() + "<Body present but not logged>",
@@ -589,7 +587,6 @@ void HttpStack::SasLogger::log_rsp_event(SAS::TrailId trail,
                                          SASEvent::HttpLogLevel level,
                                          bool omit_body)
 {
-  TRC_STATUS("log_rsp_event!!!");
   int event_id = ((level == SASEvent::HttpLogLevel::PROTOCOL) ?
                   SASEvent::TX_HTTP_RSP : SASEvent::TX_HTTP_RSP_DETAIL);
   SAS::Event event(trail, event_id, instance_id);
@@ -605,7 +602,6 @@ void HttpStack::SasLogger::log_rsp_event(SAS::TrailId trail,
   }
   else
   {
-    TRC_STATUS("omit_body was true!!!");
     // LCOV_EXCL_START
     if (req.get_tx_body().empty())
     {
@@ -615,7 +611,6 @@ void HttpStack::SasLogger::log_rsp_event(SAS::TrailId trail,
     }
     else
     {
-      TRC_STATUS("Body present!!!");
       // There was a body that we need to omit. Add a fake body to the header
       // explaining that the body was intentionally not logged.
       event.add_compressed_param(req.get_tx_header(rc) + "<Body present but not logged>",

--- a/test_utils/fakecurl.cpp
+++ b/test_utils/fakecurl.cpp
@@ -117,7 +117,7 @@ CURLcode FakeCurl::easy_perform(FakeCurl* curl)
                     text.size(),
                     _debug_data);
 
-    text = "HTTP/1.1 200 OK\r\n\r\n";
+    text = "HTTP/1.1 200 OK\r\n\r\n" + _body;
     _debug_callback((CURL*)this,
                     CURLINFO_HEADER_IN,
                     (char*)text.c_str(),

--- a/test_utils/fakecurl.cpp
+++ b/test_utils/fakecurl.cpp
@@ -102,7 +102,8 @@ CURLcode FakeCurl::easy_perform(FakeCurl* curl)
     // logging code).
     std::string text;
 
-    text = "GET / HTTP/1.1\r\n\r\n";
+    text = _method + " / HTTP/1.1\r\n\r\n" + _body;
+
     _debug_callback((CURL*)this,
                     CURLINFO_HEADER_OUT,
                     (char*)text.c_str(),


### PR DESCRIPTION
Makes changes to the HttpStack and the HttpClient so that the bodies of Http requests and responses can be optionally obscured in SAS:

- ProxiedSasLogger (which is currently only used by Bifrost) is replaced with ProxiedPrivateSasLogger which doesn't log any bodies to SAS.

- A 'should_omit_body' variable is added to HttpClient which defaults to false. If enabled, then http bodies are again obscured when being reported to SAS.