### PR TITLE
[Reviewer: Mat] Only add a Content-Type header if we have a body

### DIFF
--- a/include/httpclient.h
+++ b/include/httpclient.h
@@ -125,7 +125,7 @@ public:
   ///                           data
   /// @param response           Location to store retrieved data
   /// @param trail              SAS trail to use
-  /// @param body               Body to send on the request
+  /// @param body               JSON body to send on the request
   /// @param username           Username to assert if assertUser is true, else
   ///                           ignored
   /// @param allowed_host_state what lists to resolve hosts from, where we
@@ -159,7 +159,7 @@ public:
   /// @param headers            Location to store the header part of the retrieved
   ///                           data
   /// @param response           Location to store retrieved data
-  /// @param body               Body to send on the request
+  /// @param body               JSON body to send on the request
   /// @param extra_req_headers  Extra headers to add to the request
   /// @param trail              SAS trail to use
   /// @param username           Username to assert if assertUser is true, else
@@ -204,7 +204,7 @@ public:
   /// @param headers            Location to store the header part of the retrieved
   ///                           data
   /// @param response           Location to store retrieved data
-  /// @param body               Body to send on the request
+  /// @param body               JSON body to send on the request
   /// @param trail              SAS trail to use
   /// @param username           Username to assert if assertUser is true, else
   ///                           ignored
@@ -278,7 +278,7 @@ private:
   ///
   /// @param request_type     The type of HTTP request to send
   /// @param url              Full URL to request - includes http(s)?://
-  /// @param body             Body to send on the request
+  /// @param body             JSON body to send on the request
   /// @param response         Location to store retrieved data
   /// @param username         Username to assert if assertUser is true, else
   ///                         ignored

--- a/include/httpclient.h
+++ b/include/httpclient.h
@@ -301,6 +301,7 @@ private:
   /// Helper function that builds the curl header in the set_curl_options
   /// method.
   struct curl_slist* build_headers(std::vector<std::string> headers_to_add,
+                                   bool has_body,
                                    bool assert_user,
                                    const std::string& username,
                                    std::string uuid_str);

--- a/include/httpconnection.h
+++ b/include/httpconnection.h
@@ -133,7 +133,7 @@ public:
   ///                           data
   /// @param response           Location to store retrieved data
   /// @param trail              SAS trail to use
-  /// @param body               Body to send on the request
+  /// @param body               JSON body to send on the request
   /// @param username           Username to assert if assertUser is true, else
   ///                           ignored
   /// @param allowed_host_state what lists to resolve hosts from, where we
@@ -173,7 +173,7 @@ public:
   /// @param headers            Location to store the header part of the retrieved
   ///                           data
   /// @param response           Location to store retrieved data
-  /// @param body               Body to send on the request
+  /// @param body               JSON body to send on the request
   /// @param extra_req_headers  Extra headers to add to the request
   /// @param trail              SAS trail to use
   /// @param username           Username to assert if assertUser is true, else
@@ -227,7 +227,7 @@ public:
   /// @param headers  Location to store the header part of the retrieved
   ///                 data
   /// @param response Location to store retrieved data
-  /// @param body     Body to send on the request
+  /// @param body     JSON body to send on the request
   /// @param trail    SAS trail to use
   /// @param username Username to assert if assertUser is true, else
   ///                 ignored

--- a/src/httpclient.cpp
+++ b/src/httpclient.cpp
@@ -497,6 +497,7 @@ HTTPCode HttpClient::send_request(RequestType request_type,
 
     // Construct and add extra headers
     struct curl_slist* extra_headers = build_headers(headers_to_add,
+                                                     !body.empty(),
                                                      _assert_user,
                                                      username,
                                                      uuid_str);
@@ -802,12 +803,17 @@ HTTPCode HttpClient::send_request(RequestType request_type,
 }
 
 struct curl_slist* HttpClient::build_headers(std::vector<std::string> headers_to_add,
+                                             bool has_body,
                                              bool assert_user,
                                              const std::string& username,
                                              std::string uuid_str)
 {
   struct curl_slist* extra_headers = NULL;
-  extra_headers = curl_slist_append(extra_headers, "Content-Type: application/json");
+
+  if (has_body)
+  {
+    extra_headers = curl_slist_append(extra_headers, "Content-Type: application/json");
+  }
 
   // Add the UUID for SAS correlation to the HTTP message.
   extra_headers = curl_slist_append(extra_headers,


### PR DESCRIPTION
Mat,

This resolves a bug we've seen whereby we always add a Content-Type header.

This was originally the case (see https://github.com/Metaswitch/cpp-common/blob/11222e20d4fe50adb17b6fb3db05a3937f01a800/src/httpconnection.cpp#L495-L499 ) but got lost in some refactoring.