### PR TITLE
[Reviewer: HJS] Reserve some PDLog ID ranges

### DIFF
--- a/include/pdlog.h
+++ b/include/pdlog.h
@@ -74,7 +74,6 @@ public:
     // The range 19000-19999 is reserved
     // The range 20000-20999 is reserved
     // The range 21000-21999 is reserved
-    // The range 22000-22999 is reserved
   };
 
   PDLogBase(int log_id,

--- a/include/pdlog.h
+++ b/include/pdlog.h
@@ -72,6 +72,9 @@ public:
     // The range 17000-17999 is reserved
     // The range 18000-18999 is reserved
     // The range 19000-19999 is reserved
+    // The range 20000-20999 is reserved
+    // The range 21000-21999 is reserved
+    // The range 22000-22999 is reserved
   };
 
   PDLogBase(int log_id,


### PR DESCRIPTION
Marks these ID ranges as reserved so that nobody else will use them.