### PR TITLE
[Reviewer: Adam] Return HTTP 503 on curl timeout

### DIFF
--- a/src/httpclient.cpp
+++ b/src/httpclient.cpp
@@ -132,6 +132,8 @@ HTTPCode HttpClient::curl_code_to_http_code(CURL* curl, CURLcode code)
   case CURLE_COULDNT_CONNECT:
   case CURLE_AGAIN:
     return HTTP_NOT_FOUND;
+  case CURLE_OPERATION_TIMEDOUT:
+    return HTTP_SERVER_UNAVAILABLE;
   default:
     return HTTP_SERVER_ERROR;
   // LCOV_EXCL_STOP


### PR DESCRIPTION
When we get a curl timeout on an HTTP request, we should report the HTTP return code as 503.

This allows the upstream node to handle the timeout correctly.

This is a fix for issue https://github.com/Metaswitch/sprout/issues/1623

#### Testing
 - live tested by manually dropping packets to Homestead, and verifying that Sprout correctly interprets that as an HTTP 503
 - verified live tests still pass on a deployment with this fix