### PR TITLE
Add support for string and time indexed event stats

### DIFF
--- a/include/event_statistic_accumulator.h
+++ b/include/event_statistic_accumulator.h
@@ -47,7 +47,7 @@ public:
   void accumulate(uint32_t sample);
 
   // Compute the current statistics values.
-  inline void get_stats(EventStatistics &stats);
+  void get_stats(EventStatistics &stats);
 
   // Reset all of the statistics.
   void reset(uint64_t periodstart, EventStatisticAccumulator* previous = NULL);

--- a/include/event_statistic_accumulator.h
+++ b/include/event_statistic_accumulator.h
@@ -14,8 +14,6 @@
 #include <string>
 #include <atomic>
 
-#include "logger.h"
-
 #ifndef EVENT_STATISTIC_ACCUMULATOR_H
 #define EVENT_STATISTIC_ACCUMULATOR_H
 
@@ -27,6 +25,7 @@
 namespace SNMP
 {
 
+// Structure used to hold calculated statistics.
 struct EventStatistics
 {
   uint_fast64_t count;
@@ -43,16 +42,22 @@ public:
   EventStatisticAccumulator();
   virtual ~EventStatisticAccumulator() {};
 
-  // Accumulate a sample into the underlying statistics.
+  // Accumulate data about an additional event.  E.g. for SIP request
+  // latencies, this would be called each time a response is received to track
+  // the latency of that request.
   void accumulate(uint32_t sample);
 
-  // Compute the current statistics values.
+  // Compute the current statistics values and fill them in in the supplied
+  // EventStatistics structure.
   void get_stats(EventStatistics &stats);
 
   // Reset all of the statistics.
   void reset(uint64_t periodstart, EventStatisticAccumulator* previous = NULL);
 
 private:
+  // The quantities that we track dynamically as we receive information about
+  // individual events.  These are sufficient to calculate all of the
+  // statistics that we need to be able to report.
   std::atomic_uint_fast64_t _count;
   std::atomic_uint_fast64_t _sum;
   std::atomic_uint_fast64_t _sqsum;

--- a/include/event_statistic_accumulator.h
+++ b/include/event_statistic_accumulator.h
@@ -1,0 +1,65 @@
+/**
+ * @file event_statistic_accumulator.h
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#include <vector>
+#include <map>
+#include <string>
+#include <atomic>
+
+#include "logger.h"
+
+#ifndef EVENT_STATISTIC_ACCUMULATOR_H
+#define EVENT_STATISTIC_ACCUMULATOR_H
+
+// This file defines the event statistics class which is used for accumulating
+// single measurements of an event (e.g. the latency of SIP requests) and
+// calculating a set of statistics based on those measurements: HWM, LWM,
+// Count, Average (Mean) and Variance.
+
+namespace SNMP
+{
+
+struct EventStatistics
+{
+  uint_fast64_t count;
+  uint_fast64_t mean;
+  uint_fast64_t variance;
+  uint_fast64_t lwm;
+  uint_fast64_t hwm;
+};
+
+
+class EventStatisticAccumulator
+{
+public:
+  EventStatisticAccumulator();
+  virtual ~EventStatisticAccumulator() {};
+
+  // Accumulate a sample into the underlying statistics.
+  void accumulate(uint32_t sample);
+
+  // Compute the current statistics values.
+  inline void get_stats(EventStatistics &stats);
+
+  // Reset all of the statistics.
+  void reset(uint64_t periodstart, EventStatisticAccumulator* previous = NULL);
+
+private:
+  std::atomic_uint_fast64_t _count;
+  std::atomic_uint_fast64_t _sum;
+  std::atomic_uint_fast64_t _sqsum;
+  std::atomic_uint_fast64_t _hwm;
+  std::atomic_uint_fast64_t _lwm;
+};
+
+}
+
+#endif

--- a/include/snmp_internal/snmp_time_period_and_string_table.h
+++ b/include/snmp_internal/snmp_time_period_and_string_table.h
@@ -15,8 +15,8 @@
 #ifndef SNMP_TIME_PERIOD_AND_STRING_TABLE_H
 #define SNMP_TIME_PERIOD_AND_STRING_TABLE_H
 
-// This file contains the base infrastructure for SNMP tables
-// which are indexed by time period and a string (e.g. app server URI.
+// This file contains the base infrastructure for SNMP tables that are indexed
+// by time period and a string.
 namespace SNMP
 {
 

--- a/include/snmp_internal/snmp_time_period_and_string_table.h
+++ b/include/snmp_internal/snmp_time_period_and_string_table.h
@@ -1,0 +1,48 @@
+/**
+ * @file snmp_time_period_and_string_table.h
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#include "snmp_time_period_table.h"
+#include "snmp_node_types.h"
+
+#ifndef SNMP_TIME_PERIOD_AND_STRING_TABLE_H
+#define SNMP_TIME_PERIOD_AND_STRING_TABLE_H
+
+// This file contains the base infrastructure for SNMP tables
+// which are indexed by time period and a string (e.g. app server URI.
+namespace SNMP
+{
+
+template <class T> class TimeAndStringBasedRow : public TimeBasedRow<T>
+{
+public:
+  // Constructor, takes ownership of the View*.
+  TimeAndStringBasedRow(int time_index, std::string string_index, typename TimeBasedRow<T>::View* view) :
+    TimeBasedRow<T>(time_index, view),
+    _string_ndex(string_index)
+  {
+    // Add index for the other type (the time index is added in the base class)
+    netsnmp_tdata_row_add_index(this->_row,
+                                ASN_OCTET_STR,
+                                string_index.c_str(),
+                                string_index.length());
+  };
+
+  virtual ~TimeAndOtherTypeBasedRow()
+  {
+  };
+
+protected:
+  std::string _string_index;
+};
+
+}
+
+#endif

--- a/include/snmp_internal/snmp_time_period_and_string_table.h
+++ b/include/snmp_internal/snmp_time_period_and_string_table.h
@@ -26,7 +26,7 @@ public:
   // Constructor, takes ownership of the View*.
   TimeAndStringBasedRow(int time_index, std::string string_index, typename TimeBasedRow<T>::View* view) :
     TimeBasedRow<T>(time_index, view),
-    _string_ndex(string_index)
+    _index(string_index)
   {
     // Add index for the other type (the time index is added in the base class)
     netsnmp_tdata_row_add_index(this->_row,
@@ -35,12 +35,12 @@ public:
                                 string_index.length());
   };
 
-  virtual ~TimeAndOtherTypeBasedRow()
+  virtual ~TimeAndStringBasedRow()
   {
   };
 
 protected:
-  std::string _string_index;
+  std::string _index;
 };
 
 }

--- a/include/snmp_internal/snmp_time_period_and_string_table.h
+++ b/include/snmp_internal/snmp_time_period_and_string_table.h
@@ -26,7 +26,7 @@ public:
   // Constructor, takes ownership of the View*.
   TimeAndStringBasedRow(int time_index, std::string string_index, typename TimeBasedRow<T>::View* view) :
     TimeBasedRow<T>(time_index, view),
-    _index(string_index)
+    _string_index(string_index)
   {
     // Add index for the other type (the time index is added in the base class)
     netsnmp_tdata_row_add_index(this->_row,
@@ -40,7 +40,7 @@ public:
   };
 
 protected:
-  std::string _index;
+  std::string _string_index;
 };
 
 }

--- a/include/snmp_internal/snmp_time_period_and_string_table.h
+++ b/include/snmp_internal/snmp_time_period_and_string_table.h
@@ -28,7 +28,7 @@ public:
     TimeBasedRow<T>(time_index, view),
     _string_index(string_index)
   {
-    // Add index for the other type (the time index is added in the base class)
+    // Add the string index (the time index is added in the base class)
     netsnmp_tdata_row_add_index(this->_row,
                                 ASN_OCTET_STR,
                                 string_index.c_str(),

--- a/include/snmp_time_and_string_based_event_table.h
+++ b/include/snmp_time_and_string_based_event_table.h
@@ -1,0 +1,40 @@
+/**
+ * @file snmp_time_and_string_based_event_table.h
+ *
+ * Copyright (C) Metaswitch Networks 2015
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#include <vector>
+#include <map>
+
+#ifndef SNMP_TIME_AND_STRING_BASED_EVENT_TABLE_H
+#define SNMP TIME_AND_STRING_BASED_EVENT_TABLE_H
+
+// This file contains the interface for tables which:
+//   - are indexed by time period and a string
+//   - accumulate an event metric
+//   - report columns for mean, variance, hwm, lwm and count.
+//
+// This is defined as an interface in order not to pollute the codebase with netsnmp include files
+// (which indiscriminately #define things like READ and WRITE).
+
+namespace SNMP
+{
+
+class TimeAndStringBasedEventTable
+{
+public:
+  TimeAndStringBasedEventTable() {};
+  virtual ~TimeAndStringBasedEventTable() {};
+
+  static TimeAndStringBasedEventTable* create(std::string name, std::string oid);
+  virtual void accumulate(std::string str_index, uint32_t sample) = 0;
+};
+
+}
+#endif

--- a/include/snmp_time_and_string_based_event_table.h
+++ b/include/snmp_time_and_string_based_event_table.h
@@ -32,7 +32,7 @@
 // Rows are automatically added to the table the first time a measurement is
 // accumulated for a given value of the string index.  They are never removed.
 // It would be possible to enhance this table to support removal of string
-// indices in future if that is required.
+// index values in future if that is required.
 //
 // This is defined as an interface in order not to pollute the codebase with netsnmp include files
 // (which indiscriminately #define things like READ and WRITE).

--- a/include/snmp_time_and_string_based_event_table.h
+++ b/include/snmp_time_and_string_based_event_table.h
@@ -1,7 +1,7 @@
 /**
  * @file snmp_time_and_string_based_event_table.h
  *
- * Copyright (C) Metaswitch Networks 2015
+ * Copyright (C) Metaswitch Networks 2017
  * If license terms are provided to you in a COPYING file in the root directory
  * of the source code repository by which you are accessing this code, then
  * the license outlined in that COPYING file applies to your use.

--- a/include/snmp_time_and_string_based_event_table.h
+++ b/include/snmp_time_and_string_based_event_table.h
@@ -13,7 +13,7 @@
 #include <map>
 
 #ifndef SNMP_TIME_AND_STRING_BASED_EVENT_TABLE_H
-#define SNMP TIME_AND_STRING_BASED_EVENT_TABLE_H
+#define SNMP_TIME_AND_STRING_BASED_EVENT_TABLE_H
 
 // This file contains the interface for tables which:
 //   - are indexed by time period and a string

--- a/include/snmp_time_and_string_based_event_table.h
+++ b/include/snmp_time_and_string_based_event_table.h
@@ -15,14 +15,28 @@
 #ifndef SNMP_TIME_AND_STRING_BASED_EVENT_TABLE_H
 #define SNMP_TIME_AND_STRING_BASED_EVENT_TABLE_H
 
-// This file contains the interface for tables which:
+// This file contains the interface for tables that:
 //   - are indexed by time period and a string
-//   - accumulate an event metric
+//   - accumulate an event metric for different values of the string index
 //   - report columns for mean, variance, hwm, lwm and count.
+//
+// An example would be a table that tracks SIP request latencies per
+// application server URL.
+//
+// To create such a table, simply create one, and call `accumulate` on it as data comes in,
+// e.g.:
+//
+// TimeAndStringBasedEventTable* as_latency_table = TimeAndStringBasedEventTable::create("per_as_sip_latencies", ".1.2.3");
+// as_latency_table->accumulate("appserver.domain", 158);
+//
+// Rows are automatically added to the table the first time a measurement is
+// accumulated for a given value of the string index.  They are never removed.
+// It would be possible to enhance this table to support removal of string
+// indices in future if that is required.
 //
 // This is defined as an interface in order not to pollute the codebase with netsnmp include files
 // (which indiscriminately #define things like READ and WRITE).
-
+//
 namespace SNMP
 {
 

--- a/include/snmp_time_and_string_based_event_table.h
+++ b/include/snmp_time_and_string_based_event_table.h
@@ -13,7 +13,7 @@
 #include <map>
 
 #ifndef SNMP_TIME_AND_STRING_BASED_EVENT_TABLE_H
-//#define SNMP TIME_AND_STRING_BASED_EVENT_TABLE_H
+#define SNMP TIME_AND_STRING_BASED_EVENT_TABLE_H
 
 // This file contains the interface for tables which:
 //   - are indexed by time period and a string

--- a/include/snmp_time_and_string_based_event_table.h
+++ b/include/snmp_time_and_string_based_event_table.h
@@ -13,7 +13,7 @@
 #include <map>
 
 #ifndef SNMP_TIME_AND_STRING_BASED_EVENT_TABLE_H
-#define SNMP TIME_AND_STRING_BASED_EVENT_TABLE_H
+//#define SNMP TIME_AND_STRING_BASED_EVENT_TABLE_H
 
 // This file contains the interface for tables which:
 //   - are indexed by time period and a string

--- a/src/event_statistic_accumulator.cpp
+++ b/src/event_statistic_accumulator.cpp
@@ -54,7 +54,7 @@ void EventStatisticAccumulator::accumulate(uint32_t sample)
   }
 }
 
-inline void EventStatisticAccumulator::get_stats(EventStatistics &stats)
+void EventStatisticAccumulator::get_stats(EventStatistics &stats)
 {
   stats.count = _count;
 

--- a/src/event_statistic_accumulator.cpp
+++ b/src/event_statistic_accumulator.cpp
@@ -1,0 +1,91 @@
+/**
+ * @file event_statistic_accumulator.cpp
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#include <vector>
+#include <map>
+#include <string>
+#include <atomic>
+
+#include "logger.h"
+#include "event_statistic_accumulator.h"
+#include "limits.h"
+
+namespace SNMP
+{
+
+EventStatisticAccumulator::EventStatisticAccumulator()
+{
+  reset(0);
+}
+
+void EventStatisticAccumulator::accumulate(uint32_t sample)
+{
+  _count++;
+
+  // Just keep a running total as we go along, so we can calculate the average and variance on
+  // request
+  _sum += sample;
+  _sqsum += (sample * sample);
+
+  // Update the low- and high-water marks.  In each case, we get the current
+  // value, decide whether a change is required and then atomically swap it
+  // if so, repeating if it was changed in the meantime.  Note that
+  // compare_exchange_weak loads the current value into the expected value
+  // parameter (lwm or hwm below) if the compare fails.
+  uint_fast64_t lwm = _lwm.load();
+  while ((sample < lwm) &&
+         (!_lwm.compare_exchange_weak(lwm, sample)))
+  {
+    // Do nothing.
+  }
+  uint_fast64_t hwm = _hwm.load();
+  while ((sample > hwm) &&
+         (!_hwm.compare_exchange_weak(hwm, sample)))
+  {
+    // Do nothing.
+  }
+}
+
+inline void EventStatisticAccumulator::get_stats(EventStatistics &stats)
+{
+  stats.count = _count;
+
+  if (_count > 0)
+  {
+    // Get the values that we are working with atomically.
+    uint_fast64_t sum = _sum;
+    uint_fast64_t sumsq = _sqsum;
+
+    // Calculate the average and the variance from the stored sum and sum-of-squares.
+    stats.mean = sum/stats.count;
+    stats.variance = ((sumsq * stats.count) - (sum * sum)) / (stats.count * stats.count);
+    stats.hwm = _hwm;
+    stats.lwm = _lwm;
+  }
+  else
+  {
+    stats.mean = 0;
+    stats.variance = 0;
+    stats.lwm = 0;
+    stats.hwm = 0;
+  }
+}
+
+void EventStatisticAccumulator::reset(uint64_t periodstart, EventStatisticAccumulator* previous)
+{
+  _count = 0;
+  _sum = 0;
+  _sqsum = 0;
+  _lwm = ULONG_MAX;
+  _hwm = 0;
+}
+
+}

--- a/src/event_statistic_accumulator.cpp
+++ b/src/event_statistic_accumulator.cpp
@@ -14,7 +14,7 @@
 #include <string>
 #include <atomic>
 
-#include "logger.h"
+#include "log.h"
 #include "event_statistic_accumulator.h"
 #include "limits.h"
 
@@ -28,6 +28,7 @@ EventStatisticAccumulator::EventStatisticAccumulator()
 
 void EventStatisticAccumulator::accumulate(uint32_t sample)
 {
+  TRC_DEBUG("Accumulate %u for %p", sample, this);
   _count++;
 
   // Just keep a running total as we go along, so we can calculate the average and variance on
@@ -56,6 +57,7 @@ void EventStatisticAccumulator::accumulate(uint32_t sample)
 
 void EventStatisticAccumulator::get_stats(EventStatistics &stats)
 {
+  TRC_DEBUG("Get stats for %p", this);
   stats.count = _count;
 
   if (_count > 0)

--- a/src/event_statistic_accumulator.cpp
+++ b/src/event_statistic_accumulator.cpp
@@ -68,11 +68,11 @@ void EventStatisticAccumulator::get_stats(EventStatistics &stats)
     // Note that e.g. _sum is a std::atomic and so assignment is guaranteed
     // atomic.
     uint_fast64_t sum = _sum;
-    uint_fast64_t sumsq = _sqsum;
+    uint_fast64_t sqsum = _sqsum;
 
     // Calculate the average and the variance from the stored sum and sum-of-squares.
     stats.mean = sum/stats.count;
-    stats.variance = ((sumsq * stats.count) - (sum * sum)) / (stats.count * stats.count);
+    stats.variance = ((sqsum * stats.count) - (sum * sum)) / (stats.count * stats.count);
     stats.hwm = _hwm;
     stats.lwm = _lwm;
   }

--- a/src/snmp_event_accumulator_by_scope_table.cpp
+++ b/src/snmp_event_accumulator_by_scope_table.cpp
@@ -1,7 +1,7 @@
 /**
  * @file snmp_event_accumulator_by_scope_table.cpp
  *
- * Copyright (C) Metaswitch Networks 2016
+ * Copyright (C) Metaswitch Networks 2017
  * If license terms are provided to you in a COPYING file in the root directory
  * of the source code repository by which you are accessing this code, then
  * the license outlined in that COPYING file applies to your use.

--- a/src/snmp_event_accumulator_by_scope_table.cpp
+++ b/src/snmp_event_accumulator_by_scope_table.cpp
@@ -13,28 +13,17 @@
 #include "snmp_internal/snmp_time_period_and_scope_table.h"
 #include "snmp_event_accumulator_table.h"
 #include "snmp_event_accumulator_by_scope_table.h"
+#include "event_statistic_accumulator.h"
 #include "limits.h"
 
 namespace SNMP
 {
 
-// Storage for the underlying data
-struct EventStatistics
-{
-  std::atomic_uint_fast64_t count;
-  std::atomic_uint_fast64_t sum;
-  std::atomic_uint_fast64_t sqsum;
-  std::atomic_uint_fast64_t hwm;
-  std::atomic_uint_fast64_t lwm;
-
-  void reset(uint64_t periodstart, EventStatistics* previous = NULL);
-};
-
-// A TimeAndScopeBasedRow that maps the data from EventStatistics into the right five columns.
-class EventAccumulatorByScopeRow: public TimeAndScopeBasedRow<EventStatistics>
+// A TimeAndScopeBasedRow that maps the data from EventStatisticAccumulator into the right five columns.
+class EventAccumulatorByScopeRow: public TimeAndScopeBasedRow<EventStatisticAccumulator>
 {
 public:
-  EventAccumulatorByScopeRow(int time_index, std::string scope_index, View* view): TimeAndScopeBasedRow<EventStatistics>(time_index, scope_index, view) {};
+  EventAccumulatorByScopeRow(int time_index, std::string scope_index, View* view): TimeAndScopeBasedRow<EventStatisticAccumulator>(time_index, scope_index, view) {};
   ColumnData get_columns();
 };
 
@@ -88,76 +77,38 @@ private:
     return new EventAccumulatorByScopeRow(index, "node", view);
   }
 
-  void accumulate_internal(CurrentAndPrevious<EventStatistics>& data, uint32_t sample)
+  void accumulate_internal(CurrentAndPrevious<EventStatisticAccumulator>& data, uint32_t sample)
   {
     struct timespec now;
     clock_gettime(CLOCK_REALTIME_COARSE, &now);
 
-    EventStatistics* current = data.get_current(now);
-
-    current->count++;
-
-    // Just keep a running total as we go along, so we can calculate the average and variance on
-    // request
-    current->sum += sample;
-    current->sqsum += (sample * sample);
-
-    // Update the low- and high-water marks.  In each case, we get the current
-    // value, decide whether a change is required and then atomically swap it
-    // if so, repeating if it was changed in the meantime.  Note that
-    // compare_exchange_weak loads the current value into the expected value
-    // parameter (lwm or hwm below) if the compare fails.
-    uint_fast64_t lwm = current->lwm.load();
-    while ((sample < lwm) &&
-           (!current->lwm.compare_exchange_weak(lwm, sample)))
-    {
-      // Do nothing.
-    }
-    uint_fast64_t hwm = current->hwm.load();
-    while ((sample > hwm) &&
-           (!current->hwm.compare_exchange_weak(hwm, sample)))
-    {
-      // Do nothing.
-    }
+    EventStatisticAccumulator* current = data.get_current(now);
+    current->accumulate(sample);
   };
 
   int n;
 
-  CurrentAndPrevious<EventStatistics> five_second;
-  CurrentAndPrevious<EventStatistics> five_minute;
+  CurrentAndPrevious<EventStatisticAccumulator> five_second;
+  CurrentAndPrevious<EventStatisticAccumulator> five_minute;
 };
 
 ColumnData EventAccumulatorByScopeRow::get_columns()
 {
   struct timespec now;
   clock_gettime(CLOCK_REALTIME_COARSE, &now);
+  EventStatistics statistics;
 
-  EventStatistics* accumulated = _view->get_data(now);
-  uint_fast32_t count = accumulated->count.load();
-
-  uint_fast32_t avg = 0;
-  uint_fast32_t variance = 0;
-  uint_fast32_t lwm = 0;
-  uint_fast32_t hwm = 0;
-
-  if (count > 0)
-  {
-    uint_fast64_t sum = accumulated->sum.load();
-    uint_fast64_t sumsq = accumulated->sqsum.load();
-    // Calculate the average and the variance from the stored sum and sum-of-squares.
-    avg = sum/count;
-    variance = ((sumsq * count) - (sum * sum)) / (count * count);
-    hwm = accumulated->hwm.load();
-    lwm = accumulated->lwm.load();
-  }
+  EventStatisticAccumulator* accumulated = _view->get_data(now);
+  accumulated->get_stats(statistics);
 
   // Construct and return a ColumnData with the appropriate values
   ColumnData ret;
-  ret[3] = Value::uint(avg);
-  ret[4] = Value::uint(variance);
-  ret[5] = Value::uint(hwm);
-  ret[6] = Value::uint(lwm);
-  ret[7] = Value::uint(count);
+  ret[3] = Value::uint(statistics.mean);
+  ret[4] = Value::uint(statistics.variance);
+  ret[5] = Value::uint(statistics.hwm);
+  ret[6] = Value::uint(statistics.lwm);
+  ret[7] = Value::uint(statistics.count);
+
   return ret;
 }
 

--- a/src/snmp_event_accumulator_table.cpp
+++ b/src/snmp_event_accumulator_table.cpp
@@ -1,7 +1,7 @@
 /**
  * @file snmp_event_accumulator_table.cpp
  *
- * Copyright (C) Metaswitch Networks 2015
+ * Copyright (C) Metaswitch Networks 2017
  * If license terms are provided to you in a COPYING file in the root directory
  * of the source code repository by which you are accessing this code, then
  * the license outlined in that COPYING file applies to your use.

--- a/src/snmp_event_accumulator_table.cpp
+++ b/src/snmp_event_accumulator_table.cpp
@@ -11,28 +11,17 @@
 
 #include "snmp_internal/snmp_time_period_table.h"
 #include "snmp_event_accumulator_table.h"
+#include "event_statistic_accumulator.h"
 #include "limits.h"
 
 namespace SNMP
 {
 
-// Storage for the underlying data
-struct EventStatistics
-{
-  std::atomic_uint_fast64_t count;
-  std::atomic_uint_fast64_t sum;
-  std::atomic_uint_fast64_t sqsum;
-  std::atomic_uint_fast64_t hwm;
-  std::atomic_uint_fast64_t lwm;
-
-  void reset(uint64_t periodstart, EventStatistics* previous = NULL);
-};
-
-// Just a TimeBasedRow that maps the data from EventStatistics into the right five columns.
-class EventAccumulatorRow: public TimeBasedRow<EventStatistics>
+// Just a TimeBasedRow that maps the data from EventStatisticAccumulator into the right five columns.
+class EventAccumulatorRow: public TimeBasedRow<EventStatisticAccumulator>
 {
 public:
-  EventAccumulatorRow(int index, View* view): TimeBasedRow<EventStatistics>(index, view) {};
+  EventAccumulatorRow(int index, View* view): TimeBasedRow<EventStatisticAccumulator>(index, view) {};
   ColumnData get_columns();
 };
 
@@ -83,86 +72,38 @@ private:
     return new EventAccumulatorRow(index, view);
   }
 
-  void accumulate_internal(CurrentAndPrevious<EventStatistics>& data, uint32_t sample)
+  void accumulate_internal(CurrentAndPrevious<EventStatisticAccumulator>& data, uint32_t sample)
   {
     struct timespec now;
     clock_gettime(CLOCK_REALTIME_COARSE, &now);
 
-    EventStatistics* current = data.get_current(now);
-
-    current->count++;
-
-    // Just keep a running total as we go along, so we can calculate the average and variance on
-    // request
-    current->sum += sample;
-    current->sqsum += (sample * sample);
-
-    // Update the low- and high-water marks.  In each case, we get the current
-    // value, decide whether a change is required and then atomically swap it
-    // if so, repeating if it was changed in the meantime.  Note that
-    // compare_exchange_weak loads the current value into the expected value
-    // parameter (lwm or hwm below) if the compare fails.
-    uint_fast64_t lwm = current->lwm.load();
-    while ((sample < lwm) &&
-           (!current->lwm.compare_exchange_weak(lwm, sample)))
-    {
-      // Do nothing.
-    }
-    uint_fast64_t hwm = current->hwm.load();
-    while ((sample > hwm) &&
-           (!current->hwm.compare_exchange_weak(hwm, sample)))
-    {
-      // Do nothing.
-    }
+    EventStatisticAccumulator* current = data.get_current(now);
+    current->accumulate(sample);
   };
 
 
-  CurrentAndPrevious<EventStatistics> five_second;
-  CurrentAndPrevious<EventStatistics> five_minute;
+  CurrentAndPrevious<EventStatisticAccumulator> five_second;
+  CurrentAndPrevious<EventStatisticAccumulator> five_minute;
 };
 
-
-void EventStatistics::reset(uint64_t periodstart, EventStatistics* previous)
-{
-  count.store(0);
-  sum.store(0);
-  sqsum.store(0);
-  lwm.store(ULONG_MAX);
-  hwm.store(0);
-}
 
 ColumnData EventAccumulatorRow::get_columns()
 {
   struct timespec now;
   clock_gettime(CLOCK_REALTIME_COARSE, &now);
+  EventStatistics statistics;
 
-  EventStatistics* accumulated = _view->get_data(now);
-  uint_fast32_t count = accumulated->count.load();
-
-  uint_fast32_t avg = 0;
-  uint_fast32_t variance = 0;
-  uint_fast32_t lwm = 0;
-  uint_fast32_t hwm = 0;
-
-  if (count > 0)
-  {
-    uint_fast64_t sum = accumulated->sum.load();
-    uint_fast64_t sumsq = accumulated->sqsum.load();
-    // Calculate the average and the variance from the stored sum and sum-of-squares.
-    avg = sum/count;
-    variance = ((sumsq * count) - (sum * sum)) / (count * count);
-    hwm = accumulated->hwm.load();
-    lwm = accumulated->lwm.load();
-  }
+  EventStatisticAccumulator* accumulated = _view->get_data(now);
+  accumulated->get_stats(statistics);
 
   // Construct and return a ColumnData with the appropriate values
   ColumnData ret;
   ret[1] = Value::integer(_index);
-  ret[2] = Value::uint(avg);
-  ret[3] = Value::uint(variance);
-  ret[4] = Value::uint(hwm);
-  ret[5] = Value::uint(lwm);
-  ret[6] = Value::uint(count);
+  ret[2] = Value::uint(statistics.mean);
+  ret[3] = Value::uint(statistics.variance);
+  ret[4] = Value::uint(statistics.hwm);
+  ret[5] = Value::uint(statistics.lwm);
+  ret[6] = Value::uint(statistics.count);
   return ret;
 }
 

--- a/src/snmp_time_and_string_based_event_table.cpp
+++ b/src/snmp_time_and_string_based_event_table.cpp
@@ -1,0 +1,147 @@
+/**
+ * @file snmp_time_and_string_based_event_table.cpp
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#include "snmp_internal/snmp_includes.h"
+//#include "snmp_internal/snmp_time_period_and_string_table.h"
+#include "snmp_time_and_string_based_event_table.h"
+#include "event_statistic_accumulator.h"
+#include <vector>
+#include "logger.h"
+
+namespace SNMP
+{
+
+
+// Time and String Indexed Row that maps the data from SingleCount into the right column.
+class TimeAndStringBasedEventRow: public TimeAndStringBasedRow<EventStatisticAccumulator>
+{
+public:
+  TimeAndStringBasedEventRow(int time_index, std::string str_index, View* view):
+    TimeAndStringBasedRow<EventStatisticAccumulator>(time_index, str_index, view) {};
+
+  ColumnData get_columns()
+  {
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME_COARSE, &now);
+
+    EventStatistics statistics;
+
+    EventStatisticAccumulator* accumulated = _view->get_data(now);
+    accumulated->get_stats(statistics);
+
+    // Construct and return a ColumnData with the appropriate values
+    ColumnData ret;
+    ret[3] = Value::uint(statistics.mean);
+    ret[4] = Value::uint(statistics.variance);
+    ret[5] = Value::uint(statistics.hwm);
+    ret[6] = Value::uint(statistics.lwm);
+    ret[7] = Value::uint(statistics.count);
+    return ret;
+  }
+};
+
+class TimeAndStringBasedEventTableImpl: public ManagedTable<TimeAndStringBasedEventRow, int>, public TimeAndStringBasedEventTable
+{
+public:
+  TimeAndStringBasedEventTableImpl(std::string name,
+                                   std::string tbl_oid):
+    ManagedTable<TimeAndStringBasedEventRow, int>(name,
+                                                  tbl_oid,
+                                                  4,
+                                                  4,
+                                                  { ASN_INTEGER , ASN_INTEGER , ASN_INTEGER })
+  {
+    _table_rows = 0;
+    pthread_rwlock_init(&_table_lock, NULL);
+  }
+
+  void create_and_add_rows(std::string string_index)
+  {
+    // Create CurrentAndPrevious views of EventStatisticAccumulator to
+    // accumulate statistics for this row at each of 5s and 5m scopes.
+    // This is going to mutate the maps so get the write lock first.
+    pthread_rwlock_wrlock(&_table_lock);
+    _five_second[string_index] = new CurrentAndPrevious<EventStatisticAccumulator>(5000);
+    _five_minute[string_index] = new CurrentAndPrevious<EventStatisticAccumulator>(300000);
+    pthread_rwlock_unlock(&_table_lock);
+
+    // Now add the actual rows to the table, referencing the relevant views of
+    // the data that we've just created.
+    this->add(_table_rows++, new TimeAndStringBasedEventRow(TimePeriodIndexes::scopePrevious5SecondPeriod,
+                                    string_index,
+                                    new TimeAndStringBasedEventRow::PreviousView((*five_second)[code])));
+    this->add(_table_rows++, new TimeAndStringBasedEventRow(TimePeriodIndexes::scopeCurrent5MinutePeriod,
+                                    string_index,
+                                    new TimeAndStringBasedEventRow::CurrentView((*five_minute)[code])));
+    this->add(_table_rows++, new TimeAndStringBasedEventRow(TimePeriodIndexes::scopePrevious5MinutePeriod,
+                                    string_index,
+                                    new TimeAndStringBasedEventRow::PreviousView((*five_minute)[code])));
+  }
+
+  void accumulate(std::string string_index, uint32_t sample)
+  {
+    // First of all check to see if we have already created rows for this
+    // index.  If we have created rows then we will also have created entries
+    // in our _five_second and _five_minute maps for storing the data.  Check
+    // one of them.
+    bool rows_exist = false;
+
+    // We want to make sure that we get this right -- deciding that the rows
+    // exist when actually they don't would be bad.  Get the read lock first.
+    pthread_rwlock_rdlock(&_table_lock);
+    rows_exist = (_five_second.count(string_index) != 0)
+    pthread_rwlock_unlock(&_table_lock);
+
+    if (!rows_exist)
+    {
+      // We don't have rows for this index so create them now.
+      create_and_add_rows(string_index);
+    }
+
+    // The rows definitely exist now, so go ahead and accumulate the counts.
+    // We don't bother about locking the table here -- the worst that will
+    // happen is that the stats might be slightly wrong.
+    _five_second[string_index]->get_current().accumulate(sample);
+    _five_minute[string_index]->get_current().accumulate(sample);
+
+  }
+
+  ~TimeAndStringBasedEventTableImpl()
+  {
+    pthread_rwlock_destroy(&_table_lock);
+
+    //Spin through the maps of 5s and 5m views and delete them.
+    for (auto& kv : _five_second) {  delete kv->second; }
+    for (auto& kv : _five_minute) {  delete kv->second; }
+  }
+private:
+
+  TimeAndStringBasedEventRow* new_row(int indexes) { return NULL;};
+
+  // The number of rows in the table -- used to assign a unique (but arbitrary)
+  // index to each row.
+  int _table_rows;
+
+  // Maps for tracking our 5s and 5m views of the data for each string index
+  // used in the table, plus a lock to protect them.
+  pthread_rwlock_t _table_lock;
+
+  std::map<std::string, CurrentAndPrevious<SingleCount>*> _five_second;
+  std::map<std::string, CurrentAndPrevious<SingleCount>*> _five_minute;
+};
+
+TimeAndStringBasedEventTable* TimeAndStringBasedEventTable::create(std::string name,
+                                       std::string oid)
+{
+  return new TimeAndStringBasedEventTableImpl(name, oid);
+}
+
+}

--- a/src/snmp_time_and_string_based_event_table.cpp
+++ b/src/snmp_time_and_string_based_event_table.cpp
@@ -64,6 +64,7 @@ public:
                                                   7,
                                                   { ASN_INTEGER , ASN_OCTET_STR })
   {
+    TRC_INFO("Created table with name %s, OID %s", name.c_str(), tbl_oid.c_str());
     _table_rows = 0;
 
     // Create a lock to protect the maps in this table.  Note that our policy
@@ -89,6 +90,7 @@ public:
       // The rows already exist.  We don't release the RW lock until we've
       // completely finished adding all the rows so existence in the 5s map
       // means that all the rows are fully created.  Just return.
+      TRC_DEBUG("Tried to add new rows but another thread beat us to it");
       pthread_rwlock_unlock(&_table_lock);
       return;
     }
@@ -151,6 +153,8 @@ public:
 
   ~TimeAndStringBasedEventTableImpl()
   {
+    TRC_INFO("Destroying table with name %s", _name.c_str());
+
     pthread_rwlock_destroy(&_table_lock);
 
     //Spin through the maps of 5s and 5m views and delete them.

--- a/test_utils/test_snmp.h
+++ b/test_utils/test_snmp.h
@@ -13,6 +13,7 @@
 #include "utils.h"
 
 #include "snmp_event_accumulator_table.h"
+#include "snmp_event_accumulator_by_scope_table.h"
 #include "snmp_continuous_accumulator_table.h"
 #include "snmp_counter_table.h"
 #include "snmp_success_fail_count_table.h"

--- a/test_utils/test_snmp.h
+++ b/test_utils/test_snmp.h
@@ -22,6 +22,7 @@
 #include "test_interposer.hpp"
 #include "snmp_single_count_by_node_type_table.h"
 #include "snmp_success_fail_count_by_request_type_table.h"
+#include "snmp_time_and_string_based_event_table.h"
 #include "snmp_cx_counter_table.h"
 #include "snmp_ip_time_based_counter_table.h"
 
@@ -45,6 +46,10 @@ public:
 
   static void SetUpTestCase();
   static void TearDownTestCase();
+
+  std::string time_string_event_oid(std::string base, int stat, int time, std::string string_index);
+  void snmp_walk_debug(std::string base);
+
 private:
   std::string alarm_address;
 
@@ -134,5 +139,20 @@ void SNMPTest::TearDownTestCase()
   pthread_cancel(thr);
   pthread_join(thr, NULL);
   snmp_shutdown("fvtest");
+}
+
+std::string SNMPTest::time_string_event_oid(std::string base, int stat, int time, std::string string_index)
+{
+  std::string oid = base + ".1." + std::to_string(stat+2) + "." + std::to_string(time) + "." + string_index;
+  return oid;
+}
+
+void SNMPTest::snmp_walk_debug(std::string base)
+{
+  std::vector<std::string> entries = snmp_walk(".2.2.2");
+  for (auto entry: entries)
+  {
+    printf("%s\n", entry.c_str());
+  }
 }
 

--- a/test_utils/test_snmp.h
+++ b/test_utils/test_snmp.h
@@ -149,7 +149,7 @@ std::string SNMPTest::time_string_event_oid(std::string base, int stat, int time
 
 void SNMPTest::snmp_walk_debug(std::string base)
 {
-  std::vector<std::string> entries = snmp_walk(".2.2.2");
+  std::vector<std::string> entries = snmp_walk(base);
   for (auto entry: entries)
   {
     printf("%s\n", entry.c_str());

--- a/test_utils/test_snmp.h
+++ b/test_utils/test_snmp.h
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Metaswitch Networks 2016
+ * Copyright (C) Metaswitch Networks 2017
  * If license terms are provided to you in a COPYING file in the root directory
  * of the source code repository by which you are accessing this code, then
  * the license outlined in that COPYING file applies to your use.


### PR DESCRIPTION
Add support for string and time indexed event stats.   We're going to need these in order to expose per AS latency stats in the S-CSCF.

Tested by https://github.com/Metaswitch/clearwater-fv-test/pull/56