### PR TITLE
[Reviewer AJH] Add timeout override to HttpClient

### DIFF
--- a/include/http_connection_pool.h
+++ b/include/http_connection_pool.h
@@ -50,7 +50,8 @@ class HttpConnectionPool : public ConnectionPool<CURL*>
 {
 public:
   HttpConnectionPool(LoadMonitor* load_monitor,
-                     SNMP::IPCountTable* stat_table);
+                     SNMP::IPCountTable* stat_table,
+                     long timeout_ms = -1);
 
   ~HttpConnectionPool()
   {

--- a/include/httpclient.h
+++ b/include/httpclient.h
@@ -64,7 +64,8 @@ public:
              LoadMonitor* load_monitor,
              SASEvent::HttpLogLevel sas_log_level,
              BaseCommunicationMonitor* comm_monitor,
-             bool should_omit_body = false);
+             bool should_omit_body = false,
+             long timeout_ms = -1);
 
   HttpClient(bool assert_user,
              HttpResolver* resolver,
@@ -362,4 +363,6 @@ private:
   SNMP::IPCountTable* _stat_table;
   HttpConnectionPool _conn_pool;
   bool _should_omit_body;
+  // CURL timeout to apply. "-1" means use CURL default
+  long _timeout_ms;
 };

--- a/include/httpclient.h
+++ b/include/httpclient.h
@@ -363,6 +363,4 @@ private:
   SNMP::IPCountTable* _stat_table;
   HttpConnectionPool _conn_pool;
   bool _should_omit_body;
-  // CURL timeout to apply. "-1" means use CURL default
-  long _timeout_ms;
 };

--- a/src/httpclient.cpp
+++ b/src/httpclient.cpp
@@ -46,9 +46,8 @@ HttpClient::HttpClient(bool assert_user,
   _sas_log_level(sas_log_level),
   _comm_monitor(comm_monitor),
   _stat_table(stat_table),
-  _conn_pool(load_monitor, stat_table),
-  _should_omit_body(should_omit_body),
-  _timeout_ms(timeout_ms)
+  _conn_pool(load_monitor, stat_table, timeout_ms),
+  _should_omit_body(should_omit_body)
 {
   pthread_key_create(&_uuid_thread_local, cleanup_uuid);
   pthread_mutex_init(&_lock, NULL);
@@ -457,13 +456,6 @@ HTTPCode HttpClient::send_request(RequestType request_type,
     curl_easy_getinfo(curl, CURLINFO_PRIVATE, &host_resolve);
     curl_easy_setopt(curl, CURLOPT_PRIVATE, NULL);
 
-    // Set the CURL timeout if overridden in this client
-    if (_timeout_ms != -1)
-    {
-      TRC_DEBUG("Override CURL timeout");
-      curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, _timeout_ms);
-    }
-    
     // Add the new entry - except in the case where the host is already an IP
     // address.
     if (!host_is_ip)

--- a/test_utils/curl_interposer.cpp
+++ b/test_utils/curl_interposer.cpp
@@ -229,6 +229,11 @@ CURLcode curl_easy_setopt(CURL* handle, CURLoption option, ...)
     curl->_url = va_arg(args, char*);
   }
   break;
+  case CURLOPT_TIMEOUT_MS:
+  {
+    curl->_timeout_ms = va_arg(args, long);
+  }
+  break;
   case CURLOPT_WRITEFUNCTION:
   {
     curl->_writefn = va_arg(args, datafn_ty);
@@ -374,7 +379,6 @@ CURLcode curl_easy_setopt(CURL* handle, CURLoption option, ...)
   break;
 
   case CURLOPT_MAXCONNECTS:
-  case CURLOPT_TIMEOUT_MS:
   case CURLOPT_CONNECTTIMEOUT_MS:
   case CURLOPT_DNS_CACHE_TIMEOUT:
   case CURLOPT_TCP_NODELAY:

--- a/test_utils/fakecurl.cpp
+++ b/test_utils/fakecurl.cpp
@@ -33,6 +33,7 @@ CURLcode FakeCurl::easy_perform(FakeCurl* curl)
   req._method = _method;
   req._headers = _headers;
   req._httpauth = _httpauth;
+  req._timeout_ms = _timeout_ms;
   req._username = _username;
   req._password = _password;
   req._fresh = _fresh;

--- a/test_utils/fakecurl.hpp
+++ b/test_utils/fakecurl.hpp
@@ -38,6 +38,7 @@ public:
   std::list<std::string> _headers;
   std::string _body;
   long _httpauth; //^ OR of CURLAUTH_ constants
+  long _timeout_ms;
   std::string _username;
   std::string _password;
   bool _fresh;
@@ -139,6 +140,7 @@ public:
 
   bool _failonerror;
   long _httpauth;  //^ OR of CURLAUTH_* constants
+  long _timeout_ms;
   std::string _username;
   std::string _password;
   bool _fresh;


### PR DESCRIPTION
Alex, are you OK to review this?  Its part of the fix for this "send provisioning traffic over the signaling interface" enhancement we discussed the other day.

The change I had to make to cpp-common here was to add a CURL timeout override to HttpClient.  I've tested this live and checked that the timeout is applied if that new parameter is passed.

I've also updated cpp-common-test (PR coming up)