### PR TITLE
[Reviewer: Seb] Pass allowed_hosts through to httpconnection

### DIFF
--- a/include/a_record_resolver.h
+++ b/include/a_record_resolver.h
@@ -30,13 +30,15 @@ public:
                        int port,
                        int max_targets,
                        std::vector<AddrInfo>& targets,
-                       SAS::TrailId trail);
+                       SAS::TrailId trail,
+                       int allowed_host_state=BaseResolver::ALL_LISTS);
 
   // Lazily resolve a hostname to a list of AddrInfo targets using an A record
   // lookup.
   virtual BaseAddrIterator* resolve_iter(const std::string& host,
                                          int port,
-                                         SAS::TrailId trail);
+                                         SAS::TrailId trail,
+                                         int allowed_host_state=BaseResolver::ALL_LISTS);
 
   /// Default duration to blacklist hosts after we fail to connect to them.
   static const int DEFAULT_BLACKLIST_DURATION = 30;

--- a/include/httpclient.h
+++ b/include/httpclient.h
@@ -92,23 +92,23 @@ public:
                         const std::string& username,
                         std::vector<std::string> headers_to_add,
                         SAS::TrailId trail,
-                        int allowed_host_state=BaseResolver::ALL_LISTS);
+                        int allowed_host_state = BaseResolver::ALL_LISTS);
   virtual long send_get(const std::string& path,
                         std::string& response,
                         std::vector<std::string> headers,
                         SAS::TrailId trail,
-                        int allowed_host_state=BaseResolver::ALL_LISTS);
+                        int allowed_host_state = BaseResolver::ALL_LISTS);
   virtual long send_get(const std::string& url,
                         std::string& response,
                         const std::string& username,
                         SAS::TrailId trail,
-                        int allowed_host_state=BaseResolver::ALL_LISTS);
+                        int allowed_host_state = BaseResolver::ALL_LISTS);
   virtual long send_get(const std::string& url,
                         std::map<std::string, std::string>& headers,
                         std::string& response,
                         const std::string& username,
                         SAS::TrailId trail,
-                        int allowed_host_state=BaseResolver::ALL_LISTS);
+                        int allowed_host_state = BaseResolver::ALL_LISTS);
 
   /// Sends a HTTP DELETE request to _host with the specified parameters
   ///
@@ -128,16 +128,16 @@ public:
                            SAS::TrailId trail,
                            const std::string& body = "",
                            const std::string& username = "",
-                           int allowed_host_state=BaseResolver::ALL_LISTS);
+                           int allowed_host_state = BaseResolver::ALL_LISTS);
   virtual long send_delete(const std::string& url,
                            SAS::TrailId trail,
                            const std::string& body = "",
-                           int allowed_host_state=BaseResolver::ALL_LISTS);
+                           int allowed_host_state = BaseResolver::ALL_LISTS);
   virtual long send_delete(const std::string& url,
                            SAS::TrailId trail,
                            const std::string& body,
-                           std::string& response
-                           int allowed_host_state=BaseResolver::ALL_LISTS);
+                           std::string& response,
+                           int allowed_host_state = BaseResolver::ALL_LISTS);
   /// Sends a HTTP PUT request to _host with the specified parameters
   ///
   /// @param url               Full URL to request - includes http(s)?://
@@ -158,24 +158,24 @@ public:
                         const std::vector<std::string>& extra_req_headers,
                         SAS::TrailId trail,
                         const std::string& username = "",
-                        int allowed_host_state=BaseResolver::ALL_LISTS);
+                        int allowed_host_state = BaseResolver::ALL_LISTS);
   virtual long send_put(const std::string& url,
                         const std::string& body,
                         SAS::TrailId trail,
                         const std::string& username = "",
-                        int allowed_host_state=BaseResolver::ALL_LISTS);
+                        int allowed_host_state = BaseResolver::ALL_LISTS);
   virtual long send_put(const std::string& url,
                         std::string& response,
                         const std::string& body,
                         SAS::TrailId trail,
                         const std::string& username = "",
-                        int allowed_host_state=BaseResolver::ALL_LISTS);
+                        int allowed_host_state = BaseResolver::ALL_LISTS);
   virtual long send_put(const std::string& url,
                         std::map<std::string, std::string>& headers,
                         const std::string& body,
                         SAS::TrailId trail,
                         const std::string& username = "",
-                        int allowed_host_state=BaseResolver::ALL_LISTS);
+                        int allowed_host_state = BaseResolver::ALL_LISTS);
 
   /// Sends a HTTP POST request to _host with the specified parameters
   ///
@@ -195,13 +195,13 @@ public:
                          const std::string& body,
                          SAS::TrailId trail,
                          const std::string& username = "",
-                         int allowed_host_state=BaseResolver::ALL_LISTS);
+                         int allowed_host_state = BaseResolver::ALL_LISTS);
   virtual long send_post(const std::string& url,
                          std::map<std::string, std::string>& headers,
                          const std::string& body,
                          SAS::TrailId trail,
                          const std::string& username = "",
-                         int allowed_host_state=BaseResolver::ALL_LISTS);
+                         int allowed_host_state = BaseResolver::ALL_LISTS);
 
 
   static size_t string_store(void* ptr, size_t size, size_t nmemb, void* stream);
