### PR TITLE
Replace a duff engineering log with a SAS log

### DIFF
--- a/include/sasevent.h
+++ b/include/sasevent.h
@@ -18,7 +18,7 @@
 namespace SASEvent {
   // The resource bundle datestamp is updated automatically by Jenkins.
   // !!!DO NOT EDIT THE FOLLOWING LINE MANUALLY!!!
-  const std::string CURRENT_RESOURCE_BUNDLE_DATESTAMP = "20170720";
+  const std::string CURRENT_RESOURCE_BUNDLE_DATESTAMP = "20170719";
   const std::string RESOURCE_BUNDLE_NAME = "org.projectclearwater";
   const std::string CURRENT_RESOURCE_BUNDLE =
                  RESOURCE_BUNDLE_NAME + "." + CURRENT_RESOURCE_BUNDLE_DATESTAMP;

--- a/include/sasevent.h
+++ b/include/sasevent.h
@@ -18,7 +18,7 @@
 namespace SASEvent {
   // The resource bundle datestamp is updated automatically by Jenkins.
   // !!!DO NOT EDIT THE FOLLOWING LINE MANUALLY!!!
-  const std::string CURRENT_RESOURCE_BUNDLE_DATESTAMP = "20170719";
+  const std::string CURRENT_RESOURCE_BUNDLE_DATESTAMP = "20170720";
   const std::string RESOURCE_BUNDLE_NAME = "org.projectclearwater";
   const std::string CURRENT_RESOURCE_BUNDLE =
                  RESOURCE_BUNDLE_NAME + "." + CURRENT_RESOURCE_BUNDLE_DATESTAMP;
@@ -103,6 +103,9 @@ namespace SASEvent {
 
   const int HTTP_BAD_RETRY_AFTER_VALUE = COMMON_BASE + 0x000016;
   const int HTTP_BAD_RETRY_AFTER_VALUE_DETAIL = COMMON_BASE + 0x000017;
+
+  const int HTTP_HOSTNAME_DID_NOT_RESOLVE = COMMON_BASE + 0x000018;
+  const int HTTP_HOSTNAME_DID_NOT_RESOLVE_DETAIL = COMMON_BASE + 0x000019;
 
   const int MEMCACHED_GET_START = COMMON_BASE + 0x000100;
   const int MEMCACHED_GET_SUCCESS = COMMON_BASE + 0x000101;

--- a/src/httpclient.cpp
+++ b/src/httpclient.cpp
@@ -645,6 +645,7 @@ HTTPCode HttpClient::send_request(RequestType request_type,
   if (attempts == 0)
   {
     // We didn't even attempt to contact a server, so produce a SAS log saying so.
+    TRC_INFO("Failed to resolve hostname for %s to %s", method_str.c_str(), url.c_str());
     SAS::Event event(trail,
                      ((_sas_log_level == SASEvent::HttpLogLevel::PROTOCOL) ?
                        SASEvent::HTTP_HOSTNAME_DID_NOT_RESOLVE :

--- a/src/httpclient.cpp
+++ b/src/httpclient.cpp
@@ -337,6 +337,9 @@ HTTPCode HttpClient::send_request(RequestType request_type,
   HTTPCode http_code;
   CURLcode rc;
 
+  // Get the request method for logging purposes.
+  std::string method_str = request_type_to_string(request_type);
+
   // Create a UUID to use for SAS correlation.
   boost::uuids::uuid uuid = get_random_uuid();
   std::string uuid_str = boost::uuids::to_string(uuid);
@@ -384,7 +387,8 @@ HTTPCode HttpClient::send_request(RequestType request_type,
   // connection is made, a specified number of failures is reached, or the
   // targets are exhausted. If only one target is available, it should be tried
   // twice.
-  for (int attempts = 0;
+  int attempts;
+  for (attempts = 0;
        target_it->next(target) || attempts == 1;
        ++attempts)
   {
@@ -481,7 +485,6 @@ HTTPCode HttpClient::send_request(RequestType request_type,
     rc = curl_easy_perform(curl);
 
     // If a request was sent, log it to SAS.
-    std::string method_str = request_type_to_string(request_type);
     if (recorder.request.length() > 0)
     {
       sas_log_http_req(trail, curl, method_str, url, recorder.request, req_timestamp, 0);
@@ -639,6 +642,19 @@ HTTPCode HttpClient::send_request(RequestType request_type,
 
   delete target_it;
 
+  if (attempts == 0)
+  {
+    // We didn't even attempt to contact a server, so produce a SAS log saying so.
+    SAS::Event event(trail,
+                     ((_sas_log_level == SASEvent::HttpLogLevel::PROTOCOL) ?
+                       SASEvent::HTTP_HOSTNAME_DID_NOT_RESOLVE :
+                       SASEvent::HTTP_HOSTNAME_DID_NOT_RESOLVE_DETAIL),
+                     0);
+    event.add_var_param(method_str);
+    event.add_var_param(url);
+    SAS::report_event(event);
+  }
+
   // Check whether we should apply a penalty. We do this when:
   //  - both attempts return 503 errors, which means the downstream node is
   //    overloaded/requests to it are timeing.
@@ -680,11 +696,6 @@ HTTPCode HttpClient::send_request(RequestType request_type,
     {
       _comm_monitor->inform_failure(now_ms);
     }
-  }
-
-  if (((rc != CURLE_OK) && (rc != CURLE_REMOTE_FILE_NOT_FOUND)) || (http_code >= 400))
-  {
-    TRC_ERROR("cURL failure with cURL error code %d (see man 3 libcurl-errors) and HTTP error code %ld", (int)rc, http_code);  // LCOV_EXCL_LINE
   }
 
   return http_code;


### PR DESCRIPTION
The log at the end of `HttpClient::send_request` is all kinds of wrong. 

* It contains little useful information about what was going on that might have caused the problem.
* It can be generated when there wasn't a cURL error.
* It can be generated when cURL wasn't even invoked (e.g. when DNS failed to resolve).
* It shouldn't even be a log - it should be a SAS event instead. 

This PR fixes these issues by removing the log and replacing it with a SAS log covering the scenario when the hostname does not resolve. 