### PR TITLE
Change log level of reraising alarms log and add more logging

### DIFF
--- a/src/alarm.cpp
+++ b/src/alarm.cpp
@@ -88,6 +88,7 @@ void BaseAlarm::switch_to_state(AlarmState* new_state)
   if (_last_state_raised !=  new_state)
   {
     pthread_mutex_lock(&_issue_alarm_change_state);
+    TRC_STATUS("Alarm severity changed");
     new_state->issue();
     _last_state_raised = new_state;
     pthread_mutex_unlock(&_issue_alarm_change_state);
@@ -250,7 +251,7 @@ void AlarmReRaiser::reraise_alarms()
     time_limit.tv_sec += 30;
 
     // Now raise the alarms
-    TRC_DEBUG("Reraising all alarms with a known state");
+    TRC_STATUS("Reraising all alarms with a known state");
     for (std::vector<BaseAlarm*>::iterator it = _alarm_list.begin();
                                            it != _alarm_list.end();
                                            it++)

--- a/src/alarm.cpp
+++ b/src/alarm.cpp
@@ -87,8 +87,23 @@ void BaseAlarm::switch_to_state(AlarmState* new_state)
 {
   if (_last_state_raised !=  new_state)
   {
+    std::string old_state_text = "NULL";
+    std::string new_state_text = "NULL";
+
+    if (_last_state_raised != NULL)
+    {
+      old_state_text = _last_state_raised->get_identifier();
+    }
+
+    if (new_state != NULL)
+    {
+      new_state_text = new_state->get_identifier();
+    }
+
     pthread_mutex_lock(&_issue_alarm_change_state);
-    TRC_STATUS("Alarm severity changed");
+    TRC_STATUS("Alarm severity changed from %s to %s",
+               old_state_text.c_str(),
+               new_state_text.c_str());
     new_state->issue();
     _last_state_raised = new_state;
     pthread_mutex_unlock(&_issue_alarm_change_state);


### PR DESCRIPTION
This pull request fixes https://github.com/Metaswitch/stats-engine/issues/434. In this issue AME2 reported a periodical log spam every 30 seconds writing out logs like 
```
21-02-2017 14:39:35.623 UTC Status alarm.cpp:62: statistics engine issued 10001.1 alarm
21-02-2017 14:39:35.623 UTC Status alarm.cpp:62: statistics engine issued 10002.1 alarm
21-02-2017 14:39:35.623 UTC Status alarm.cpp:62: stats-engine issued 10003.1 alarm
21-02-2017 14:39:35.623 UTC Status alarm.cpp:62: stats-engine issued 10004.1 alarm
21-02-2017 14:39:35.623 UTC Status alarm.cpp:62: stats-engine issued 10007.1 alarm
21-02-2017 14:40:05.623 UTC Status alarm.cpp:62: statistics engine issued 10001.1 alarm
21-02-2017 14:40:05.623 UTC Status alarm.cpp:62: statistics engine issued 10002.1 alarm
21-02-2017 14:40:05.623 UTC Status alarm.cpp:62: stats-engine issued 10003.1 alarm
21-02-2017 14:40:05.623 UTC Status alarm.cpp:62: stats-engine issued 10004.1 alarm
```
After a long discussion we decided that it is actually worth keeping these logs in `/var/log/stats-engine_current.txt` as an L3 engineer will be interested in what alarms were sent out via ZMQ to the AlarmAgent. It seems useful for L3 to have this snapshot every 30 seconds of all alarm statuses, but additionally we think that we need to 
- Explicitly say in the logs that it is a current snapshot (leaving no ambiguity that these are status changes)
- Additionally log any alarm status changes

I have implemented these two items in this pull request and now the logs look like this:
```
09-05-2017 15:10:02.526 UTC Status alarm.cpp:91: Alarm severity changed
09-05-2017 15:10:02.526 UTC Status alarm.cpp:62: statistics engine issued 10001.1 alarm
...
09-05-2017 15:10:32.510 UTC Status alarm.cpp:254: Reraising all alarms with a known state
09-05-2017 15:10:32.510 UTC Status alarm.cpp:62: statistics engine issued 10001.1 alarm
09-05-2017 15:10:32.510 UTC Status alarm.cpp:62: statistics engine issued 10002.1 alarm
09-05-2017 15:10:32.510 UTC Status alarm.cpp:62: stats-engine issued 10007.1 alarm
```
