### PR TITLE
Annotate the logger to catch format string errors

### DIFF
--- a/include/log.h
+++ b/include/log.h
@@ -47,7 +47,7 @@ namespace Log
   }
   void setLoggingLevel(int level);
   Logger* setLogger(Logger *log);
-  void write(int level, const char *module, int line_number, const char *fmt, ...);
+  void write(int level, const char *module, int line_number, const char *fmt, ...) __attribute__ ((__format__(printf, 4, 5)));
   void _write(int level, const char *module, int line_number, const char *fmt, va_list args);
   void backtrace(const char *fmt, ...);
   void commit();


### PR DESCRIPTION
As discussed...

With this change, the format string at https://gitlab.datcon.co.uk/clearwater/another-clearwater-stress-tool/merge_requests/32/diffs#note_28384 created a compiler warning where previously it didn't 9and then crashed at runtime). This is useful.

However, I'm nervous about the impact of this - I think it will cause build failures across Clearwater wherever our int types are wrong. I'm inclined to have a `#define PEDANTIC_LOGGER` unless you have a better idea.