### PR TITLE
[Reviewer: Ellie] Correctly determine the length of the socket file

### DIFF
--- a/src/namespace_hop.cpp
+++ b/src/namespace_hop.cpp
@@ -89,7 +89,15 @@ int create_connection_in_namespace(const char* host,
             socket_factory_path);
   
   struct sockaddr_un addr = {AF_LOCAL};
-  size_t max_chars = std::min(sizeof(addr.sun_path), sizeof(socket_factory_path));
+  size_t sfp_size = strlen(socket_factory_path) + 1;
+  size_t asp_size = sizeof(addr.sun_path);
+  size_t max_chars = std::min(asp_size, sfp_size);
+
+  TRC_DEBUG("Size of path is: %d, size of addr.sun_path: %d, max_chars: %d",
+            sfp_size,
+            asp_size,
+            max_chars);
+
   strncpy(addr.sun_path, socket_factory_path, max_chars);
   int fd = socket(AF_LOCAL, SOCK_STREAM, 0);
 
@@ -100,10 +108,16 @@ int create_connection_in_namespace(const char* host,
   }
 
   int ret = connect(fd, (struct sockaddr *)&addr, sizeof(addr));
-  if (ret < 0)
+  if (ret != 0)
   {
-    TRC_ERROR("Failed to connect to cross-namespace socket factory %s",
-              socket_factory_path);
+    int err = errno;
+    TRC_ERROR("Failed to connect to cross-namespace socket factory %s on FD: %d with result: %d and error: %d - 0x%x - %s",
+              socket_factory_path,
+              fd,
+              ret,
+              err,
+              err,
+              strerror(err));
     return -1;
   }
 


### PR DESCRIPTION
Also add additional logging so that namespace hop connection failures can be debugged

The code as written fails to perform a namespace hop if the length of the path is something other than 8 bytes (7 characters + a null terminator).

This is because it compares sizeof(socket_factory_path) is always 8 bytes on a system with 64 bit pointers (because it's a char*, not a char[108] like addr.sun_path), which means we only copy the first 8 bytes of the path into `addr.sun_path` which means the connect call fails with `No such file or directory`.

I've added a bunch of logs which I used to debug the problem.

