### PR TITLE
[Reviewer: Rich] Lock around Net-SNMP calls

### DIFF
--- a/include/snmp_agent.h
+++ b/include/snmp_agent.h
@@ -9,8 +9,34 @@
  * Metaswitch Networks in a separate written agreement.
  */
 
+#include <string>
+#include "snmp_internal/snmp_includes.h"
+
 #ifndef CW_SNMP_AGENT_H
 #define CW_SNMP_AGENT_H
+
+class SNMPAgent
+{
+public:
+  SNMPAgent(std::string name) : _name(name) {}
+  static inline void instance(SNMPAgent* instance) { _instance = instance; }
+  static inline SNMPAgent* instance() { return _instance; }
+  int initialize();
+  int start(void);
+  void stop(void);
+  void add_row_to_table(netsnmp_tdata* table, netsnmp_tdata_row* row);
+  void remove_row_from_table(netsnmp_tdata* table, netsnmp_tdata_row* row);
+
+private:
+  static SNMPAgent* _instance;
+  std::string _name;
+  pthread_t _thread;
+  pthread_mutex_t _netsnmp_lock = PTHREAD_MUTEX_INITIALIZER;
+
+  static void* thread_fn(void* snmp_handler);
+  void thread_fn(void);
+  static int logging_callback(int majorID, int minorID, void* serverarg, void* clientarg);
+};
 
 // Starts the SNMP agent thread. 'name' is passed through to the netsnmp library as the application
 // name - this is arbitrary, but should be spomething sensible (e.g. 'sprout', 'bono').

--- a/include/snmp_internal/snmp_table.h
+++ b/include/snmp_internal/snmp_table.h
@@ -89,7 +89,7 @@ public:
   {
     // We're not necessarily on the Net-SNMP thread, so we can't call into
     // Net-SNMP here.  Call into SNMP Agent to add the row to the table.
-    SNMPAgent::instance()->add_row_to_table(_table, row->get_netsnmp_row());
+    SNMP::Agent::instance()->add_row_to_table(_table, row->get_netsnmp_row());
   };
 
   // Remove a Row from the underlying table.
@@ -97,7 +97,7 @@ public:
   {
     // We're not necessarily on the Net-SNMP thread, so we can't call into
     // Net-SNMP here.  Call into SNMP Agent to remove the row to the table.
-    SNMPAgent::instance()->remove_row_from_table(_table, row->get_netsnmp_row());
+    SNMP::Agent::instance()->remove_row_from_table(_table, row->get_netsnmp_row());
   };
 
 protected:

--- a/include/snmp_internal/snmp_table.h
+++ b/include/snmp_internal/snmp_table.h
@@ -13,6 +13,7 @@
 #include <map>
 #include <string>
 
+#include "snmp_agent.h"
 #include "snmp_row.h"
 #include "snmp_includes.h"
 #include "log.h"
@@ -86,13 +87,17 @@ public:
   // Add a Row into the underlying table.
   void add(T* row)
   {
-    netsnmp_tdata_add_row(_table, row->get_netsnmp_row());
+    // We're not necessarily on the Net-SNMP thread, so we can't call into
+    // Net-SNMP here.  Call into SNMP Agent to add the row to the table.
+    SNMPAgent::instance()->add_row_to_table(_table, row->get_netsnmp_row());
   };
 
   // Remove a Row from the underlying table.
   void remove(T* row)
   {
-    netsnmp_tdata_remove_row(_table, row->get_netsnmp_row());
+    // We're not necessarily on the Net-SNMP thread, so we can't call into
+    // Net-SNMP here.  Call into SNMP Agent to remove the row to the table.
+    SNMPAgent::instance()->remove_row_from_table(_table, row->get_netsnmp_row());
   };
 
 protected:

--- a/src/snmp_agent.cpp
+++ b/src/snmp_agent.cpp
@@ -9,6 +9,7 @@
  * Metaswitch Networks in a separate written agreement.
  */
 
+#include <limits.h>
 #include "snmp_internal/snmp_includes.h"
 #include "snmp_agent.h"
 #include "log.h"
@@ -97,7 +98,7 @@ void SNMPAgent::thread_fn()
     fd_set read_fds;
     FD_ZERO(&read_fds);
     struct timeval timeout;
-    timeout.tv_sec = 0;
+    timeout.tv_sec = LONG_MAX;
     timeout.tv_usec = 0;
     int block = 0;
     pthread_mutex_lock(&_netsnmp_lock);