@@ -267,7 +267,8 @@ private:
                             const std::string& username,
                             SAS::TrailId trail,
                             std::vector<std::string> headers_to_add,
-                            std::map<std::string, std::string>* response_headers);
+                            std::map<std::string, std::string>* response_headers,
+                            int allowed_host_state);
 
   /// Helper function that builds the curl header in the set_curl_options
   /// method.

--- a/include/httpclient.h
+++ b/include/httpclient.h
@@ -91,20 +91,24 @@ public:
                         std::string& response,
                         const std::string& username,
                         std::vector<std::string> headers_to_add,
-                        SAS::TrailId trail);
+                        SAS::TrailId trail,
+                        int allowed_host_state=BaseResolver::ALL_LISTS);
   virtual long send_get(const std::string& path,
                         std::string& response,
                         std::vector<std::string> headers,
-                        SAS::TrailId trail);
+                        SAS::TrailId trail,
+                        int allowed_host_state=BaseResolver::ALL_LISTS);
   virtual long send_get(const std::string& url,
                         std::string& response,
                         const std::string& username,
-                        SAS::TrailId trail);
+                        SAS::TrailId trail,
+                        int allowed_host_state=BaseResolver::ALL_LISTS);
   virtual long send_get(const std::string& url,
                         std::map<std::string, std::string>& headers,
                         std::string& response,
                         const std::string& username,
-                        SAS::TrailId trail);
+                        SAS::TrailId trail,
+                        int allowed_host_state=BaseResolver::ALL_LISTS);
 
   /// Sends a HTTP DELETE request to _host with the specified parameters
   ///
@@ -123,15 +127,17 @@ public:
                            std::string& response,
                            SAS::TrailId trail,
                            const std::string& body = "",
-                           const std::string& username = "");
+                           const std::string& username = "",
+                           int allowed_host_state=BaseResolver::ALL_LISTS);
   virtual long send_delete(const std::string& url,
                            SAS::TrailId trail,
-                           const std::string& body = "");
+                           const std::string& body = "",
+                           int allowed_host_state=BaseResolver::ALL_LISTS);
   virtual long send_delete(const std::string& url,
                            SAS::TrailId trail,
                            const std::string& body,
-                           std::string& response);
-
+                           std::string& response
+                           int allowed_host_state=BaseResolver::ALL_LISTS);
   /// Sends a HTTP PUT request to _host with the specified parameters
   ///
   /// @param url               Full URL to request - includes http(s)?://
@@ -151,21 +157,25 @@ public:
                         const std::string& body,
                         const std::vector<std::string>& extra_req_headers,
                         SAS::TrailId trail,
-                        const std::string& username = "");
+                        const std::string& username = "",
+                        int allowed_host_state=BaseResolver::ALL_LISTS);
   virtual long send_put(const std::string& url,
                         const std::string& body,
                         SAS::TrailId trail,
-                        const std::string& username = "");
+                        const std::string& username = "",
+                        int allowed_host_state=BaseResolver::ALL_LISTS);
   virtual long send_put(const std::string& url,
                         std::string& response,
                         const std::string& body,
                         SAS::TrailId trail,
-                        const std::string& username = "");
+                        const std::string& username = "",
+                        int allowed_host_state=BaseResolver::ALL_LISTS);
   virtual long send_put(const std::string& url,
                         std::map<std::string, std::string>& headers,
                         const std::string& body,
                         SAS::TrailId trail,
-                        const std::string& username = "");
+                        const std::string& username = "",
+                        int allowed_host_state=BaseResolver::ALL_LISTS);
 
   /// Sends a HTTP POST request to _host with the specified parameters
   ///
@@ -184,12 +194,14 @@ public:
                          std::string& response,
                          const std::string& body,
                          SAS::TrailId trail,
-                         const std::string& username = "");
+                         const std::string& username = "",
+                         int allowed_host_state=BaseResolver::ALL_LISTS);
   virtual long send_post(const std::string& url,
                          std::map<std::string, std::string>& headers,
                          const std::string& body,
                          SAS::TrailId trail,
-                         const std::string& username = "");
+                         const std::string& username = "",
+                         int allowed_host_state=BaseResolver::ALL_LISTS);
 
 
   static size_t string_store(void* ptr, size_t size, size_t nmemb, void* stream);

--- a/include/httpconnection.h
+++ b/include/httpconnection.h
@@ -95,20 +95,20 @@ public:
                         const std::string& username,
                         std::vector<std::string> headers_to_add,
                         SAS::TrailId trail,
-                        int BaseResolver::allowed_host_state);
+                        int allowed_host_state = BaseResolver::ALL_LISTS);
 
   virtual long send_get(const std::string& url_tail,
                         std::string& response,
                         const std::string& username,
                         SAS::TrailId trail,
-                        int BaseResolver::allowed_host_state);
+                        int allowed_host_state = BaseResolver::ALL_LISTS);
 
   virtual long send_get(const std::string& url_tail,
                         std::map<std::string, std::string>& headers,
                         std::string& response,
                         const std::string& username,
                         SAS::TrailId trail,
-                        int BaseResolver::allowed_host_state);
+                        int allowed_host_state = BaseResolver::ALL_LISTS);
 
   /// Sends a HTTP DELETE request to _server with the specified parameters
   ///
