### PR TITLE
[Reviewer: Alex] Make CM logs more specific

### DIFF
--- a/include/communicationmonitor.h
+++ b/include/communicationmonitor.h
@@ -14,6 +14,24 @@
 
 #include "alarm.h"
 #include "base_communication_monitor.h"
+#include "pdlog.h"
+
+/// Structure that holds the different ENT logs that get raised by the
+// Communication Monitor
+struct CMPDLogs
+{
+  PDLog _log_when_no_errors;
+  PDLog _log_when_some_errors;
+  PDLog _log_when_only_errors;
+
+  CMPDLogs(PDLog log_when_no_errors,
+           PDLog log_when_some_errors,
+           PDLog log_when_only_errors) :
+    _log_when_no_errors(log_when_no_errors),
+    _log_when_some_errors(log_when_some_errors),
+    _log_when_only_errors(log_when_only_errors)
+  {}
+};
 
 /// @class CommunicationMonitor
 ///
@@ -32,6 +50,7 @@ class CommunicationMonitor : public BaseCommunicationMonitor
 {
 public:
   CommunicationMonitor(Alarm* alarm,
+                       CMPDLogs cm_pd_logs,
                        std::string sender,
                        std::string receiver,
                        unsigned int clear_confirm_sec = 30,
@@ -44,12 +63,14 @@ private:
   unsigned long current_time_ms();
 
   Alarm* _alarm;
+  CMPDLogs _cm_pd_logs;
   std::string _sender;
   std::string _receiver;
   unsigned int _clear_confirm_ms;
   unsigned int _set_confirm_ms;
   unsigned long _next_check;
   int _previous_state;
+
   // Setup the possible error states
   enum { NO_ERRORS, SOME_ERRORS, ONLY_ERRORS };
 };

--- a/include/cpp_common_pd_definitions.h
+++ b/include/cpp_common_pd_definitions.h
@@ -66,46 +66,6 @@ static const PDLog3<int, int, const char*> CL_MEMCACHED_CLUSTER_UPDATE_RESIZE
   "None."
 );
 
-static const PDLog2<const char*, const char*> CL_CM_CONNECTION_PARTIAL_ERROR
-(
-  PDLogBase::CL_CPP_COMMON_ID + 8,
-  LOG_INFO,
-  "Some connections between %s and %s applications have failed.",
-  "This process was unable to contact at least one instance of the application "
-  "it's trying to connect to, but did make some successful contact",
-  "This process was unable to contact at least one instance of the application "
-  "it's trying to connect to",
-  "(1). Check that the application this process is trying to connect to is running."
-  "(2). Check the configuration in /etc/clearwater is correct."
-  "(3). Check that this process has connectivity to the application it's trying to connect to."
-);
-
-static const PDLog2<const char*, const char*> CL_CM_CONNECTION_ERRORED
-(
-  PDLogBase::CL_CPP_COMMON_ID + 9,
-  LOG_ERR,
-  "%s is unable to contact any %s applications. It will periodically "
-  "attempt to reconnect",
-  "This process is unable to contact any instances of the application "
-  "it's trying to connect to",
-  "This process is unable to contact any instances of the application "
-  "it's trying to connect to",
-  "(1). Check that the application this process is trying to connect to is running."
-  "(2). Check the configuration in /etc/clearwater is correct."
-  "(3). Check that this process has connectivity to the application it's trying to connect to."
-);
-
-static const PDLog2<const char*, const char*> CL_CM_CONNECTION_CLEARED
-(
-  PDLogBase::CL_CPP_COMMON_ID + 10,
-  LOG_INFO,
-  "Connection between %s and %s has been restored.",
-  "This process can now contact at least one instance of the application it's "
-  "trying to connect to, and has seen no errors in the previous monitoring period",
-  "Normal.",
-  "None."
-);
-
 static const PDLog CL_DNS_FILE_MALFORMED
 (
   PDLogBase::CL_CPP_COMMON_ID + 11,


### PR DESCRIPTION
The communication monitor had a very generic set of ENT logs that weren't very specific. This PR makes users of the monitor have to provide the ENT logs, so they can now be specific.

Tested in UT