### PR TITLE
Separate PrivateSasLogger from ProxiedPrivateSasLogger

### DIFF
--- a/include/httpstack.h
+++ b/include/httpstack.h
@@ -355,11 +355,11 @@ public:
                                   uint32_t instance_id = 0);
   };
 
-  /// SAS logger for http-stacks behind nginx reverse proxies.
-  class ProxiedPrivateSasLogger : public DefaultSasLogger
+  /// SAS logger which omits bodies of requests and responses
+  /// in SAS logs.
+  class PrivateSasLogger : public DefaultSasLogger
   {
   protected:
-    void add_ip_addrs_and_ports(SAS::Event& event, Request& req);
     void sas_log_rx_http_req(SAS::TrailId trail,
                              Request& req,
                              uint32_t instance_id = 0);
@@ -367,6 +367,13 @@ public:
                              Request& req,
                              int rc,
                              uint32_t instance_id = 0);
+  };
+
+  /// SAS logger for http-stacks behind nginx reverse proxies.
+  class ProxiedPrivateSasLogger : public PrivateSasLogger
+  {
+  protected:
+    void add_ip_addrs_and_ports(SAS::Event& event, Request& req);
   };
 
   /// "Null" SAS Logger.  Does not log.
@@ -452,6 +459,7 @@ public:
   };
 
   static DefaultSasLogger DEFAULT_SAS_LOGGER;
+  static PrivateSasLogger PRIVATE_SAS_LOGGER;
   static ProxiedPrivateSasLogger PROXIED_PRIVATE_SAS_LOGGER;
   static NullSasLogger NULL_SAS_LOGGER;
 

--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -45,6 +45,7 @@ const std::string BODY_OMITTED = "<Body present but not logged>";
 
 bool HttpStack::_ev_using_pthreads = false;
 HttpStack::DefaultSasLogger HttpStack::DEFAULT_SAS_LOGGER;
+HttpStack::PrivateSasLogger HttpStack::PRIVATE_SAS_LOGGER;
 HttpStack::ProxiedPrivateSasLogger HttpStack::PROXIED_PRIVATE_SAS_LOGGER;
 HttpStack::NullSasLogger HttpStack::NULL_SAS_LOGGER;
 
@@ -706,6 +707,22 @@ void HttpStack::DefaultSasLogger::sas_log_overload(SAS::TrailId trail,
   log_overload_event(trail, req, rc, target_latency, current_latency, rate_limit, instance_id);
 }
 
+void HttpStack::PrivateSasLogger::sas_log_rx_http_req(SAS::TrailId trail,
+                                                      HttpStack::Request& req,
+                                                      uint32_t instance_id)
+{
+  log_correlator(trail, req, instance_id);
+  log_req_event(trail, req, instance_id, SASEvent::HttpLogLevel::PROTOCOL, true);
+}
+
+void HttpStack::PrivateSasLogger::sas_log_tx_http_rsp(SAS::TrailId trail,
+                                                      HttpStack::Request& req,
+                                                      int rc,
+                                                      uint32_t instance_id)
+{
+  log_rsp_event(trail, req, rc, instance_id, SASEvent::HttpLogLevel::PROTOCOL, true);
+}
+
 //
 // ProxiedPrivateSasLogger methods.
 //
@@ -747,20 +764,4 @@ void HttpStack::ProxiedPrivateSasLogger::add_ip_addrs_and_ports(SAS::Event& even
     event.add_static_param(0);
     // LCOV_EXCL_STOP
   }
-}
-
-void HttpStack::ProxiedPrivateSasLogger::sas_log_rx_http_req(SAS::TrailId trail,
-                                                             HttpStack::Request& req,
-                                                             uint32_t instance_id)
-{
-  log_correlator(trail, req, instance_id);
-  log_req_event(trail, req, instance_id, SASEvent::HttpLogLevel::PROTOCOL, true);
-}
-
-void HttpStack::ProxiedPrivateSasLogger::sas_log_tx_http_rsp(SAS::TrailId trail,
-                                                             HttpStack::Request& req,
-                                                             int rc,
-                                                             uint32_t instance_id)
-{
-  log_rsp_event(trail, req, rc, instance_id, SASEvent::HttpLogLevel::PROTOCOL, true);
 }


### PR DESCRIPTION
As per my email, this is to separate the part of the SAS logger which obscures the bodies of requests from the part that sits behind a reverse proxy.