@@ -130,18 +130,18 @@ public:
                            SAS::TrailId trail,
                            const std::string& body = "",
                            const std::string& username = "",
-                           int BaseResolver::allowed_host_state);
+                           int allowed_host_state = BaseResolver::ALL_LISTS);
 
   virtual long send_delete(const std::string& url_tail,
                            SAS::TrailId trail,
                            const std::string& body = "",
-                           int BaseResolver::allowed_host_state);
+                           int allowed_host_state = BaseResolver::ALL_LISTS);
 
   virtual long send_delete(const std::string& url_tail,
                            SAS::TrailId trail,
                            const std::string& body,
                            std::string& response,
-                           int BaseResolver::allowed_host_state);
+                           int allowed_host_state = BaseResolver::ALL_LISTS);
 
   /// Sends a HTTP PUT request to _server with the specified parameters
   ///
@@ -165,27 +165,27 @@ public:
                         const std::vector<std::string>& extra_req_headers,
                         SAS::TrailId trail,
                         const std::string& username = "",
-                        int BaseResolver::allowed_host_state);
+                        int allowed_host_state = BaseResolver::ALL_LISTS);
 
   virtual long send_put(const std::string& url_tail,
                         const std::string& body,
                         SAS::TrailId trail,
                         const std::string& username = "",
-                        int BaseResolver::allowed_host_state);
+                        int allowed_host_state = BaseResolver::ALL_LISTS);
 
   virtual long send_put(const std::string& url_tail,
                         std::string& response,
                         const std::string& body,
                         SAS::TrailId trail,
                         const std::string& username = "",
-                        int BaseResolver::allowed_host_state);
+                        int allowed_host_state = BaseResolver::ALL_LISTS);
 
   virtual long send_put(const std::string& url_tail,
                         std::map<std::string, std::string>& headers,
                         const std::string& body,
                         SAS::TrailId trail,
                         const std::string& username = "",
-                        int BaseResolver::allowed_host_state);
+                        int allowed_host_state = BaseResolver::ALL_LISTS);
 
   /// Sends a HTTP POST request to _server with the specified parameters
   ///
@@ -207,14 +207,14 @@ public:
                          const std::string& body,
                          SAS::TrailId trail,
                          const std::string& username = "",
-                         int BaseResolver::allowed_host_state);
+                         int allowed_host_state = BaseResolver::ALL_LISTS);
 
   virtual long send_post(const std::string& url_tail,
                          std::map<std::string, std::string>& headers,
                          const std::string& body,
                          SAS::TrailId trail,
                          const std::string& username = "",
-                         int BaseResolver::allowed_host_state);
+                         int allowed_host_state = BaseResolver::ALL_LISTS);
 
 protected:
 

--- a/include/httpconnection.h
+++ b/include/httpconnection.h
@@ -94,16 +94,21 @@ public:
                         std::string& response,
                         const std::string& username,
                         std::vector<std::string> headers_to_add,
-                        SAS::TrailId trail);
+                        SAS::TrailId trail,
+                        int BaseResolver::allowed_host_state);
+
   virtual long send_get(const std::string& url_tail,
                         std::string& response,
                         const std::string& username,
-                        SAS::TrailId trail);
+                        SAS::TrailId trail,
+                        int BaseResolver::allowed_host_state);
+
   virtual long send_get(const std::string& url_tail,
                         std::map<std::string, std::string>& headers,
                         std::string& response,
                         const std::string& username,
-                        SAS::TrailId trail);
+                        SAS::TrailId trail,
+                        int BaseResolver::allowed_host_state);
 
   /// Sends a HTTP DELETE request to _server with the specified parameters
   ///
@@ -124,14 +129,19 @@ public:
                            std::string& response,
                            SAS::TrailId trail,
                            const std::string& body = "",
-                           const std::string& username = "");
+                           const std::string& username = "",
+                           int BaseResolver::allowed_host_state);
+
   virtual long send_delete(const std::string& url_tail,
                            SAS::TrailId trail,
-                           const std::string& body = "");
+                           const std::string& body = "",
+                           int BaseResolver::allowed_host_state);
+
   virtual long send_delete(const std::string& url_tail,
                            SAS::TrailId trail,
                            const std::string& body,
-                           std::string& response);
+                           std::string& response,
+                           int BaseResolver::allowed_host_state);
 
   /// Sends a HTTP PUT request to _server with the specified parameters
   ///
@@ -154,22 +164,28 @@ public:
                         const std::string& body,
                         const std::vector<std::string>& extra_req_headers,
                         SAS::TrailId trail,
