### PR TITLE
Move mock constructors / destructors out of headers

### DIFF
--- a/test_utils/mockdiameterstack.cpp
+++ b/test_utils/mockdiameterstack.cpp
@@ -1,0 +1,4 @@
+#include "mockdiameterstack.hpp"
+
+MockDiameterStack::MockDiameterStack() {}
+MockDiameterStack::~MockDiameterStack() {}

--- a/test_utils/mockdiameterstack.hpp
+++ b/test_utils/mockdiameterstack.hpp
@@ -18,6 +18,8 @@
 class MockDiameterStack : public Diameter::Stack
 {
 public:
+  MockDiameterStack();
+  ~MockDiameterStack();
   MOCK_METHOD0(initialize, void());
   MOCK_METHOD3(register_handler, void(const Diameter::Dictionary::Application&, const Diameter::Dictionary::Message&, HandlerInterface*));
   MOCK_METHOD1(register_fallback_handler, void(const Diameter::Dictionary::Application&));

--- a/test_utils/mockhttpstack.cpp
+++ b/test_utils/mockhttpstack.cpp
@@ -1,0 +1,8 @@
+#include "mockhttpstack.hpp"
+
+MockHttpStack::MockHttpStack():
+  HttpStack(1, nullptr, nullptr, nullptr, nullptr)
+{}
+
+MockHttpStack::~MockHttpStack() {}
+

--- a/test_utils/mockhttpstack.hpp
+++ b/test_utils/mockhttpstack.hpp
@@ -72,7 +72,8 @@ public:
     }
   };
 
-  MockHttpStack() : HttpStack(1, nullptr, nullptr, nullptr, nullptr) {}
+  MockHttpStack();
+  ~MockHttpStack();
 
   MOCK_METHOD0(initialize, void());
   MOCK_METHOD2(bind_tcp_socket, void(const std::string& bind_address,


### PR DESCRIPTION
For background see out of date PR: https://github.com/Metaswitch/homestead/pull/150