### PR TITLE
[Reviewer: AJH] Add 20s HTTP request read timeout

### DIFF
--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -123,10 +123,8 @@ void HttpStack::initialize()
     _evhtp = evhtp_new(_evbase, NULL);
 
     // Set a read timeout of 20s to mitigate the Slowloris vulnerability.
-    struct timeval* recv_timeo = new timeval();
-    recv_timeo->tv_sec = 20;
-    evhtp_set_timeouts(_evhtp, recv_timeo, NULL);
-    delete recv_timeo;
+    struct timeval recv_timeo = { .tv_sec = 20, .tv_usec = 0 };
+    evhtp_set_timeouts(_evhtp, &timeval, NULL);
   }
 }
 

--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -124,7 +124,7 @@ void HttpStack::initialize()
 
     // Set a read timeout of 20s to mitigate the Slowloris vulnerability.
     struct timeval recv_timeo = { .tv_sec = 20, .tv_usec = 0 };
-    evhtp_set_timeouts(_evhtp, &timeval, NULL);
+    evhtp_set_timeouts(_evhtp, &recv_timeo, NULL);
   }
 }
 

--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -123,9 +123,10 @@ void HttpStack::initialize()
     _evhtp = evhtp_new(_evbase, NULL);
 
     // Set a read timeout of 20s to mitigate the Slowloris vulnerability.
-    struct timeval recv_timeo;
-    recv_timeo.tv_sec = 20;
+    struct timeval* recv_timeo = new timeval();
+    recv_timeo->tv_sec = 20;
     evhtp_set_timeouts(_evhtp, recv_timeo, NULL);
+    delete recv_timeo;
   }
 }
 

--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -124,8 +124,8 @@ void HttpStack::initialize()
 
     // Set a buffer read timeout of 20s to mitigate the Slowloris
     // vulnerability. This is short enough that single attackers should be
-    // unable to block the server, and long enough to handle legitimate
-    // requests unless we're hitting major network problems.
+    // unable to block the server. We don't want to set it too short to ensure
+    // multiple sites can still talk to each other with latency involved.
     struct timeval recv_timeo = { .tv_sec = 20, .tv_usec = 0 };
     evhtp_set_timeouts(_evhtp, &recv_timeo, NULL);
   }

--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -121,6 +121,11 @@ void HttpStack::initialize()
   if (!_evhtp)
   {
     _evhtp = evhtp_new(_evbase, NULL);
+
+    // Set a read timeout of 20s to mitigate the Slowloris vulnerability.
+    struct timeval recv_timeo;
+    recv_timeo.tv_sec = 20;
+    evhtp_set_timeouts(_evhtp, recv_timeo, NULL);
   }
 }
 

--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -122,7 +122,10 @@ void HttpStack::initialize()
   {
     _evhtp = evhtp_new(_evbase, NULL);
 
-    // Set a read timeout of 20s to mitigate the Slowloris vulnerability.
+    // Set a buffer read timeout of 20s to mitigate the Slowloris
+    // vulnerability. This is short enough that single attackers should be
+    // unable to block the server, and long enough to handle legitimate
+    // requests unless we're hitting major network problems.
     struct timeval recv_timeo = { .tv_sec = 20, .tv_usec = 0 };
     evhtp_set_timeouts(_evhtp, &recv_timeo, NULL);
   }


### PR DESCRIPTION
@AlexHockey please let me know if you're not the right person to take this.

This addresses a potential vulnerability in libevhtp. After initialising the stack, we set a 20s read timeout. Closure of the vulnerability has been tested by running nmap: after applying this fix, the issue is not flagged.