-                        const std::string& username = "");
+                        const std::string& username = "",
+                        int BaseResolver::allowed_host_state);
 
   virtual long send_put(const std::string& url_tail,
                         const std::string& body,
                         SAS::TrailId trail,
-                        const std::string& username = "");
+                        const std::string& username = "",
+                        int BaseResolver::allowed_host_state);
+
   virtual long send_put(const std::string& url_tail,
                         std::string& response,
                         const std::string& body,
                         SAS::TrailId trail,
-                        const std::string& username = "");
+                        const std::string& username = "",
+                        int BaseResolver::allowed_host_state);
+
   virtual long send_put(const std::string& url_tail,
                         std::map<std::string, std::string>& headers,
                         const std::string& body,
                         SAS::TrailId trail,
-                        const std::string& username = "");
+                        const std::string& username = "",
+                        int BaseResolver::allowed_host_state);
 
   /// Sends a HTTP POST request to _server with the specified parameters
   ///
@@ -190,13 +206,15 @@ public:
                          std::string& response,
                          const std::string& body,
                          SAS::TrailId trail,
-                         const std::string& username = "");
+                         const std::string& username = "",
+                         int BaseResolver::allowed_host_state);
 
   virtual long send_post(const std::string& url_tail,
                          std::map<std::string, std::string>& headers,
                          const std::string& body,
                          SAS::TrailId trail,
-                         const std::string& username = "");
+                         const std::string& username = "",
+                         int BaseResolver::allowed_host_state);
 
 protected:
 

--- a/src/a_record_resolver.cpp
+++ b/src/a_record_resolver.cpp
@@ -38,16 +38,18 @@ void ARecordResolver::resolve(const std::string& host,
                               int port,
                               int max_targets,
                               std::vector<AddrInfo>& targets,
-                              SAS::TrailId trail)
+                              SAS::TrailId trail,
+                              int allowed_host_state)
 {
-  BaseAddrIterator* addr_it = resolve_iter(host, port, trail);
+  BaseAddrIterator* addr_it = resolve_iter(host, port, trail, allowed_host_state);
   targets = addr_it->take(max_targets);
   delete addr_it; addr_it = nullptr;
 }
 
 BaseAddrIterator* ARecordResolver::resolve_iter(const std::string& host,
                                                 int port,
-                                                SAS::TrailId trail)
+                                                SAS::TrailId trail,
+                                                int allowed_host_state)
 {
   BaseAddrIterator* addr_it;
 
@@ -69,7 +71,7 @@ BaseAddrIterator* ARecordResolver::resolve_iter(const std::string& host,
   {
     int dummy_ttl = 0;
     addr_it = a_resolve_iter(
-      host, _address_family, port, TRANSPORT, dummy_ttl, trail, BaseResolver::ALL_LISTS);
+      host, _address_family, port, TRANSPORT, dummy_ttl, trail, allowed_host_state);
   }
 
   return addr_it;

--- a/src/httpclient.cpp
+++ b/src/httpclient.cpp
@@ -120,22 +120,24 @@ HTTPCode HttpClient::curl_code_to_http_code(CURL* curl, CURLcode code)
 
 HTTPCode HttpClient::send_delete(const std::string& url,
                                  SAS::TrailId trail,
-                                 const std::string& body)
+                                 const std::string& body,
+                                 int allowed_host_state)
 {
   std::string unused_response;
   std::map<std::string, std::string> unused_headers;
 
-  return send_delete(url, unused_headers, unused_response, trail, body);
+  return send_delete(url, unused_headers, unused_response, trail, body, allowed_host_state);
 }
 
 HTTPCode HttpClient::send_delete(const std::string& url,
                                  SAS::TrailId trail,
                                  const std::string& body,
-                                 std::string& response)
+                                 std::string& response,
+                                 int allowed_host_state)
 {
   std::map<std::string, std::string> unused_headers;
 
-  return send_delete(url, unused_headers, response, trail, body);
+  return send_delete(url, unused_headers, response, trail, body, allowed_host_state);
 }
 
 HTTPCode HttpClient::send_delete(const std::string& url,
@@ -143,7 +145,8 @@ HTTPCode HttpClient::send_delete(const std::string& url,
                                  std::string& response,
                                  SAS::TrailId trail,
                                  const std::string& body,
-                                 const std::string& username)
+                                 const std::string& username,
+                                 int allowed_host_state)
 {
   std::vector<std::string> unused_extra_headers;
   HTTPCode status = send_request(RequestType::DELETE,
@@ -153,14 +156,16 @@ HTTPCode HttpClient::send_delete(const std::string& url,
                                  username,
                                  trail,
                                  unused_extra_headers,
-                                 NULL);
+                                 NULL,
+                                 allowed_host_state);
   return status;
 }
 
 HTTPCode HttpClient::send_put(const std::string& url,
                               const std::string& body,
                               SAS::TrailId trail,
-                              const std::string& username)
+                              const std::string& username,
+                              int allowed_host_state)
 {
   std::string unused_response;
   std::map<std::string, std::string> unused_headers;
@@ -171,14 +176,16 @@ HTTPCode HttpClient::send_put(const std::string& url,
                               body,
                               extra_req_headers,
                               trail,
-                              username);
+                              username,
+                              allowed_host_state);
 }
 
 HTTPCode HttpClient::send_put(const std::string& url,
                               std::string& response,
                               const std::string& body,
                               SAS::TrailId trail,
-                              const std::string& username)
+                              const std::string& username,
+                              int allowed_host_state)
 {
   std::map<std::string, std::string> unused_headers;
   std::vector<std::string> extra_req_headers;
@@ -188,14 +195,16 @@ HTTPCode HttpClient::send_put(const std::string& url,
                               body,
                               extra_req_headers,
                               trail,
-                              username);
+                              username,
+                              allowed_host_state);
 }
 
 HTTPCode HttpClient::send_put(const std::string& url,
                               std::map<std::string, std::string>& headers,
                               const std::string& body,
                               SAS::TrailId trail,
-                              const std::string& username)
+                              const std::string& username,
+                              int allowed_host_state)
 {
   std::string unused_response;
   std::vector<std::string> extra_req_headers;
@@ -205,7 +214,8 @@ HTTPCode HttpClient::send_put(const std::string& url,
                               body,
                               extra_req_headers,
                               trail,
-                              username);
+                              username,
+                              allowed_host_state);
 }
 
 HTTPCode HttpClient::send_put(const std::string& url,
@@ -214,7 +224,8 @@ HTTPCode HttpClient::send_put(const std::string& url,
                               const std::string& body,
                               const std::vector<std::string>& extra_req_headers,
                               SAS::TrailId trail,
-                              const std::string& username)
+                              const std::string& username,
+                              int allowed_host_state)
 {
   HTTPCode status = send_request(RequestType::PUT,
                                  url,
@@ -223,7 +234,8 @@ HTTPCode HttpClient::send_put(const std::string& url,
                                  "",
                                  trail,
                                  extra_req_headers,
-                                 &headers);
+                                 &headers,
+                                 allowed_host_state);
   return status;
 }
 
