### PR TITLE
Rough pass to rework multi state alarms

### DIFF
--- a/include/alarm.h
+++ b/include/alarm.h
@@ -149,6 +149,10 @@ public:
   void set_major();
   void set_critical();
 
+  /// Uses the _last_state_raised member variable to re-raise the latest state
+  /// of the alarm.
+  void reraise_last_state();
+
 private:
   const int _index;
 
@@ -174,10 +178,6 @@ private:
   AlarmState _minor_state;
   AlarmState _major_state;
   AlarmState _critical_state;
-
-  /// Uses the _last_state_raised member variable to re-raise the latest state
-  /// of the alarm.
-  void reraise_last_state();
 
   /// Returns the current state of the alarm as one of UNKNOWN, CLEARED, or ALARMED.
   virtual AlarmState::AlarmCondition get_alarm_state();

--- a/include/communicationmonitor.h
+++ b/include/communicationmonitor.h
@@ -15,6 +15,39 @@
 #include "alarm.h"
 #include "base_communication_monitor.h"
 
+class CMAlarmAdaptor : public AlarmAdaptor
+{
+public:
+  CMAlarmAdaptor(Alarm* alarm,
+                 AlarmDef::Severity on_some_errors,
+                 AlarmDef::Severity on_all_errors):
+    AlarmAdaptor(alarm),
+    _on_some_errors(on_some_errors),
+    _on_all_errors(on_all_errors)
+  {}
+
+  virtual ~CMAlarmAdaptor() {}
+
+  void only_errors()
+  {
+    _alarm->set(_on_all_errors);
+  }
+
+  void some_errors()
+  {
+    _alarm->set(_on_some_errors);
+  }
+
+  void no_errors()
+  {
+    _alarm->clear();
+  }
+
+private:
+  AlarmDef::Severity _on_some_errors;
+  AlarmDef::Severity _on_all_errors;
+};
+
 /// @class CommunicationMonitor
 ///
 /// Provides a simple mechanism to track communication state for an entity,
