### PR TITLE
[Reviewer: HJS] 'Allowed host state' interface change and implementation for DNS resolvers

### DIFF
--- a/include/baseresolver.h
+++ b/include/baseresolver.h
@@ -64,6 +64,11 @@ public:
   // it is desirable not to expose
   friend class LazyAddrIterator;
 
+  // Constants indicating the allowed host state values.
+  const int WHITELISTED = 0x01;
+  const int BLACKLISTED = 0x02;
+  const int ALL_LISTS   = WHITELISTED | BLACKLISTED;
+
 protected:
   void create_naptr_cache(std::map<std::string, int> naptr_services);
   void create_srv_cache();
@@ -85,7 +90,8 @@ protected:
                    int retries,
                    std::vector<AddrInfo>& targets,
                    int& ttl,
-                   SAS::TrailId trail);
+                   SAS::TrailId trail,
+                   int allowed_host_state=ALL_LISTS);
 
   /// Does an A/AAAA record resolution for the specified name, selecting
   /// appropriate targets.
@@ -96,7 +102,8 @@ protected:
                  int retries,
                  std::vector<AddrInfo>& targets,
                  int& ttl,
-                 SAS::TrailId trail);
+                 SAS::TrailId trail,
+                 int allowed_host_state=ALL_LISTS);
 
   /// Does an A/AAAA record resolution for the specified name, and returns an
   /// Iterator that lazily selects appropriate targets.
@@ -105,7 +112,8 @@ protected:
                                            int port,
                                            int transport,
                                            int& ttl,
-                                           SAS::TrailId trail);
+                                           SAS::TrailId trail,
+                                           int allowed_host_state=ALL_LISTS);
 
   /// Converts a DNS A or AAAA record to an IP46Address structure.
   IP46Address to_ip46(const DnsRRecord* rr);
@@ -329,7 +337,8 @@ public:
                    BaseResolver* resolver,
                    int port,
                    int transport,
-                   SAS::TrailId trail);
+                   SAS::TrailId trail,
+                   int allowed_host_state);
   virtual ~LazyAddrIterator() {}
 
   /// Returns a vector containing at most num_requested_targets AddrInfo targets,
@@ -348,6 +357,9 @@ private:
 
   // A pointer to the BaseResolver that created this iterator
   BaseResolver* _resolver;
+
+  // The allowed state of hosts returned by this iterator
+  int _allowed_host_state;
 
   std::string _hostname;
   SAS::TrailId _trail;

--- a/include/baseresolver.h
+++ b/include/baseresolver.h
@@ -113,7 +113,7 @@ protected:
                                            int transport,
                                            int& ttl,
                                            SAS::TrailId trail,
-                                           int allowed_host_state=ALL_LISTS);
+                                           int allowed_host_state);
 
   /// Converts a DNS A or AAAA record to an IP46Address structure.
   IP46Address to_ip46(const DnsRRecord* rr);

--- a/include/baseresolver.h
+++ b/include/baseresolver.h
@@ -65,9 +65,9 @@ public:
   friend class LazyAddrIterator;
 
   // Constants indicating the allowed host state values.
-  static constexpr int WHITELISTED = 0x01;
-  static constexpr int BLACKLISTED = 0x02;
-  static constexpr int ALL_LISTS   = WHITELISTED | BLACKLISTED;
+  static const int WHITELISTED = 0x01;
+  static const int BLACKLISTED = 0x02;
+  static const int ALL_LISTS   = WHITELISTED | BLACKLISTED;
 
 protected:
   void create_naptr_cache(std::map<std::string, int> naptr_services);
@@ -81,13 +81,6 @@ protected:
   void destroy_naptr_cache();
   void destroy_srv_cache();
   void destroy_blacklist();
-
-  // Helper function that takes the bit representing the allowed host states,
-  // and sets two bool references passed into the function to indicate which
-  // host states are permitted.
-  void get_allowed_host_states(const int allowed_host_state,
-                               bool& whitelisted_allowed,
-                               bool& blacklisted_allowed) const;
 
   /// Does an SRV record resolution for the specified SRV name, selecting
   // appropriate targets.

--- a/include/baseresolver.h
+++ b/include/baseresolver.h
@@ -65,9 +65,9 @@ public:
   friend class LazyAddrIterator;
 
   // Constants indicating the allowed host state values.
-  constexpr int WHITELISTED = 0x01;
-  constexpr int BLACKLISTED = 0x02;
-  constexpr int ALL_LISTS   = WHITELISTED | BLACKLISTED;
+  static constexpr int WHITELISTED = 0x01;
+  static constexpr int BLACKLISTED = 0x02;
+  static constexpr int ALL_LISTS   = WHITELISTED | BLACKLISTED;
 
 protected:
   void create_naptr_cache(std::map<std::string, int> naptr_services);

