### PR TITLE
Enhance the local store to allow failures when getting data

### DIFF
--- a/include/localstore.h
+++ b/include/localstore.h
@@ -51,6 +51,7 @@ public:
   void flush_all();
   void force_contention();
   void force_error();
+  void force_get_error();
 
   Store::Status get_data(const std::string& table,
                          const std::string& key,
@@ -76,7 +77,8 @@ private:
   bool _data_contention_flag;
   pthread_mutex_t _db_lock;
   std::map<std::string, Record> _db;
-  bool _force_error_flag;
+  bool _force_error_on_set_flag;
+  bool _force_error_on_get_flag;
   std::map<std::string, Record> _old_db;
 };
 

--- a/src/localstore.cpp
+++ b/src/localstore.cpp
@@ -108,7 +108,7 @@ Store::Status LocalStore::get_data(const std::string& table,
 
   // This is for the purpose of testing data GETs failing.  If the flag is set
   // to true, then we'll just return an error.
-  if (_force_error_on_get_flag == true)
+  if (_force_error_on_get_flag)
   {
     TRC_DEBUG("Force an error on the GET");
     _force_error_on_get_flag = false;
@@ -124,7 +124,7 @@ Store::Status LocalStore::get_data(const std::string& table,
   // true _db_in_use will become a reference to _old_db the out-of-date
   // database we constructed in set_data().
   std::map<std::string, Record>& _db_in_use = _data_contention_flag ? _old_db : _db;
-  if (_data_contention_flag == true)
+  if (_data_contention_flag)
   {
     _data_contention_flag = false;
   }
@@ -178,7 +178,7 @@ Store::Status LocalStore::set_data(const std::string& table,
 
   // This is for the purpose of testing data SETs failing.  If the flag is set
   // to true, then we'll just return an error.
-  if (_force_error_on_set_flag == true)
+  if (_force_error_on_set_flag)
   {
     TRC_DEBUG("Force an error on the SET");
     _force_error_on_set_flag = false;


### PR DESCRIPTION
Some enhancements to the local store class we us in UTs to allow it to fail get requests. Needed for https://github.com/Metaswitch/sprout/pull/1823