--- a/src/snmp_agent.cpp
+++ b/src/snmp_agent.cpp
@@ -53,7 +53,7 @@ int SNMPAgent::start(void)
   init_snmp(_name.c_str());
   pthread_mutex_unlock(&_netsnmp_lock);
 
-  int rc = pthread_create(&_thread, NULL, thread_fn, NULL);
+  int rc = pthread_create(&_thread, NULL, thread_fn, this);
   return rc;
 }
 

--- a/src/snmp_agent.cpp
+++ b/src/snmp_agent.cpp
@@ -13,18 +13,123 @@
 #include "snmp_agent.h"
 #include "log.h"
 
-static pthread_t snmp_thread_var;
+SNMPAgent* SNMPAgent::_instance = NULL;
 
-void* snmp_thread(void* data)
+int SNMPAgent::initialize()
+{
+  pthread_mutex_lock(&_netsnmp_lock);
+
+  // Make sure we start as a subagent, not a master agent.
+  netsnmp_ds_set_boolean(NETSNMP_DS_APPLICATION_ID, NETSNMP_DS_AGENT_ROLE, 1);
+
+  // Set the persistent directory to somewhere that the process can write to
+  std::string persistent_file = "/tmp/";
+  persistent_file.append(_name.c_str());
+  netsnmp_ds_set_string(NETSNMP_DS_LIBRARY_ID,
+                        NETSNMP_DS_LIB_PERSISTENT_DIR,
+                        persistent_file.c_str());
+
+  // Uncomment this line to send AgentX requests over TCP, rather than a unix
+  // domain socket, in order to snoop them with tcpdump. You'll also need to
+  // replace the agentXSocket line in /etc/snmp/snmpd.conf on your node with
+  // 'agentXSocket tcp:localhost:705' and restart snmpd.
+  // netsnmp_ds_set_string(NETSNMP_DS_APPLICATION_ID, NETSNMP_DS_AGENT_X_SOCKET, "tcp:localhost:705");
+
+  // Use callback-based logging, and integrate it with the Clearwater logger
+  snmp_enable_calllog();
+  snmp_register_callback(SNMP_CALLBACK_LIBRARY, SNMP_CALLBACK_LOGGING, logging_callback, NULL);
+
+  netsnmp_container_init_list();
+  int rc = init_agent(_name.c_str());
+
+  pthread_mutex_unlock(&_netsnmp_lock);
+
+  return rc;
+}
+
+int SNMPAgent::start(void)
+{
+  pthread_mutex_lock(&_netsnmp_lock);
+  init_snmp(_name.c_str());
+  pthread_mutex_unlock(&_netsnmp_lock);
+
+  int rc = pthread_create(&_thread, NULL, thread_fn, NULL);
+  return rc;
+}
+
+void SNMPAgent::stop(void)
+{
+  pthread_cancel(_thread);
+
+  pthread_mutex_lock(&_netsnmp_lock);
+  snmp_shutdown(_name.c_str());
+  netsnmp_container_free_list();
+  pthread_mutex_unlock(&_netsnmp_lock);
+}
+
+void SNMPAgent::add_row_to_table(netsnmp_tdata* table, netsnmp_tdata_row* row)
+{
+  pthread_mutex_lock(&_netsnmp_lock);
+  netsnmp_tdata_add_row(table, row);
+  pthread_mutex_unlock(&_netsnmp_lock);
+}
+
+void SNMPAgent::remove_row_from_table(netsnmp_tdata* table, netsnmp_tdata_row* row)
+{
+  pthread_mutex_lock(&_netsnmp_lock);
+  netsnmp_tdata_remove_row(table, row);
+  pthread_mutex_unlock(&_netsnmp_lock);
+}
+
+void* SNMPAgent::thread_fn(void* snmp_agent)
+{
+  ((SNMPAgent*)snmp_agent)->thread_fn();
+  return NULL;
+}
+
+void SNMPAgent::thread_fn()
 {
   while (1)
   {
-    agent_check_and_process(1);
+    // Set up some variables and call into Net-SNMP to initialize them ready
+    // for the select call.
+    int num_fds = 0;
+    fd_set read_fds;
+    FD_ZERO(&read_fds);
+    struct timeval timeout;
+    timeout.tv_sec = 0;
+    timeout.tv_usec = 0;
+    int block = 0;
+    pthread_mutex_lock(&_netsnmp_lock);
+    snmp_select_info(&num_fds, &read_fds, &timeout, &block);
+    pthread_mutex_unlock(&_netsnmp_lock);
+
+    // Wait for some SNMP work or the timeout to expire, and then process.
+    int select_rc = select(num_fds, &read_fds, NULL, NULL, (!block) ? &timeout : NULL);
+
+    if (select_rc >= 0)
+    {
+      // Pass the work or the timeout indication to Net-SNMP.
+      pthread_mutex_lock(&_netsnmp_lock);
+      if (select_rc > 0)
+      {
+        snmp_read(&read_fds);
+      }
+      else if (select_rc == 0)
+      {
+        snmp_timeout();
+      }
+      pthread_mutex_unlock(&_netsnmp_lock);
+    }
+    else if ((select_rc != -1) || (errno != EINTR))
+    {
+      // Error.  We ignore EINTR, as it can happen spuriously.
+      TRC_WARNING("SNMP select failed with RC %d (errno: %d)", select_rc, errno);
+    }
   }
-  return NULL;
 };
 
