### PR TITLE
Added support for using X-Span-Id as a SAS correlation header

### DIFF
--- a/include/httpstack.h
+++ b/include/httpstack.h
@@ -252,7 +252,14 @@ public:
     //
 
     // Log any correlating markers encoded in the message header.
-    void log_correlator(SAS::TrailId trail, Request& req, uint32_t instance_id);
+    void log_correlators(SAS::TrailId trail, Request& req, uint32_t instance_id);
+
+    // Log a single correlating marker or type marker_type, extracted from header_name
+    void log_correlator(SAS::TrailId trail,
+                        Request& req,
+                        uint32_t instance_id,
+                        std::string header_name,
+                        int marker_type);
 
     // Log that a request has been received using the normal SAS event IDs.
     void log_req_event(SAS::TrailId trail,

--- a/include/sasevent.h
+++ b/include/sasevent.h
@@ -30,7 +30,7 @@ namespace SASEvent {
   // Name of the HTTP header we use to correlate the client and server in SAS.
   const std::string HTTP_BRANCH_HEADER_NAME = "X-SAS-HTTP-Branch-ID";
 
-  // Name of the HTTP header we use to correlate the client and server in SAS.
+  // Name of the header used by microservices for trail correlation.
   const std::string HTTP_SPAN_ID = "X-Span-Id";
 
   // The levels at which clearwater nodes may log HTTP messages.

--- a/include/sasevent.h
+++ b/include/sasevent.h
@@ -30,6 +30,9 @@ namespace SASEvent {
   // Name of the HTTP header we use to correlate the client and server in SAS.
   const std::string HTTP_BRANCH_HEADER_NAME = "X-SAS-HTTP-Branch-ID";
 
+  // Name of the HTTP header we use to correlate the client and server in SAS.
+  const std::string HTTP_SPAN_ID = "X-Span-Id";
+
   // The levels at which clearwater nodes may log HTTP messages.
   enum struct HttpLogLevel
   {

--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -508,6 +508,7 @@ bool HttpStack::Request::get_local_ip_port(std::string& ip, unsigned short& port
 //
 // SasLogger methods.
 //
+
 void HttpStack::SasLogger::log_correlators(SAS::TrailId trail,
                                           Request& req,
                                           uint32_t instance_id)
@@ -543,7 +544,7 @@ void HttpStack::SasLogger::log_correlator(SAS::TrailId trail,
     SAS::Marker corr_marker(trail, marker_type, instance_id);
     corr_marker.add_var_param(correlator);
 
-    // Generic correlators have a uniqueness scope. Use UUIDs for HTTP headers
+    // Generic correlators have a uniqueness scope. Use UUIDs for HTTP requests
     if (marker_type == MARKED_ID_GENERIC_CORRELATOR) {
       corr_marker.add_static_param(
         static_cast<uint32_t>(UniquenessScopes::UUID_RFC4122));

--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -514,10 +514,24 @@ void HttpStack::SasLogger::log_correlator(SAS::TrailId trail,
                                           uint32_t instance_id)
 {
   std::string correlator = req.header(SASEvent::HTTP_BRANCH_HEADER_NAME);
+
   if (correlator != "")
   {
     SAS::Marker corr_marker(trail, MARKER_ID_VIA_BRANCH_PARAM, instance_id);
     corr_marker.add_var_param(correlator);
+
+    // Report a correlating marker to SAS.  Set the option that means any
+    // associations will not reactivate the trail group.  Otherwise
+    // interactions with this server that happen after the call ends will cause
+    // long delays in the call appearing in SAS.
+    SAS::report_marker(corr_marker, SAS::Marker::Scope::Trace, false);
+  }
+  std::string qs_correlator = req.header(SASEvent::HTTP_SPAN_ID);
+
+  if (qs_correlator != "")
+  {
+    SAS::Marker corr_marker(trail, MARKER_ID_VIA_BRANCH_PARAM, instance_id);
+    corr_marker.add_var_param(qs_correlator);
 
     // Report a correlating marker to SAS.  Set the option that means any
     // associations will not reactivate the trail group.  Otherwise

--- a/src/httpstack_utils.cpp
+++ b/src/httpstack_utils.cpp
@@ -31,9 +31,9 @@ namespace HttpStackUtils
   HandlerThreadPool::HandlerThreadPool(unsigned int num_threads,
                                        ExceptionHandler* exception_handler,
                                        unsigned int max_queue) :
-    _pool(num_threads, 
-          exception_handler, 
-          &exception_callback, 
+    _pool(num_threads,
+          exception_handler,
+          &exception_callback,
           max_queue),
     _wrappers()
   {
@@ -124,7 +124,7 @@ namespace HttpStackUtils
                                              HttpStack::Request& req,
                                              uint32_t instance_id)
   {
-    log_correlator(trail, req, instance_id);
+    log_correlators(trail, req, instance_id);
     log_req_event(trail, req, instance_id, SASEvent::HttpLogLevel::DETAIL);
   }
 


### PR DESCRIPTION
Quicksilver microservices are expected to use X-Span-Id for correlating SAS trails. This PR adds support for logging this in clearwater components, if present on an inbound request.

See https://github.com/Metaswitch/cpp-common-test/pull/71 for the corresponding PR to cpp-common-test