### PR TITLE
[Reviewer=CJR, KH1] Add ability to customize the server details we send to SAS

### DIFF
--- a/include/httpclient.h
+++ b/include/httpclient.h
@@ -66,7 +66,9 @@ public:
              BaseCommunicationMonitor* comm_monitor,
              bool should_omit_body = false,
              bool remote_connection = false,
-             long timeout_ms = -1);
+             long timeout_ms = -1,
+             bool log_display_address = false,
+             std::string server_display_address = "");
 
   HttpClient(bool assert_user,
              HttpResolver* resolver,
@@ -402,4 +404,6 @@ private:
   SNMP::IPCountTable* _stat_table;
   HttpConnectionPool _conn_pool;
   bool _should_omit_body;
+  bool _log_display_address;
+  std::string _server_display_address;
 };

--- a/include/httpconnection.h
+++ b/include/httpconnection.h
@@ -37,7 +37,10 @@ public:
                  BaseCommunicationMonitor* comm_monitor,
                  const std::string& scheme = "http",
                  bool should_omit_body = false,
-                 bool remote_connection = false) :
+                 bool remote_connection = false,
+                 long timeout_ms = -1,
+                 bool log_display_address = false,
+                 std::string server_display_address = "") :
     _scheme(scheme),
     _server(server),
     _client(assert_user,
@@ -47,7 +50,10 @@ public:
             sas_log_level,
             comm_monitor,
             should_omit_body,
-            remote_connection)
+            remote_connection,
+            timeout_ms,
+            log_display_address,
+            server_display_address)
   {
     TRC_STATUS("Configuring HTTP Connection");
     TRC_STATUS("  Connection created for server %s", _server.c_str());


### PR DESCRIPTION
This PR give us the ability to log a different server address to the SAS call flow, than the actual address in the HTTP request.  An example use case is when sending requests to localhost, where we may wish to instead log the public/private IP of the node in SAS

I don't think that the arguments I have added to the constructor necessarily belong at the end, but I have added them at the end to ensure this is a non-breaking change for existing uses of these classes.

I have tested this on my deployment and run the live test suite, and `make full_test` passes in Sprout