### PR TITLE
[Reviewer: Seb] Fix issues arising from name hiding

### DIFF
--- a/include/localstore.h
+++ b/include/localstore.h
@@ -30,12 +30,15 @@ public:
   void force_delete_error();
   void swap_dbs(LocalStore* rhs);
 
+  using Store::get_data;
+  using Store::set_data;
+
   Store::Status get_data(const std::string& table,
                          const std::string& key,
                          std::string& data,
                          uint64_t& cas,
                          SAS::TrailId trail,
-                         bool log_body);
+                         bool log_body) override;
 
   Store::Status set_data(const std::string& table,
                          const std::string& key,
@@ -43,26 +46,26 @@ public:
                          uint64_t cas,
                          int expiry,
                          SAS::TrailId trail,
-                         bool log_body);
+                         bool log_body) override;
 
   Store::Status set_data_without_cas(const std::string& table,
                                      const std::string& key,
                                      const std::string& data,
                                      int expiry,
                                      SAS::TrailId trail,
-                                     bool log_body);
+                                     bool log_body) override;
 
   Store::Status delete_data(const std::string& table,
                             const std::string& key,
-                            SAS::TrailId trail = 0);
+                            SAS::TrailId trail = 0) override;
 private:
-  Store::Status set_data(const std::string& table,
-                         const std::string& key,
-                         const std::string& data,
-                         uint64_t cas,
-                         bool check_cas,
-                         int expiry,
-                         SAS::TrailId trail = 0);
+  Store::Status set_data_inner(const std::string& table,
+                               const std::string& key,
+                               const std::string& data,
+                               uint64_t cas,
+                               bool check_cas,
+                               int expiry,
+                               SAS::TrailId trail = 0);
   typedef struct record
   {
     std::string data;

--- a/include/memcachedstore.h
+++ b/include/memcachedstore.h
@@ -123,6 +123,9 @@ public:
 
   ~TopologyNeutralMemcachedStore() {}
 
+  using Store::get_data;
+  using Store::set_data;
+
   /// Gets the data for the specified table and key.
   Store::Status get_data(const std::string& table,
                          const std::string& key,

--- a/src/localstore.cpp
+++ b/src/localstore.cpp
@@ -159,7 +159,7 @@ Store::Status LocalStore::set_data_without_cas(const std::string& table,
   TRC_DEBUG("set_data_without_cas table=%s key=%s expiry=%d",
             table.c_str(), key.c_str(), expiry);
 
-  return set_data(table, key, data, 0, false, expiry, trail);
+  return set_data_inner(table, key, data, 0, false, expiry, trail);
 }
 
 Store::Status LocalStore::set_data(const std::string& table,
@@ -173,16 +173,16 @@ Store::Status LocalStore::set_data(const std::string& table,
   TRC_DEBUG("set_data table=%s key=%s CAS=%ld expiry=%d",
             table.c_str(), key.c_str(), cas, expiry);
 
-  return set_data(table, key, data, cas, true, expiry, trail);
+  return set_data_inner(table, key, data, cas, true, expiry, trail);
 }
 
-Store::Status LocalStore::set_data(const std::string& table,
-                                   const std::string& key,
-                                   const std::string& data,
-                                   uint64_t cas,
-                                   bool check_cas,
-                                   int expiry,
-                                   SAS::TrailId trail)
+Store::Status LocalStore::set_data_inner(const std::string& table,
+                                         const std::string& key,
+                                         const std::string& data,
+                                         uint64_t cas,
+                                         bool check_cas,
+                                         int expiry,
+                                         SAS::TrailId trail)
 {
   Store::Status status = Store::Status::DATA_CONTENTION;
 


### PR DESCRIPTION
Seb,

When the Sprout UTs directly call through to the local store, they use a LocalStore* pointer, rather than a Store*.

Due to a feature in C++, called name hiding, which is invoked because when of the methods is override, the other argument overload for the function is hidden. This means that the code defaults to a different overload of the method, which means we end up using the CAS value as the expiry, which means that the data expires immediately.

I've fixed this by:
- Overriding the name hiding by asking to import the names into the derived classes.
- Renaming the inner function to avoid it being picked up accidentally.

I've verified the failing test now passes.