@@ -231,10 +243,11 @@ HTTPCode HttpClient::send_post(const std::string& url,
                                std::map<std::string, std::string>& headers,
                                const std::string& body,
                                SAS::TrailId trail,
-                               const std::string& username)
+                               const std::string& username,
+                               int allowed_host_state)
 {
   std::string unused_response;
-  return HttpClient::send_post(url, headers, unused_response, body, trail, username);
+  return HttpClient::send_post(url, headers, unused_response, body, trail, username, allowed_host_state);
 }
 
 HTTPCode HttpClient::send_post(const std::string& url,
@@ -242,7 +255,8 @@ HTTPCode HttpClient::send_post(const std::string& url,
                                std::string& response,
                                const std::string& body,
                                SAS::TrailId trail,
-                               const std::string& username)
+                               const std::string& username,
+                               int allowed_host_state)
 {
   std::vector<std::string> unused_extra_headers;
   HTTPCode status = send_request(RequestType::POST,
@@ -252,7 +266,8 @@ HTTPCode HttpClient::send_post(const std::string& url,
                                  username,
                                  trail,
                                  unused_extra_headers,
-                                 &headers);
+                                 &headers,
+                                 allowed_host_state);
   return status;
 }
 
@@ -260,21 +275,35 @@ HTTPCode HttpClient::send_post(const std::string& url,
 HTTPCode HttpClient::send_get(const std::string& url,
                               std::string& response,
                               const std::string& username,
-                              SAS::TrailId trail)
+                              SAS::TrailId trail,
+                              int allowed_host_state)
 {
   std::map<std::string, std::string> unused_rsp_headers;
   std::vector<std::string> unused_req_headers;
-  return HttpClient::send_get(url, unused_rsp_headers, response, username, unused_req_headers, trail);
+  return HttpClient::send_get(url,
+                              unused_rsp_headers,
+                              response,
+                              username,
+                              unused_req_headers,
+                              trail,
+                              allowed_host_state);
 }
 
 /// Get data; return a HTTP return code
 HTTPCode HttpClient::send_get(const std::string& url,
                               std::string& response,
                               std::vector<std::string> headers,
-                              SAS::TrailId trail)
+                              SAS::TrailId trail,
+                              int allowed_host_state)
 {
   std::map<std::string, std::string> unused_rsp_headers;
-  return HttpClient::send_get(url, unused_rsp_headers, response, "", headers, trail);
+  return HttpClient::send_get(url,
+                              unused_rsp_headers,
+                              response,
+                              "",
+                              headers,
+                              trail,
+                              allowed_host_state);
 }
 
 /// Get data; return a HTTP return code
@@ -282,10 +311,17 @@ HTTPCode HttpClient::send_get(const std::string& url,
                               std::map<std::string, std::string>& headers,
                               std::string& response,
                               const std::string& username,
-                              SAS::TrailId trail)
+                              SAS::TrailId trail,
+                              int allowed_host_state)
 {
   std::vector<std::string> unused_req_headers;
-  return HttpClient::send_get(url, headers, response, username, unused_req_headers, trail);
+  return HttpClient::send_get(url,
+                              headers,
+                              response,
+                              username,
+                              unused_req_headers,
+                              trail,
+                              allowed_host_state);
 }
 
 /// Get data; return a HTTP return code