--- a/include/baseresolver.h
+++ b/include/baseresolver.h
@@ -82,7 +82,9 @@ protected:
   void destroy_srv_cache();
   void destroy_blacklist();
 
-  // @TODO - Explanatory comment
+  // Helper function that takes the bit representing the allowed host states,
+  // and sets two bool references passed into the function to indicate which
+  // host states are permitted.
   void get_allowed_host_states(const int allowed_host_state,
                                bool& whitelisted_allowed,
                                bool& blacklisted_allowed) const;

--- a/include/baseresolver.h
+++ b/include/baseresolver.h
@@ -82,6 +82,11 @@ protected:
   void destroy_srv_cache();
   void destroy_blacklist();
 
+  // @TODO - Explanatory comment
+  void get_allowed_host_states(const int allowed_host_state,
+                               bool& whitelisted_allowed,
+                               bool& blacklisted_allowed) const;
+
   /// Does an SRV record resolution for the specified SRV name, selecting
   // appropriate targets.
   void srv_resolve(const std::string& srv_name,

--- a/include/baseresolver.h
+++ b/include/baseresolver.h
@@ -65,9 +65,9 @@ public:
   friend class LazyAddrIterator;
 
   // Constants indicating the allowed host state values.
-  const int WHITELISTED = 0x01;
-  const int BLACKLISTED = 0x02;
-  const int ALL_LISTS   = WHITELISTED | BLACKLISTED;
+  constexpr int WHITELISTED = 0x01;
+  constexpr int BLACKLISTED = 0x02;
+  constexpr int ALL_LISTS   = WHITELISTED | BLACKLISTED;
 
 protected:
   void create_naptr_cache(std::map<std::string, int> naptr_services);

--- a/src/a_record_resolver.cpp
+++ b/src/a_record_resolver.cpp
@@ -68,7 +68,8 @@ BaseAddrIterator* ARecordResolver::resolve_iter(const std::string& host,
   else
   {
     int dummy_ttl = 0;
-    addr_it = a_resolve_iter(host, _address_family, port, TRANSPORT, dummy_ttl, trail);
+    addr_it = a_resolve_iter(
+      host, _address_family, port, TRANSPORT, dummy_ttl, trail, BaseResolver::ALL_LISTS);
   }
 
   return addr_it;

--- a/src/baseresolver.cpp
+++ b/src/baseresolver.cpp
@@ -122,7 +122,7 @@ void BaseResolver::srv_resolve(const std::string& srv_name,
                                std::vector<AddrInfo>& targets,
                                int& ttl,
                                SAS::TrailId trail,
-                               int allowed_host_state=BaseResolver::ALL_LISTS)
+                               int allowed_host_state)
 {
   // @TODO - PARAMETER NOT IMPLEMENTED: allowed_host_state
   (void)allowed_host_state;
@@ -326,7 +326,7 @@ void BaseResolver::a_resolve(const std::string& hostname,
                              std::vector<AddrInfo>& targets,
                              int& ttl,
                              SAS::TrailId trail,
-                             int allowed_host_state=BaseResolver::ALL_LISTS)
+                             int allowed_host_state)
 {
   BaseAddrIterator* it = a_resolve_iter(hostname, af, port, transport, ttl, trail, allowed_host_state);
   targets = it->take(retries);
@@ -339,7 +339,7 @@ BaseAddrIterator* BaseResolver::a_resolve_iter(const std::string& hostname,
                                                int transport,
                                                int& ttl,
                                                SAS::TrailId trail,
-                                               int allowed_host_state=BaseResolver::ALL_LISTS)
+                                               int allowed_host_state)
 {
   DnsResult result = _dns_client->dns_query(hostname, (af == AF_INET) ? ns_t_a : ns_t_aaaa, trail);
   ttl = result.ttl();

--- a/src/baseresolver.cpp
+++ b/src/baseresolver.cpp
@@ -1027,13 +1027,15 @@ std::vector<AddrInfo> LazyAddrIterator::take(int num_requested_targets)
                 targets.size(),
                 num_requested_targets);
     }
-    else if ( blacklisted_allowed )
+    else if ((_resolver->host_state(result) == BaseResolver::Host::State::BLACK) &&
+             blacklisted_allowed )
     {
       // Add the record to the list of unhealthy targets.
       _unhealthy_results.push_back(result);
 
       // Update logging.
       found_blacklisted_str += result.address_and_port_to_string() + ";";
+      TRC_DEBUG("Found an unhealthy server");
     }
   }
 

