### PR TITLE
[Reviewer: AJH] Disable Nagle's algorithm in memcached

### DIFF
--- a/include/baseresolver.h
+++ b/include/baseresolver.h
@@ -55,9 +55,6 @@ public:
   /// Indicates that the calling thread has left the given AddrInfo untested.
   virtual void untested(const AddrInfo& ai);
 
-  /// Utility function to parse a target name to see if it is a valid IPv4 or IPv6 address.
-  static bool parse_ip_target(const std::string& target, IP46Address& address);
-
   void clear_blacklist();
 
   // LazyAddrIterator must access the private host_state method of BaseResolver, which

--- a/include/utils.h
+++ b/include/utils.h
@@ -361,6 +361,9 @@ namespace Utils
                        std::string& host,
                        int& port);
 
+  /// Utility function to parse a target name to see if it is a valid IPv4 or IPv6 address.
+  bool parse_ip_target(const std::string& target, IP46Address& address);
+
   /// Generates a random number which is exponentially distributed
   class ExponentialDistribution
   {

--- a/include/utils.h
+++ b/include/utils.h
@@ -142,18 +142,44 @@ struct AddrInfo
 
   std::string address_and_port_to_string() const
   {
-    std::stringstream os;
+    std::stringstream oss;
     char buf[100];
-    os << inet_ntop(address.af, &address.addr, buf, sizeof(buf));
-    os << ":" << port;
-    return os.str();
+    if (address.af == AF_INET6)
+    {
+      oss << "[";
+    }
+    oss << inet_ntop(address.af, &address.addr, buf, sizeof(buf));
+    if (address.af == AF_INET6)
+    {
+      oss << "]";
+    }
+
+    oss << ":" << port;
+    return oss.str();
   }
 
   std::string to_string() const
   {
-    std::stringstream os;
-    os << address_and_port_to_string() << " transport " << transport;
-    return os.str();
+    std::stringstream oss;
+    oss << address_and_port_to_string() << ";transport=";
+    if (transport == IPPROTO_SCTP)
+    {
+      oss << "SCTP";
+    }
+    else if (transport == IPPROTO_TCP)
+    {
+      oss << "TCP";
+    }
+    else if (transport == IPPROTO_UDP)
+    {
+      oss << "UDP";
+    }
+    else
+    {
+      oss << "Unknown (" << transport << ")";
+    }
+
+    return oss.str();
   }
 };
 

