### PR TITLE
[Reviewer: Rich] Process alarms

### DIFF
--- a/src/snmp_agent.cpp
+++ b/src/snmp_agent.cpp
@@ -158,6 +158,9 @@ void Agent::thread_fn()
       {
         snmp_timeout();
       }
+
+      // Process any "alarms" - note these aren't SNMP TRAPs, but timers run by SNMP itself.
+      run_alarms();
       pthread_mutex_unlock(&_netsnmp_lock);
     }
     else if ((select_rc != -1) || (errno != EINTR))

--- a/src/snmp_agent.cpp
+++ b/src/snmp_agent.cpp
@@ -161,6 +161,10 @@ void Agent::thread_fn()
 
       // Process any "alarms" - note these aren't SNMP TRAPs, but timers run by SNMP itself.
       run_alarms();
+
+      // ...and finally process any delegated or queued requests.
+      netsnmp_check_outstanding_agent_requests();
+
       pthread_mutex_unlock(&_netsnmp_lock);
     }
     else if ((select_rc != -1) || (errno != EINTR))


### PR DESCRIPTION
Not sure why I didn't hit this during my testing, and a shame that it isn't covered by https://linux.die.net/man/3/snmp_select_info, but we need to process alarms too.

I've done a review against `agent_check_and_process` and

*   also added `netsnmp_check_outstanding_agent_requests`, although I don't think we use it
*   not added `snmp_store_if_needed` because we definitely don't use that.

Please can you review?