### PR TITLE
[Reviewer EM] Improve DNS behaviour in the event of server failure

### DIFF
--- a/include/dnscachedresolver.h
+++ b/include/dnscachedresolver.h
@@ -77,10 +77,10 @@ private:
 class DnsCachedResolver
 {
 public:
-  DnsCachedResolver(const std::vector<IP46Address>& dns_servers, const std::string& filename = "");
-  DnsCachedResolver(const std::vector<std::string>& dns_servers, const std::string& filename = "");
-  DnsCachedResolver(const std::string& dns_server, int port, const std::string& filename = "");
-  DnsCachedResolver(const std::string& dns_server) : DnsCachedResolver(dns_server, 53) {};
+  DnsCachedResolver(const std::vector<IP46Address>& dns_servers, int timeout = DEFAULT_TIMEOUT, const std::string& filename = "");
+  DnsCachedResolver(const std::vector<std::string>& dns_servers, int timeout = DEFAULT_TIMEOUT, const std::string& filename = "");
+  DnsCachedResolver(const std::string& dns_server, int port, int timeout = DEFAULT_TIMEOUT, const std::string& filename = "");
+  DnsCachedResolver(const std::string& dns_server) : DnsCachedResolver(dns_server, DEFAULT_PORT) {};
   ~DnsCachedResolver();
 
   /// Queries a single DNS record.
@@ -107,6 +107,12 @@ public:
 
   // Reads DNS records from _dns_config_file and stores them in _static_records
   void reload_static_records();
+
+  // Default timeout for DNS requests over the wire (in milliseconds)
+  static const int DEFAULT_TIMEOUT = 200;
+
+  // Default port number for DNS requests
+  static const int DEFAULT_PORT = 53;
 
 private:
   void init(const std::vector<IP46Address>& dns_server);
@@ -202,6 +208,9 @@ private:
   struct ares_addr_node _ares_addrs[3];
   std::vector<IP46Address> _dns_servers;
   int _port;
+
+  // C_ARES request timeout
+  int _timeout;
 
   // The thread-local store - used for storing DnsChannels.
   pthread_key_t _thread_local;

--- a/include/sasevent.h
+++ b/include/sasevent.h
@@ -152,6 +152,7 @@ namespace SASEvent {
   const int DNS_SUCCESS = COMMON_BASE + 0x000203;
   const int DNS_FAILED = COMMON_BASE + 0x000204;
   const int DNS_NOT_FOUND = COMMON_BASE + 0x000205;
+  const int DNS_TIMEOUT = COMMON_BASE + 0x000206;
 
   const int CASS_CONNECT_FAIL = COMMON_BASE + 0x0300;
 

--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -127,6 +127,7 @@ void DnsCachedResolver::init(const std::vector<IP46Address>& dns_servers)
 {
   _dns_servers = dns_servers;
   _cache_lock = PTHREAD_RECURSIVE_MUTEX_INITIALIZER_NP;
+  TRC_DEBUG("Timeout = %d", _timeout);
 
   // Initialize the ares library.  This might have already been done by curl
   // but it's safe to do it twice.
@@ -1116,7 +1117,6 @@ DnsCachedResolver::DnsChannel* DnsCachedResolver::get_dns_channel()
                       ARES_OPT_TRIES |
                       ARES_OPT_NDOTS |
                       ARES_OPT_UDP_PORT |
-                      ARES_OPT_ROTATE |
                       ARES_OPT_SERVERS);
 
     // Convert our vector of IP46Addresses into the linked list of


### PR DESCRIPTION
Hi Ellie

Can you review this package of DNS timeout changes (I've discussed with MIRW)?   They are

- Changing the default timeout for a query to 200, and adding the facility to override this
- Adding a SAS log for when a timeout fails (at the moment, we only see a timeout log if _all_ DNS servers fail, so if multiple DNS servers are configured and only one is offline, we don't notice anything in SAS other than a time jump in the SAS logs). 
-  Changing "tries" in the ares_init_options back to 1.  Rob explicitly set this to "server_count" in https://github.com/Metaswitch/cpp-common/pull/243/files#diff-b76e44fc3db821f376c4d58277322bc6L691, but I don't think this makes sense - the ARES docs explicitly say that "tries" is the number of tries per server, not overall. I don't think we want more than one try per DNS server, as we have a good fallback position for internal DNS names (we just use what we've already cached) and if the DNS servers really are offline, we don't want to hold up the request waiting for the retries.
-  ARES_OPT_ROTATE.  This flag ensures that, if we have more than one DNS server configured, ARES will round robin the first DNS server tried for the channel for any given request.  This means that if the first DNS server of three is offline, we'll only be hit by the DNS timeout on a third of the requests (instead of all of them) 

Tested live using wireshark to verify DNS retry behaviour against multiple DNS servers in both "all down" and "some down" scenarios.

Companion PRs containing plumbing from Ralf, Homestead and Sprout, and the SAS resource PR  to follow