### PR TITLE
[Reviewer: Richard] Fix cwtest_completely_control_time

### DIFF
--- a/test_utils/test_interposer.cpp
+++ b/test_utils/test_interposer.cpp
@@ -153,7 +153,14 @@ void cwtest_completely_control_time(bool start_of_epoch)
     }
   }
 
-  abs_time = real_time(NULL);
+  if (start_of_epoch)
+  {
+    abs_time = 0L;
+  }
+  else
+  {
+    abs_time = real_time(NULL);
+  }
 
   pthread_mutex_unlock(&time_lock);
 }


### PR DESCRIPTION
If start_of_epoch is specified, we should set the time to 0