--- a/src/a_record_resolver.cpp
+++ b/src/a_record_resolver.cpp
@@ -59,7 +59,7 @@ BaseAddrIterator* ARecordResolver::resolve_iter(const std::string& host,
   port = (port != 0) ? port : _default_port;
   AddrInfo ai;
 
-  if (parse_ip_target(host, ai.address))
+  if (Utils::parse_ip_target(host, ai.address))
   {
     // The name is already an IP address so no DNS resolution is possible.
     TRC_DEBUG("Target is an IP address");

--- a/src/astaire_resolver.cpp
+++ b/src/astaire_resolver.cpp
@@ -55,7 +55,7 @@ void AstaireResolver::resolve(const std::string& host,
     port = PORT;
   }
 
-  if (parse_ip_target(host_without_port, ai.address))
+  if (Utils::parse_ip_target(host_without_port, ai.address))
   {
     // The name is already an IP address, so no DNS resolution is possible.
     TRC_DEBUG("Target is an IP address");

--- a/src/baseresolver.cpp
+++ b/src/baseresolver.cpp
@@ -420,35 +420,6 @@ bool BaseResolver::blacklisted(const AddrInfo& ai)
   return rc;
 }
 
-/// Parses a target as if it was an IPv4 or IPv6 address and returns the
-/// status of the parse.
-bool BaseResolver::parse_ip_target(const std::string& target, IP46Address& address)
-{
-  // Assume the parse fails.
-  TRC_DEBUG("Attempt to parse %s as IP address", target.c_str());
-  bool rc = false;
-
-  // Strip start and end white-space, and any brackets if this is an IPv6
-  // address
-  std::string ip_target = Utils::remove_brackets_from_ip(target);
-  Utils::trim(ip_target);
-
-  if (inet_pton(AF_INET6, ip_target.c_str(), &address.addr.ipv6) == 1)
-  {
-    // Parsed the address as a valid IPv6 address.
-    address.af = AF_INET6;
-    rc = true;
-  }
-  else if (inet_pton(AF_INET, ip_target.c_str(), &address.addr.ipv4) == 1)
-  {
-    // Parsed the address as a valid IPv4 address.
-    address.af = AF_INET;
-    rc = true;
-  }
-
-  return rc;
-}
-
 BaseResolver::NAPTRCacheFactory::NAPTRCacheFactory(const std::map<std::string, int>& services,
                                                    int default_ttl,
                                                    DnsCachedResolver* dns_client) :

--- a/src/diameterresolver.cpp
+++ b/src/diameterresolver.cpp
@@ -149,7 +149,7 @@ void DiameterResolver::resolve(const std::string& realm,
 
   if ((targets.empty()) && (host != ""))
   {
-    if (parse_ip_target(host, ai.address))
+    if (Utils::parse_ip_target(host, ai.address))
     {
       // The name is already an IP address, so no DNS resolution is possible.
       // Use specified transport and port or defaults if not specified.

--- a/src/httpclient.cpp
+++ b/src/httpclient.cpp
@@ -452,7 +452,7 @@ HTTPCode HttpClient::send_request(RequestType request_type,
   // Resolve the host, and check whether it was an IP address all along.
   BaseAddrIterator* target_it = _resolver->resolve_iter(host, port, trail, allowed_host_state);
   IP46Address dummy_address;
-  bool host_is_ip = BaseResolver::parse_ip_target(host, dummy_address);
+  bool host_is_ip = Utils::parse_ip_target(host, dummy_address);
 
   // Track the number of HTTP 503 and 504 responses and the number of timeouts
   // or I/O errors.

--- a/src/memcached_connection_pool.cpp
+++ b/src/memcached_connection_pool.cpp
@@ -20,6 +20,28 @@ memcached_st* MemcachedConnectionPool::create_connection(AddrInfo target)
   memcached_behavior_set(conn,
                          MEMCACHED_BEHAVIOR_CONNECT_TIMEOUT,
                          _max_connect_latency_ms);
+
+  // Disable Nagle's algorithm
+  // (https://en.wikipedia.org/wiki/Nagle%27s_algorithm). If we leave it on
+  // there can be up to 500ms delay between this code sending an
+  // asynchronous SET and it actually being sent on the wire, e.g.
+  //
+  // * Ask libmemcached to do async SET.
+  // * Async SET sent on the wire.
+  // * Ask libmemcached to do a 2nd async SET.
+  // * Up to 500ms passes.
+  // * TCP stack receives ACK to 1st SET (may be delayed because the server
+  //   does not send a protocol level response to the async SET).
+  // * 2nd async SET sent on the wire (up to 500ms late).
+  //
+  // This delay can open up window conditions in failure scenarios. In
+  // addition there is not much point in using Nagle. libmemcached's buffers
+  // are large enough that it will never send small message fragments, and
+  // this store's implementation means we very rarely pipeline requests.
+  memcached_behavior_set(conn,
+                         MEMCACHED_BEHAVIOR_TCP_NODELAY,
+                         true);
+
   memcached_server_add(conn, target.address.to_string().c_str(), target.port);
 
   return conn;

--- a/src/memcached_connection_pool.cpp
+++ b/src/memcached_connection_pool.cpp
@@ -36,8 +36,8 @@ memcached_st* MemcachedConnectionPool::create_connection(AddrInfo target)
   //
   // This delay can open up window conditions in failure scenarios. In
   // addition there is not much point in using Nagle. libmemcached's buffers
-  // are large enough that it will never send small message fragments, and
-  // this store's implementation means we very rarely pipeline requests.
+  // are large enough that it will never send small message fragments, and we
+  // very rarely pipeline requests.
   memcached_behavior_set(conn,
                          MEMCACHED_BEHAVIOR_TCP_NODELAY,
                          true);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -362,6 +362,35 @@ bool Utils::split_host_port(const std::string& host_port,
   return true;
 }
 
+/// Parses a target as if it was an IPv4 or IPv6 address and returns the
+/// status of the parse.
+bool Utils::parse_ip_target(const std::string& target, IP46Address& address)
+{
+  // Assume the parse fails.
+  TRC_DEBUG("Attempt to parse %s as IP address", target.c_str());
+  bool rc = false;
+
+  // Strip start and end white-space, and any brackets if this is an IPv6
+  // address
+  std::string ip_target = Utils::remove_brackets_from_ip(target);
+  Utils::trim(ip_target);
+
+  if (inet_pton(AF_INET6, ip_target.c_str(), &address.addr.ipv6) == 1)
+  {
+    // Parsed the address as a valid IPv6 address.
+    address.af = AF_INET6;
+    rc = true;
+  }
+  else if (inet_pton(AF_INET, ip_target.c_str(), &address.addr.ipv4) == 1)
+  {
+    // Parsed the address as a valid IPv4 address.
+    address.af = AF_INET;
+    rc = true;
+  }
+
+  return rc;
+}
+
 bool Utils::overflow_less_than(uint32_t a, uint32_t b)
 {
     return ((a - b) > ((uint32_t)(1) << 31));

--- a/test_utils/fakehttpresolver.hpp
+++ b/test_utils/fakehttpresolver.hpp
@@ -64,7 +64,7 @@ public:
   static AddrInfo create_target(std::string address_str, int port = 80)
   {
     AddrInfo ai;
-    BaseResolver::parse_ip_target(address_str, ai.address);
+    Utils::parse_ip_target(address_str, ai.address);
     ai.port = port;
     ai.transport = IPPROTO_TCP;
     return ai;


### PR DESCRIPTION
Now that I'm adding connection pooling to astaire, I've moved the code to disable Nagle's algorithm into the memcached connection pool code. I think this is ok because of the last part of the comment which says "libmemcached's buffers are large enough that it will never send small message fragments, and this store's implementation means we very rarely pipeline requests".

I've also tidied up some other code:
- I've moved `parse_ip_target()` from the Baseresolver to Utils since that's where all the other address parsing utility functions live. It also means I don't need to include baseresolver.h to use this function.
- We have 3 implementations of a function to turn an AddrInfo into a string. I've consolidated all this in the AddrInfo class and will be deleting the other functions.