### PR TITLE
[Reviewer: Alex] Consider time waiting for memcached as IO time

### DIFF
--- a/src/memcached_connection_pool.cpp
+++ b/src/memcached_connection_pool.cpp
@@ -42,7 +42,13 @@ memcached_st* MemcachedConnectionPool::create_connection(AddrInfo target)
                          MEMCACHED_BEHAVIOR_TCP_NODELAY,
                          true);
 
-  memcached_server_add(conn, target.address.to_string().c_str(), target.port);
+  std::string address = target.address.to_string();
+
+  CW_IO_STARTS("Memcached Server Add for " + address)
+  {
+    memcached_server_add(conn, address.c_str(), target.port);
+  }
+  CW_IO_COMPLETES()
 
   return conn;
 }

--- a/src/memcachedstore.cpp
+++ b/src/memcachedstore.cpp
@@ -91,7 +91,12 @@ memcached_return_t BaseMemcachedStore::get_from_replica(memcached_st* replica,
     TRC_DEBUG("Fetch result");
     memcached_result_st result;
     memcached_result_create(replica, &result);
-    memcached_fetch_result(replica, &result, &rc);
+
+    CW_IO_STARTS("Memcached GET fetch result for " + std::string(key_ptr, key_len))
+    {
+      memcached_fetch_result(replica, &result, &rc);
+    }
+    CW_IO_COMPLETES()
 
     if (memcached_success(rc))
     {


### PR DESCRIPTION
This resolves two places which we didn't consider IO operations, and thus didn't call the IO hooks.

- `memcached_server_add()` This will attempt to connect to the server over TCP, as memcached has it's own connection management code. Thus, in a high latency deployment, this can take > 100ms.

- `memcached_fetch_result()`. While `memcached_mget()`, is responsible for performing a GET, fetch result is responsible for waiting for that get to actually be available. This thus means that it will block waiting for the other end.

I've tested this live