@@ -31,7 +64,7 @@
 class CommunicationMonitor : public BaseCommunicationMonitor
 {
 public:
-  CommunicationMonitor(Alarm* alarm,
+  CommunicationMonitor(CMAlarmAdaptor* alarm_adaptor,
                        std::string sender,
                        std::string receiver,
                        unsigned int clear_confirm_sec = 30,
@@ -43,7 +76,7 @@ private:
   virtual void track_communication_changes(unsigned long now_ms);
   unsigned long current_time_ms();
 
-  Alarm* _alarm;
+  CMAlarmAdaptor* _alarm_adaptor;
   std::string _sender;
   std::string _receiver;
   unsigned int _clear_confirm_ms;

--- a/src/communicationmonitor.cpp
+++ b/src/communicationmonitor.cpp
@@ -13,13 +13,13 @@
 #include "log.h"
 #include "cpp_common_pd_definitions.h"
 
-CommunicationMonitor::CommunicationMonitor(Alarm* alarm,
+CommunicationMonitor::CommunicationMonitor(CMAlarmAdaptor* alarm_adaptor,
                                            std::string sender,
                                            std::string receiver,
                                            unsigned int clear_confirm_sec,
                                            unsigned int set_confirm_sec) :
   BaseCommunicationMonitor(),
-  _alarm(alarm),
+  _alarm_adaptor(alarm_adaptor),
   _sender(sender),
   _receiver(receiver),
   _clear_confirm_ms(clear_confirm_sec * 1000),
@@ -31,7 +31,7 @@ CommunicationMonitor::CommunicationMonitor(Alarm* alarm,
 
 CommunicationMonitor::~CommunicationMonitor()
 {
-  delete _alarm;
+  delete _alarm_adaptor;
 }
 
 void CommunicationMonitor::track_communication_changes(unsigned long now_ms)
@@ -85,20 +85,20 @@ void CommunicationMonitor::track_communication_changes(unsigned long now_ms)
         case NO_ERRORS:
           switch (_new_state)
           {
-            case NO_ERRORS: // No change in state. Ensure alarm is cleared.
-              _alarm->clear();
+            case NO_ERRORS: // No change in state.
+              _alarm_adaptor->no_errors();
               break;
 
             case SOME_ERRORS:
               CL_CM_CONNECTION_PARTIAL_ERROR.log(_sender.c_str(),
                                                  _receiver.c_str());
-              _alarm->clear();
+              _alarm_adaptor->some_errors();
               break;
 
             case ONLY_ERRORS:
               CL_CM_CONNECTION_ERRORED.log(_sender.c_str(),
                                            _receiver.c_str());
-              _alarm->set();
+              _alarm_adaptor->only_errors();
               break;
           }
           break;
@@ -108,17 +108,17 @@ void CommunicationMonitor::track_communication_changes(unsigned long now_ms)
             case NO_ERRORS:
               CL_CM_CONNECTION_CLEARED.log(_sender.c_str(),
                                            _receiver.c_str());
-              _alarm->clear();
+              _alarm_adaptor->no_errors();
               break;
 
             case SOME_ERRORS: // No change in state. Ensure alarm is cleared.
-              _alarm->clear();
+              _alarm_adaptor->some_errors();
               break;
 
             case ONLY_ERRORS:
               CL_CM_CONNECTION_ERRORED.log(_sender.c_str(),
                                            _receiver.c_str());
-              _alarm->set();
+              _alarm_adaptor->only_errors();
               break;
           }
           break;
@@ -128,17 +128,17 @@ void CommunicationMonitor::track_communication_changes(unsigned long now_ms)
             case NO_ERRORS:
               CL_CM_CONNECTION_CLEARED.log(_sender.c_str(),
                                            _receiver.c_str());
-              _alarm->clear();
+              _alarm_adaptor->no_errors();
               break;
 
             case SOME_ERRORS:
               CL_CM_CONNECTION_PARTIAL_ERROR.log(_sender.c_str(),
                                                  _receiver.c_str());
-              _alarm->clear();
+              _alarm_adaptor->some_errors();
               break;
 
             case ONLY_ERRORS: // No change in state. Ensure alarm is raised.
-              _alarm->set();
+              _alarm_adaptor->only_errors();
               break;
           }
           break;

--- a/src/communicationmonitor.cpp
+++ b/src/communicationmonitor.cpp
@@ -86,19 +86,19 @@ void CommunicationMonitor::track_communication_changes(unsigned long now_ms)
           switch (_new_state)
           {
             case NO_ERRORS: // No change in state.
-              _alarm_adaptor->no_errors();
+              _alarm_adaptor->no_comm_errors();
               break;
 
             case SOME_ERRORS:
               CL_CM_CONNECTION_PARTIAL_ERROR.log(_sender.c_str(),
                                                  _receiver.c_str());
-              _alarm_adaptor->some_errors();
+              _alarm_adaptor->some_comm_errors();
               break;
 
             case ONLY_ERRORS:
               CL_CM_CONNECTION_ERRORED.log(_sender.c_str(),
                                            _receiver.c_str());
-              _alarm_adaptor->only_errors();
+              _alarm_adaptor->only_comm_errors();
               break;
           }
           break;
@@ -108,17 +108,17 @@ void CommunicationMonitor::track_communication_changes(unsigned long now_ms)
             case NO_ERRORS:
               CL_CM_CONNECTION_CLEARED.log(_sender.c_str(),
                                            _receiver.c_str());
-              _alarm_adaptor->no_errors();
+              _alarm_adaptor->no_comm_errors();
               break;
 
             case SOME_ERRORS: // No change in state. Ensure alarm is cleared.
-              _alarm_adaptor->some_errors();
+              _alarm_adaptor->some_comm_errors();
               break;
 
             case ONLY_ERRORS:
               CL_CM_CONNECTION_ERRORED.log(_sender.c_str(),
                                            _receiver.c_str());
-              _alarm_adaptor->only_errors();
+              _alarm_adaptor->only_comm_errors();
               break;
           }
           break;
@@ -128,17 +128,17 @@ void CommunicationMonitor::track_communication_changes(unsigned long now_ms)
             case NO_ERRORS:
               CL_CM_CONNECTION_CLEARED.log(_sender.c_str(),
                                            _receiver.c_str());
-              _alarm_adaptor->no_errors();
+              _alarm_adaptor->no_comm_errors();
               break;
 
             case SOME_ERRORS:
               CL_CM_CONNECTION_PARTIAL_ERROR.log(_sender.c_str(),
                                                  _receiver.c_str());
-              _alarm_adaptor->some_errors();
+              _alarm_adaptor->some_comm_errors();
               break;
 
             case ONLY_ERRORS: // No change in state. Ensure alarm is raised.
-              _alarm_adaptor->only_errors();
+              _alarm_adaptor->only_comm_errors();
               break;
           }
           break;

--- a/src/memcachedstore.cpp
+++ b/src/memcachedstore.cpp
@@ -672,4 +672,3 @@ bool TopologyNeutralMemcachedStore::get_targets(std::vector<AddrInfo>& targets,
 
   return true;
 }
-// LCOV_EXCL_STOP

--- a/test_utils/mockalarm.h
+++ b/test_utils/mockalarm.h
@@ -19,24 +19,11 @@ class MockAlarm : public Alarm
 {
 public:
   MockAlarm(AlarmManager* alarm_manager) :
-    Alarm(alarm_manager, "sprout", 0, AlarmDef::CRITICAL) {}
+    Alarm(alarm_manager, "sprout", 0) {}
 
   MOCK_METHOD0(clear, void());
-  MOCK_METHOD0(set, void());
   MOCK_METHOD0(get_alarm_state, AlarmState::AlarmCondition());
-};
-
-class MockMultiStateAlarm : public MultiStateAlarm
-{
-public:
-  MockMultiStateAlarm(AlarmManager* alarm_manager) :
-    MultiStateAlarm(alarm_manager, "sprout", 0) {}
-
-  MOCK_METHOD0(set_indeterminate, void());
-  MOCK_METHOD0(set_warning, void());
-  MOCK_METHOD0(set_minor, void());
-  MOCK_METHOD0(set_major, void());
-  MOCK_METHOD0(set_critical, void());
+  MOCK_METHOD1(set, void(AlarmDef::Severity));
 };
 
 #endif

--- a/test_utils/mockcommunicationmonitor.h
+++ b/test_utils/mockcommunicationmonitor.h
@@ -19,7 +19,7 @@ class MockCommunicationMonitor : public CommunicationMonitor
 {
 public:
   MockCommunicationMonitor(AlarmManager* alarm_manager) :
-    CommunicationMonitor(new Alarm(alarm_manager, "sprout", 0, AlarmDef::CRITICAL), "sprout", "chronos") {}
+    CommunicationMonitor(new CMAlarmAdaptor(new Alarm(alarm_manager, "sprout", 0), AlarmDef::MINOR, AlarmDef::CRITICAL), "sprout", "chronos") {}
 
   MOCK_METHOD1(inform_success, void(unsigned long now_ms));
   MOCK_METHOD1(inform_failure, void(unsigned long now_ms));


### PR DESCRIPTION
Alex, you've agreed to quickly look over these changes before I change the rest of the code to use it,

The changes:
* Merge the Alarm and MultiStateAlarm classes so that there's one Alarm class. Code that uses alarms must now call set_major(), set_minor(), etc.. rather than calling set().
* Adds an adaptor class (in this case just for the communication monitor) to translate for code that doesn't know what the right severity to raise is in a particular situation.

I've not added comments/thought about naming yet.