### PR TITLE
[Reviewer: KH1] Add table for queue success/fail by priority

### DIFF
--- a/include/sip_event_priority.h
+++ b/include/sip_event_priority.h
@@ -1,0 +1,37 @@
+/**
+ * @file sip_event_priority.h
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#ifndef SIP_EVENT_PRIORITY_H
+#define SIP_EVENT_PRIORITY_H
+
+// Allowable priority levels for SIP events. Levels with higher values correspond
+// to higher priorities.
+enum SIPEventPriorityLevel
+{
+  NORMAL_PRIORITY=0,
+  HIGH_PRIORITY_1,
+  HIGH_PRIORITY_2,
+  HIGH_PRIORITY_3,
+  HIGH_PRIORITY_4,
+  HIGH_PRIORITY_5,
+  HIGH_PRIORITY_6,
+  HIGH_PRIORITY_7,
+  HIGH_PRIORITY_8,
+  HIGH_PRIORITY_9,
+  HIGH_PRIORITY_10,
+  HIGH_PRIORITY_11,
+  HIGH_PRIORITY_12,
+  HIGH_PRIORITY_13,
+  HIGH_PRIORITY_14,
+  HIGH_PRIORITY_15
+};
+
+#endif

--- a/include/snmp_internal/snmp_counts_by_other_type_and_scope_table.h
+++ b/include/snmp_internal/snmp_counts_by_other_type_and_scope_table.h
@@ -1,0 +1,73 @@
+/**
+ * @file snmp_counts_by_other_type_and_scope_table.h
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#ifndef SNMP_COUNTS_BY_OTHER_TYPE_AND_SCOPE_TABLE_H
+#define SNMP_COUNTS_BY_OTHER_TYPE_AND_SCOPE_TABLE_H
+
+#include "snmp_internal/snmp_time_period_other_type_and_scope_table.h"
+
+namespace SNMP
+{
+
+template <class RowType, class DataType> class CountsByOtherTypeAndScopeTableImpl: public ManagedTable<RowType, int>
+{
+public:
+  CountsByOtherTypeAndScopeTableImpl(std::string name,
+                                     std::string tbl_oid,
+                                     std::vector<int> types):
+    ManagedTable<RowType, int>(name,
+                         tbl_oid,
+                         4,
+                         4 + RowType::get_count_size() - 1,
+                         { ASN_INTEGER , ASN_INTEGER , ASN_OCTET_STR}) // Types of the index columns
+  {
+    int n = 0;
+
+    for (std::vector<int>::iterator type = types.begin();
+         type != types.end();
+         type++)
+    {
+      five_second[*type] = new CurrentAndPrevious<DataType>(5000);
+      five_minute[*type] = new CurrentAndPrevious<DataType>(300000);
+
+      this->add(n++, new RowType(TimePeriodIndexes::scopePrevious5SecondPeriod, *type, new typename RowType::PreviousView(five_second[*type])));
+      this->add(n++, new RowType(TimePeriodIndexes::scopeCurrent5MinutePeriod, *type, new typename RowType::CurrentView(five_minute[*type])));
+      this->add(n++, new RowType(TimePeriodIndexes::scopePrevious5MinutePeriod, *type, new typename RowType::PreviousView(five_minute[*type])));
+    }
+  }
+
+  ~CountsByOtherTypeAndScopeTableImpl()
+  {
+    for (typename std::map<int, CurrentAndPrevious<DataType>*>::iterator type = five_second.begin();
+         type != five_second.end();
+         type++)
+    {
+      delete type->second;
+    }
+
+    for (typename std::map<int, CurrentAndPrevious<DataType>*>::iterator type = five_minute.begin();
+         type != five_minute.end();
+         type++)
+    {
+      delete type->second;
+    }
+  }
+
+protected:
+  RowType* new_row(int indexes) { return NULL; };
+
+  std::map<int, CurrentAndPrevious<DataType>*> five_second;
+  std::map<int, CurrentAndPrevious<DataType>*> five_minute;
+};
+
+}
+
+#endif

--- a/include/snmp_internal/snmp_time_period_other_type_and_scope_table.h
+++ b/include/snmp_internal/snmp_time_period_other_type_and_scope_table.h
@@ -1,0 +1,49 @@
+/**
+ * @file snmp_time_period_other_type_and_scope_table.h
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#include "snmp_time_period_and_other_type_table.h"
+#include "snmp_node_types.h"
+
+#ifndef SNMP_TIME_PERIOD_OTHER_TYPE_AND_SCOPE_TABLE_H
+#define SNMP_TIME_PERIOD_OTHER_TYPE_AND_SCOPE_TABLE_H
+
+// This file contains the base infrastructure for SNMP tables
+// which are indexed by time period, another type (e.g. message priority) and
+// scope (node type).
+namespace SNMP
+{
+
+template <class T> class TimeOtherTypeAndScopeBasedRow : public TimeAndOtherTypeBasedRow<T>
+{
+public:
+  // Constructor, takes ownership of the View*.
+  TimeOtherTypeAndScopeBasedRow(int time_index, int type_index, std::string scope_index, typename TimeAndOtherTypeBasedRow<T>::View* view) :
+    TimeAndOtherTypeBasedRow<T>(time_index, type_index, view),
+    _scope_index(scope_index)
+  {
+    // Add the scope index (the time index and type index is added in the base class)
+    netsnmp_tdata_row_add_index(this->_row,
+                                ASN_OCTET_STR,
+                                _scope_index.c_str(),
+                                _scope_index.length());
+  };
+
+  virtual ~TimeOtherTypeAndScopeBasedRow()
+  {
+  };
+
+protected:
+  std::string _scope_index;
+};
+
+}
+
+#endif

--- a/include/snmp_success_fail_count_by_priority_and_scope_table.h
+++ b/include/snmp_success_fail_count_by_priority_and_scope_table.h
@@ -1,0 +1,41 @@
+/**
+ * @file snmp_success_fail_count_by_priority_and_scope_table.h
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#include <string>
+
+#ifndef SNMP_SUCCESS_FAIL_COUNT_BY_PRIORITY_AND_SCOPE_TABLE_H
+#define SNMP_SUCCESS_FAIL_COUNT_BY_PRIORITY_AND_SCOPE_TABLE_H
+
+// This file contains the interface for tables which:
+//   - are indexed by time period, message priority and scope (node type)
+//   - increment a count of the attempts, successes and failures over time
+//   - report a count of the attempts, successes and failures
+//
+// This is defined as an interface in order not to pollute the codebase with netsnmp include files
+// (which indiscriminately #define things like READ and WRITE).
+
+namespace SNMP
+{
+
+class SuccessFailCountByPriorityAndScopeTable
+{
+public:
+  SuccessFailCountByPriorityAndScopeTable() {};
+  virtual ~SuccessFailCountByPriorityAndScopeTable() {};
+
+  static SuccessFailCountByPriorityAndScopeTable* create(std::string name, std::string oid);
+  virtual void increment_attempts(int priority) = 0;
+  virtual void increment_successes(int priority) = 0;
+  virtual void increment_failures(int priotity) = 0;
+};
+
+}
+#endif

--- a/src/snmp_success_fail_count_by_priority_and_scope_table.cpp
+++ b/src/snmp_success_fail_count_by_priority_and_scope_table.cpp
@@ -1,0 +1,120 @@
+/**
+ * @file snmp_success_fail_count_by_priority_and_scope_table.cpp
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#include "snmp_success_fail_count_by_priority_and_scope_table.h"
+#include "snmp_internal/snmp_includes.h"
+#include "snmp_internal/snmp_counts_by_other_type_and_scope_table.h"
+#include "snmp_statistics_structures.h"
+#include "logger.h"
+
+namespace SNMP
+{
+
+// Time, Priority and Scope Based Row that maps the data from SuccessFailCount into the right column.
+class SuccessFailCountByPriorityAndScopeRow: public TimeOtherTypeAndScopeBasedRow<SuccessFailCount>
+{
+public:
+  SuccessFailCountByPriorityAndScopeRow(int time_index, int type_index, View* view):
+    TimeOtherTypeAndScopeBasedRow<SuccessFailCount>(time_index, type_index, "node", view) {};
+  ColumnData get_columns()
+  {
+    struct timespec now;
+    clock_gettime(CLOCK_REALTIME_COARSE, &now);
+
+    SuccessFailCount* counts = _view->get_data(now);
+    uint_fast32_t attempts = counts->attempts.load();
+    uint_fast32_t successes = counts->successes.load();
+    uint_fast32_t failures = counts->failures.load();
+    uint_fast32_t success_percent_in_ten_thousands = 0;
+    if (attempts == uint_fast32_t(0))
+    {
+      // If there are no attempts made we report the Success Percent as being
+      // 100% to indicate that there have been no errors.
+      // Note that units for Success Percent are actually 10,000's of a percent.
+      success_percent_in_ten_thousands = 100 * 10000;
+    }
+    else if (successes > 0)
+    {
+      // Units for Success Percent are actually 10,000's of a percent.
+      success_percent_in_ten_thousands = (successes * 100 * 10000) / (successes + failures);
+    }
+
+    // Construct and return a ColumnData with the appropriate values
+    ColumnData ret;
+    ret[1] = Value::integer(this->_index);
+    ret[2] = Value::integer(this->_type_index);
+    ret[3] = Value::uint(attempts);
+    ret[4] = Value::uint(successes);
+    ret[5] = Value::uint(failures);
+    ret[6] = Value::uint(success_percent_in_ten_thousands);
+    return ret;
+  }
+  static int get_count_size() { return 4; }
+};
+
+static std::vector<int> priorities =
+{
+  0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  8,
+  9,
+  10,
+  11,
+  12,
+  13,
+  14,
+  15
+};
+
+class SuccessFailCountByPriorityAndScopeTableImpl: public CountsByOtherTypeAndScopeTableImpl<SuccessFailCountByPriorityAndScopeRow, SuccessFailCount>,
+  public SuccessFailCountByPriorityAndScopeTable
+{
+public:
+  SuccessFailCountByPriorityAndScopeTableImpl(std::string name,
+                                              std::string tbl_oid):
+    CountsByOtherTypeAndScopeTableImpl<SuccessFailCountByPriorityAndScopeRow,
+                                       SuccessFailCount>(name,
+                                                         tbl_oid,
+                                                         priorities)
+  {}
+
+  void increment_attempts(int priority)
+  {
+    five_second[priority]->get_current()->attempts++;
+    five_minute[priority]->get_current()->attempts++;
+  }
+
+  void increment_successes(int priority)
+  {
+    five_second[priority]->get_current()->successes++;
+    five_minute[priority]->get_current()->successes++;
+  }
+
+  void increment_failures(int priority)
+  {
+    five_second[priority]->get_current()->failures++;
+    five_minute[priority]->get_current()->failures++;
+  }
+};
+
+SuccessFailCountByPriorityAndScopeTable* SuccessFailCountByPriorityAndScopeTable::create(std::string name,
+                                                                                         std::string oid)
+{
+  return new SuccessFailCountByPriorityAndScopeTableImpl(name, oid);
+}
+
+}

--- a/src/snmp_success_fail_count_by_priority_and_scope_table.cpp
+++ b/src/snmp_success_fail_count_by_priority_and_scope_table.cpp
@@ -50,12 +50,10 @@ public:
 
     // Construct and return a ColumnData with the appropriate values
     ColumnData ret;
-    ret[1] = Value::integer(this->_index);
-    ret[2] = Value::integer(this->_type_index);
-    ret[3] = Value::uint(attempts);
-    ret[4] = Value::uint(successes);
-    ret[5] = Value::uint(failures);
-    ret[6] = Value::uint(success_percent_in_ten_thousands);
+    ret[4] = Value::uint(attempts);
+    ret[5] = Value::uint(successes);
+    ret[6] = Value::uint(failures);
+    ret[7] = Value::uint(success_percent_in_ten_thousands);
     return ret;
   }
   static int get_count_size() { return 4; }

--- a/src/snmp_success_fail_count_by_priority_and_scope_table.cpp
+++ b/src/snmp_success_fail_count_by_priority_and_scope_table.cpp
@@ -13,6 +13,7 @@
 #include "snmp_internal/snmp_includes.h"
 #include "snmp_internal/snmp_counts_by_other_type_and_scope_table.h"
 #include "snmp_statistics_structures.h"
+#include "sip_event_priority.h"
 #include "logger.h"
 
 namespace SNMP
@@ -62,22 +63,22 @@ public:
 
 static std::vector<int> priorities =
 {
-  0,
-  1,
-  2,
-  3,
-  4,
-  5,
-  6,
-  7,
-  8,
-  9,
-  10,
-  11,
-  12,
-  13,
-  14,
-  15
+  SIPEventPriorityLevel::NORMAL_PRIORITY,
+  SIPEventPriorityLevel::HIGH_PRIORITY_1,
+  SIPEventPriorityLevel::HIGH_PRIORITY_2,
+  SIPEventPriorityLevel::HIGH_PRIORITY_3,
+  SIPEventPriorityLevel::HIGH_PRIORITY_4,
+  SIPEventPriorityLevel::HIGH_PRIORITY_5,
+  SIPEventPriorityLevel::HIGH_PRIORITY_6,
+  SIPEventPriorityLevel::HIGH_PRIORITY_7,
+  SIPEventPriorityLevel::HIGH_PRIORITY_8,
+  SIPEventPriorityLevel::HIGH_PRIORITY_9,
+  SIPEventPriorityLevel::HIGH_PRIORITY_10,
+  SIPEventPriorityLevel::HIGH_PRIORITY_11,
+  SIPEventPriorityLevel::HIGH_PRIORITY_12,
+  SIPEventPriorityLevel::HIGH_PRIORITY_13,
+  SIPEventPriorityLevel::HIGH_PRIORITY_14,
+  SIPEventPriorityLevel::HIGH_PRIORITY_15
 };
 
 class SuccessFailCountByPriorityAndScopeTableImpl: public CountsByOtherTypeAndScopeTableImpl<SuccessFailCountByPriorityAndScopeRow, SuccessFailCount>,


### PR DESCRIPTION
Adds a new SNMP table that covers tracks attempts/successes/failures of events put on the queue for worker threads by priority level.