--- a/src/baseresolver.cpp
+++ b/src/baseresolver.cpp
@@ -1015,27 +1015,39 @@ std::vector<AddrInfo> LazyAddrIterator::take(int num_requested_targets)
     AddrInfo result = _unused_results.back();
     _unused_results.pop_back();
 
-    if (( _resolver->host_state(result) == BaseResolver::Host::State::WHITE ) &&
-        whitelisted_allowed)
+    if ( _resolver->host_state(result) == BaseResolver::Host::State::WHITE )
     {
-      // Add the record to the targets list.
-      targets.push_back(result);
+      if (whitelisted_allowed)
+      {
+        // Add the record to the targets list.
+        targets.push_back(result);
 
-      // Update logging.
-      whitelisted_targets_str += result.address_and_port_to_string() + ";";
-      TRC_DEBUG("Added a whitelisted server, now have %ld of %d",
-                targets.size(),
-                num_requested_targets);
+        // Update logging.
+        whitelisted_targets_str += result.address_and_port_to_string() + ";";
+        TRC_DEBUG("Added a whitelisted server, now have %ld of %d",
+                  targets.size(),
+                  num_requested_targets);
+      }
+      else
+      {
+        TRC_DEBUG("Whitelisted hosts not allowed, ignoring whitelisted server");
+      }
     }
-    else if ((_resolver->host_state(result) == BaseResolver::Host::State::BLACK) &&
-             blacklisted_allowed )
+    else
     {
-      // Add the record to the list of unhealthy targets.
-      _unhealthy_results.push_back(result);
+      if (blacklisted_allowed)
+      {
+        // Add the record to the list of unhealthy targets.
+        _unhealthy_results.push_back(result);
 
-      // Update logging.
-      found_blacklisted_str += result.address_and_port_to_string() + ";";
-      TRC_DEBUG("Found an unhealthy server");
+        // Update logging.
+        found_blacklisted_str += result.address_and_port_to_string() + ";";
+        TRC_DEBUG("Found an unhealthy server");
+      }
+      else
+      {
+        TRC_DEBUG("Blacklisted hosts not allowed, ignoring blacklisted server");
+      }
     }
   }
 

--- a/src/baseresolver.cpp
+++ b/src/baseresolver.cpp
@@ -927,9 +927,9 @@ LazyAddrIterator::LazyAddrIterator(DnsResult& dns_result,
                                    SAS::TrailId trail,
                                    int allowed_host_state) :
   _resolver(resolver),
+  _allowed_host_state(allowed_host_state),
   _trail(trail),
-  _first_call(true),
-  _allowed_host_state(allowed_host_state)
+  _first_call(true)
 {
   _hostname = dns_result.domain();
 


### PR DESCRIPTION
Goes along with Metaswitch/sprout#1891. I will be opening the cpp-common-test PR shortly, which includes the unit tests for this change.

Interesting things to note:
* The constants defining the allowed host states had to be defined as `static`. Furthermore, I chose to define them as `constexpr` instead of `const` - this implies both `inline` and `const` for the static variable, so they are evaluated at compile time. I saw no downside in doing this, but please shout if you disagree.
* As discussed in the Sprout PR - I felt that it was appropriate to add a helper function (`get_allowed_host_states`) which takes the `allowed_host_state` bit and sets two bool references to indicate which host states were allowed, instead of performing a bitwise check every single time we want to evaluate this in the various resolve functions. This was also a convenient place to add trace for these bitwise checks.
* In both `srv_resolve` and `LazyAddrIterator::take`, I declare both bools in one line before passing to the above-mentioned function. Shout if you disagree and think they should be on separate lines.
* As with the `SIPResolver` SAS change, I'm adding the allowed host states as extra static parameters on the SAS events here, where the events should change their text based on these parameters. However, for these events specifically, if we wanted to avoid a change to their interface and their definition, we could instead just modify the strings we pass in to something appropriate - thoughts?
* For A-record resolution, I was unsure whether we should always be returning a graylisted record, or whether we should only do so if set to allow whitelisted records. I implemented the latter, but shout if this is wrong.
* The weird if/else statement structure starting at line 1018 in `baseresolver.cpp` is necessary to be able to log cases where we're ignoring a server. It's also necessary to split the if/else for the host state check away from checking whether whitelisting is allowed, otherwise we'd move on to the second branch in the case where the host is whitelisted and whitelisted results aren't allowed - we would have to check the host state again to ensure that it's not white, alongside checking whether blacklisted results are allowed.