### PR TITLE
Add resource bundle comment

### DIFF
--- a/include/sasevent.h
+++ b/include/sasevent.h
@@ -16,7 +16,11 @@
 #include "sas.h"
 
 namespace SASEvent {
-  // The resource bundle datestamp is updated automatically by Jenkins.
+  // The resource bundle datestamp is updated automatically by Jenkins.  You
+  // should not normally edit this value by hand.  If you have to, make sure
+  // that you update all of the other code locations that are updated by the
+  // Jenkins job "update-sas-resources".
+  //
   // !!!DO NOT EDIT THE FOLLOWING LINE MANUALLY!!!
   const std::string CURRENT_RESOURCE_BUNDLE_DATESTAMP = "20170911";
   const std::string RESOURCE_BUNDLE_NAME = "org.projectclearwater";


### PR DESCRIPTION
Add a comment to the resource bundle datestamp line, making it clear what needs to be updated if you ever do need to change this value by hand.  This should help to avoid issues where we ship releases in which different components depend on different SAS resource bundles.