@@ -294,7 +330,8 @@ HTTPCode HttpClient::send_get(const std::string& url,
                               std::string& response,
                               const std::string& username,
                               std::vector<std::string> headers_to_add,
-                              SAS::TrailId trail)
+                              SAS::TrailId trail,
+                              int allowed_host_state)
 {
   return send_request(RequestType::GET,
                       url,
@@ -303,7 +340,8 @@ HTTPCode HttpClient::send_get(const std::string& url,
                       username,
                       trail,
                       headers_to_add,
-                      NULL);
+                      NULL,
+                      allowed_host_state);
 }
 
 std::string HttpClient::request_type_to_string(RequestType request_type)
@@ -333,7 +371,8 @@ HTTPCode HttpClient::send_request(RequestType request_type,
                                   const std::string& username,
                                   SAS::TrailId trail,
                                   std::vector<std::string> headers_to_add,
-                                  std::map<std::string, std::string>* response_headers)
+                                  std::map<std::string, std::string>* response_headers,
+                                  int allowed_host_state)
 {
   HTTPCode http_code;
   CURLcode rc;
@@ -366,7 +405,7 @@ HTTPCode HttpClient::send_request(RequestType request_type,
   int port = port_from_server(scheme, server);
 
   // Resolve the host, and check whether it was an IP address all along.
-  BaseAddrIterator* target_it = _resolver->resolve_iter(host, port, trail);
+  BaseAddrIterator* target_it = _resolver->resolve_iter(host, port, trail, allowed_host_state);
   IP46Address dummy_address;
   bool host_is_ip = BaseResolver::parse_ip_target(host, dummy_address);
 

--- a/src/httpclient.cpp
+++ b/src/httpclient.cpp
@@ -125,8 +125,9 @@ HTTPCode HttpClient::send_delete(const std::string& url,
 {
   std::string unused_response;
   std::map<std::string, std::string> unused_headers;
+  std::string unused_username;
 
-  return send_delete(url, unused_headers, unused_response, trail, body, allowed_host_state);
+  return send_delete(url, unused_headers, unused_response, trail, body, unused_username, allowed_host_state);
 }
 
 HTTPCode HttpClient::send_delete(const std::string& url,
@@ -136,8 +137,8 @@ HTTPCode HttpClient::send_delete(const std::string& url,
                                  int allowed_host_state)
 {
   std::map<std::string, std::string> unused_headers;
-
-  return send_delete(url, unused_headers, response, trail, body, allowed_host_state);
+  std::string unused_username;
+  return send_delete(url, unused_headers, response, trail, body, unused_username, allowed_host_state);
 }
 
 HTTPCode HttpClient::send_delete(const std::string& url,

--- a/src/httpconnection.cpp
+++ b/src/httpconnection.cpp
@@ -13,22 +13,26 @@
 
 HTTPCode HttpConnection::send_delete(const std::string& url_tail,
                                      SAS::TrailId trail,
-                                     const std::string& body)
+                                     const std::string& body,
+                                     int allowed_host_state)
 {
   return _client.send_delete(_scheme + "://" + _server + url_tail,
                              trail,
-                             body);
+                             body,
+                             allowed_host_state);
 }
 
 HTTPCode HttpConnection::send_delete(const std::string& url_tail,
                                      SAS::TrailId trail,
                                      const std::string& body,
-                                     std::string& response)
+                                     std::string& response,
+                                     int allowed_host_state)
 {
   return _client.send_delete(_scheme + "://" + _server + url_tail,
                              trail,
                              body,
-                             response);
+                             response,
+                             allowed_host_state);
 }
 
 HTTPCode HttpConnection::send_delete(const std::string& url_tail,
@@ -36,51 +40,59 @@ HTTPCode HttpConnection::send_delete(const std::string& url_tail,
                                      std::string& response,
                                      SAS::TrailId trail,
                                      const std::string& body,
-                                     const std::string& username)
+                                     const std::string& username,
+                                     int allowed_host_state)
 {
   return _client.send_delete(_scheme + "://" + _server + url_tail,
                              headers,
                              response,
                              trail,
                              body,
-                             username);
+                             username,
+                             allowed_host_state);
 }
 
 HTTPCode HttpConnection::send_put(const std::string& url_tail,
                                   const std::string& body,
                                   SAS::TrailId trail,
-                                  const std::string& username)
+                                  const std::string& username,
+                                  int allowed_host_state)
 {
   return _client.send_put(_scheme + "://" + _server + url_tail,
                           body,
                           trail,
-                          username);
+                          username,
+                          allowed_host_state);
 }
 
 HTTPCode HttpConnection::send_put(const std::string& url_tail,
                                   std::string& response,
                                   const std::string& body,
                                   SAS::TrailId trail,
-                                  const std::string& username)
+                                  const std::string& username,
+                                  int allowed_host_state)
 {
   return _client.send_put(_scheme + "://" + _server + url_tail,
                           response,
                           body,
                           trail,
-                          username);
+                          username,
+                          allowed_host_state);
 }
 
 HTTPCode HttpConnection::send_put(const std::string& url_tail,
                                   std::map<std::string, std::string>& headers,
                                   const std::string& body,
                                   SAS::TrailId trail,
-                                  const std::string& username)
+                                  const std::string& username,
+                                  int allowed_host_state)
 {
   return _client.send_put(_scheme + "://" + _server + url_tail,
                           headers,
                           body,
                           trail,
-                          username);
+                          username,
+                          allowed_host_state);
 }
 
 HTTPCode HttpConnection::send_put(const std::string& url_tail,
@@ -89,7 +101,8 @@ HTTPCode HttpConnection::send_put(const std::string& url_tail,
                                   const std::string& body,
                                   const std::vector<std::string>& extra_req_headers,
                                   SAS::TrailId trail,
-                                  const std::string& username)
+                                  const std::string& username,
+                                  int allowed_host_state)
 {
   return _client.send_put(_scheme + "://" + _server + url_tail,
                           headers,
@@ -97,20 +110,23 @@ HTTPCode HttpConnection::send_put(const std::string& url_tail,
                           body,
                           extra_req_headers,
                           trail,
-                          username);
+                          username,
+                          allowed_host_state);
 }
 
 HTTPCode HttpConnection::send_post(const std::string& url_tail,
                                    std::map<std::string, std::string>& headers,
                                    const std::string& body,
                                    SAS::TrailId trail,
-                                   const std::string& username)
+                                   const std::string& username,
+                                   int allowed_host_state)
 {
   return _client.send_post(_scheme + "://" + _server + url_tail,
                            headers,
                            body,
                            trail,
-                           username);
+                           username,
+                           allowed_host_state);
 }
 
 HTTPCode HttpConnection::send_post(const std::string& url_tail,
@@ -118,26 +134,30 @@ HTTPCode HttpConnection::send_post(const std::string& url_tail,
                                    std::string& response,
                                    const std::string& body,
                                    SAS::TrailId trail,
-                                   const std::string& username)
+                                   const std::string& username,
+                                   int allowed_host_state)
 {
   return _client.send_post(_scheme + "://" + _server + url_tail,
                            headers,
                            response,
                            body,
                            trail,
-                           username);
+                           username,
+                           allowed_host_state);
 }
 
 /// Get data; return a HTTP return code
 HTTPCode HttpConnection::send_get(const std::string& url_tail,
                                   std::string& response,
                                   const std::string& username,
-                                  SAS::TrailId trail)
+                                  SAS::TrailId trail,
+                                  int allowed_host_state)
 {
   return _client.send_get(_scheme + "://" + _server + url_tail,
                           response,
                           username,
-                          trail);
+                          trail,
+                          allowed_host_state);
 }
 
 /// Get data; return a HTTP return code
