### PR TITLE
[Reviewer Richard] Clear out old_db on flush_all too

### DIFF
--- a/src/localstore.cpp
+++ b/src/localstore.cpp
@@ -47,6 +47,7 @@ void LocalStore::flush_all()
   pthread_mutex_lock(&_db_lock);
   TRC_DEBUG("Flushing local store");
   _db.clear();
+  _old_db.clear();
   pthread_mutex_unlock(&_db_lock);
 }
 
@@ -56,6 +57,7 @@ void LocalStore::flush_all()
 // if the flag is true.
 void LocalStore::force_contention()
 {
+  TRC_DEBUG("Setting _data_contention_flag");
   _data_contention_flag = true;
 }
 


### PR DESCRIPTION
flush_all wasn't actually flushing all. Now it does.