-int logging_callback(int majorID, int minorID, void* serverarg, void* clientarg)
+int SNMPAgent::logging_callback(int majorID, int minorID, void* serverarg, void* clientarg)
 {
   snmp_log_message* log_message = (snmp_log_message*)serverarg;
   int snmp_priority = log_message->priority;
@@ -64,32 +169,11 @@ int logging_callback(int majorID, int minorID, void* serverarg, void* clientarg)
   return 0;
 }
 
-
 // Set up the SNMP agent. Returns 0 if it succeeds.
 int snmp_setup(const char* name)
 {
-  // Make sure we start as a subagent, not a master agent.
-  netsnmp_ds_set_boolean(NETSNMP_DS_APPLICATION_ID, NETSNMP_DS_AGENT_ROLE, 1);
-
-  // Set the persistent directory to somewhere that the process can write to
-  std::string persistent_file = "/tmp/";
-  persistent_file.append(name);
-  netsnmp_ds_set_string(NETSNMP_DS_LIBRARY_ID,
-                        NETSNMP_DS_LIB_PERSISTENT_DIR,
-                        persistent_file.c_str());
-
-  // Uncomment this line to send AgentX requests over TCP, rather than a unix
-  // domain socket, in order to snoop them with tcpdump. You'll also need to
-  // replace the agentXSocket line in /etc/snmp/snmpd.conf on your node with
-  // 'agentXSocket tcp:localhost:705' and restart snmpd.
-  // netsnmp_ds_set_string(NETSNMP_DS_APPLICATION_ID, NETSNMP_DS_AGENT_X_SOCKET, "tcp:localhost:705");
-
-  // Use callback-based logging, and integrate it with the Clearwater logger
-  snmp_enable_calllog();
-  snmp_register_callback(SNMP_CALLBACK_LIBRARY, SNMP_CALLBACK_LOGGING, logging_callback, NULL);
-
-  netsnmp_container_init_list();
-  int rc = init_agent(name);
+  SNMPAgent::instance(new SNMPAgent(name));
+  int rc = SNMPAgent::instance()->initialize();
   if (rc != 0)
   {
     TRC_WARNING("SNMP AgentX initialization failed");
@@ -104,10 +188,7 @@ int snmp_setup(const char* name)
 // Set up the SNMP handling threads. Returns 0 if it succeeds.
 int init_snmp_handler_threads(const char* name)
 {
-  init_snmp(name);
-
-  int ret = pthread_create(&snmp_thread_var, NULL, snmp_thread, NULL);
-  return ret;
+  return SNMPAgent::instance()->start();
 }
 
 // Cancel the handler thread and shut down the SNMP agent.
@@ -118,7 +199,5 @@ int init_snmp_handler_threads(const char* name)
 // between CentOS and Ubuntu when it is passed NULL.
 void snmp_terminate(const char* name)
 {
-  pthread_cancel(snmp_thread_var);
-  snmp_shutdown(name);
-  netsnmp_container_free_list();
+  SNMPAgent::instance()->stop();
 }


### PR DESCRIPTION
Rich,

Please can you review this fix to a window condition in which a Clearwater worker thread adds/removes a row to/from Net-SNMP while a Net-SNMP agent thread is accessing it?

The fix is to put a lock around Net-SNMP's operations.

To keep this all tidy, I've pulled the SNMP agent function into a class (so that it can own its variables).  I have, however, kept the start-up methods, to ensure all existing code continues to work.

I've stress-testes with simultaneous SIP and SNMP traffic and not seen any issues.  I can't be sure the crash I saw before is fixed without a whole load more stress, but I'm hoping to be able to run that in the background over the next few weeks.

Matt