@@ -145,13 +165,15 @@ HTTPCode HttpConnection::send_get(const std::string& url_tail,
                                   std::map<std::string, std::string>& headers,
                                   std::string& response,
                                   const std::string& username,
-                                  SAS::TrailId trail)
+                                  SAS::TrailId trail,
+                                  int allowed_host_state)
 {
   return _client.send_get(_scheme + "://" + _server + url_tail,
                           headers,
                           response,
                           username,
-                          trail);
+                          trail,
+                          allowed_host_state);
 }
 
 /// Get data; return a HTTP return code
@@ -160,12 +182,14 @@ HTTPCode HttpConnection::send_get(const std::string& url_tail,
                                   std::string& response,
                                   const std::string& username,
                                   std::vector<std::string> headers_to_add,
-                                  SAS::TrailId trail)
+                                  SAS::TrailId trail,
+                                  int allowed_host_state)
 {
   return _client.send_get(_scheme + "://" + _server + url_tail,
                           headers,
                           response,
                           username,
                           headers_to_add,
-                          trail);
+                          trail,
+                          allowed_host_state);
 }

--- a/test_utils/fakehttpconnection.cpp
+++ b/test_utils/fakehttpconnection.cpp
@@ -35,7 +35,7 @@ void FakeHttpConnection::flush_all()
   _db.clear();
 }
 
-long FakeHttpConnection::send_get(const std::string& uri, std::string& doc, const std::string& username, SAS::TrailId trail)
+long FakeHttpConnection::send_get(const std::string& uri, std::string& doc, const std::string& username, SAS::TrailId trail, int allowed_host_state)
 {
   std::map<std::string, std::string>::iterator i = _db.find(uri);
   if (i != _db.end())
@@ -46,13 +46,13 @@ long FakeHttpConnection::send_get(const std::string& uri, std::string& doc, cons
   return 404;
 }
 
-bool FakeHttpConnection::put(const std::string& uri, const std::string& doc, const std::string& username, SAS::TrailId trail)
+bool FakeHttpConnection::put(const std::string& uri, const std::string& doc, const std::string& username, SAS::TrailId trail, int allowed_host_state)
 {
   _db[uri] = doc;
   return true;
 }
 
-bool FakeHttpConnection::del(const std::string& uri, const std::string& username, SAS::TrailId trail)
+bool FakeHttpConnection::del(const std::string& uri, const std::string& username, SAS::TrailId trail, int allowed_host_state)
 {
   _db.erase(uri);
   return true;

--- a/test_utils/fakehttpconnection.hpp
+++ b/test_utils/fakehttpconnection.hpp
@@ -27,9 +27,9 @@ public:
 
   void flush_all();
 
-  virtual long send_get(const std::string& uri, std::string& doc, const std::string& username, SAS::TrailId trail);
-  bool put(const std::string& uri, const std::string& doc, const std::string& username, SAS::TrailId trail);
-  bool del(const std::string& uri, const std::string& username, SAS::TrailId trail);
+  virtual long send_get(const std::string& uri, std::string& doc, const std::string& username, SAS::TrailId trail, int allowed_host_state);
+  bool put(const std::string& uri, const std::string& doc, const std::string& username, SAS::TrailId trail, int allowed_host_state);
+  bool del(const std::string& uri, const std::string& username, SAS::TrailId trail, int allowed_host_state);
 
 private:
   std::map<std::string, std::string> _db;

--- a/test_utils/fakehttpresolver.hpp
+++ b/test_utils/fakehttpresolver.hpp
@@ -37,7 +37,8 @@ public:
 
   virtual BaseAddrIterator* resolve_iter(const std::string& host,
                                          int port,
-                                         SAS::TrailId trail)
+                                         SAS::TrailId trail,
+                                         int allowed_host_state)
   {
     std::vector<AddrInfo> targets = _targets;
 

--- a/test_utils/mock_a_record_resolver.h
+++ b/test_utils/mock_a_record_resolver.h
@@ -23,13 +23,15 @@ public:
 
   MOCK_METHOD3(resolve_iter, BaseAddrIterator*(const std::string& host,
                                                int port,
-                                               SAS::TrailId trail));
+                                               SAS::TrailId trail,
+                                               int allowed_host_state));
 
   MOCK_METHOD5(resolve, void(const std::string& host,
                              int port,
                              int max_targets,
                              std::vector<AddrInfo>& targets,
-                             SAS::TrailId trail));
+                             SAS::TrailId trail,
+                             int allowed_host_state));
 
   MOCK_METHOD1(blacklist, void(const AddrInfo& ai));
   MOCK_METHOD1(success, void(const AddrInfo& ai));

--- a/test_utils/mock_a_record_resolver.h
+++ b/test_utils/mock_a_record_resolver.h
@@ -21,12 +21,12 @@ public:
   MockARecordResolver() : ARecordResolver(nullptr, 0, 0, 0) {}
   ~MockARecordResolver() {}
 
-  MOCK_METHOD3(resolve_iter, BaseAddrIterator*(const std::string& host,
+  MOCK_METHOD4(resolve_iter, BaseAddrIterator*(const std::string& host,
                                                int port,
                                                SAS::TrailId trail,
                                                int allowed_host_state));
 
-  MOCK_METHOD5(resolve, void(const std::string& host,
+  MOCK_METHOD6(resolve, void(const std::string& host,
                              int port,
                              int max_targets,
                              std::vector<AddrInfo>& targets,

--- a/test_utils/mockhttpconnection.h
+++ b/test_utils/mockhttpconnection.h
@@ -20,15 +20,17 @@ class MockHttpConnection : public HttpConnection
 public:
   MockHttpConnection();
   ~MockHttpConnection();
-  MOCK_METHOD5(send_post, long(const std::string& url_tail,
+  MOCK_METHOD6(send_post, long(const std::string& url_tail,
                                std::map<std::string, std::string>& headers,
                                const std::string& body,
                                SAS::TrailId trail,
-                               const std::string& username));
-  MOCK_METHOD4(send_get, long(const std::string& url_tail,
+                               const std::string& username,
+                               int allowed_host_state));
+  MOCK_METHOD5(send_get, long(const std::string& url_tail,
                               std::string& response,
                               const std::string& username,
-                              SAS::TrailId trail));
+                              SAS::TrailId trail,
+                              int allowed_host_state));
 };
 
 #endif

--- a/test_utils/mockhttpresolver.h
+++ b/test_utils/mockhttpresolver.h
@@ -21,14 +21,16 @@ public:
   MockHttpResolver() : HttpResolver(nullptr, 0, 0, 0) {}
   ~MockHttpResolver() {}
 
-  MOCK_METHOD3(resolve_iter, BaseAddrIterator*(const std::string& host,
+  MOCK_METHOD4(resolve_iter, BaseAddrIterator*(const std::string& host,
                                                int port,
-                                               SAS::TrailId trail));
-  MOCK_METHOD5(resolve, void(const std::string& host,
+                                               SAS::TrailId trail,
+                                               int allowed_host_state));
+  MOCK_METHOD6(resolve, void(const std::string& host,
                              int port,
                              int max_targets,
                              std::vector<AddrInfo>& targets,
-                             SAS::TrailId trail));
+                             SAS::TrailId trail,
+                             int allowed_host_state));
 
   MOCK_METHOD1(blacklist, void(const AddrInfo& ai));
   MOCK_METHOD2(blacklist, void(const AddrInfo& ai, int blacklist_ttl));


### PR DESCRIPTION
This PR enables the use of allowed_host_state in baseresolver from the HttpConnection class. 
It is basically just adding the `allowed_host_state` variable to the methods that run through, and defaulting it to `ALL_LISTS`. There are then a few changes to test fixtures to get things working.

I've tested this running it in cpp-common-test, and that now all works (with associated PR to be linked below shortly)
I am also doing a search for anywhere that uses the fakehttp/mockhttp classes in their tests, and will link test fixes below, so that hopefully merging this doesn't kill builds.