### PR TITLE
[Reviewer: Alex] Treat DNS requests as IO

### DIFF
--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -537,7 +537,11 @@ void DnsCachedResolver::inner_dns_query(const std::vector<std::string>& domains,
     // request further.
     TRC_DEBUG("Wait for query responses");
     pthread_mutex_unlock(&_cache_lock);
-    wait_for_replies(channel);
+    CW_IO_STARTS("DNS query")
+    {
+      wait_for_replies(channel);
+    }
+    CW_IO_COMPLETES()
     pthread_mutex_lock(&_cache_lock);
     TRC_DEBUG("Received all query responses");
   }
@@ -556,7 +560,11 @@ void DnsCachedResolver::inner_dns_query(const std::vector<std::string>& domains,
       // We must release the global lock and let the other thread finish
       // the query.
       TRC_DEBUG("Waiting for (non-cached) DNS query for %s", i->c_str());
-      pthread_cond_wait(&_got_reply_cond, &_cache_lock);
+      CW_IO_STARTS("DNS pending query")
+      {
+        pthread_cond_wait(&_got_reply_cond, &_cache_lock);
+      }
+      CW_IO_COMPLETES()
       ce = get_cache_entry(*i, dnstype);
       TRC_DEBUG("Reawoken from wait for %s type %d", i->c_str(), dnstype);
     }


### PR DESCRIPTION
Currently we don't treat DNS requests as IO operations, which means that they can cause requests to erroneously be regarded as being slow on a process (e.g. on Sprout), which can cause incorrect overload behaviour.

There's two changes here:

- The first is relatively uncontroversial I think - waiting for DNS query replies, we treat as an IO operation.

- The second is more controversial, but I think it's the right think to do - we treat waiting for another thread to complete when it's performing an outstanding IO operation, as an IO operation. I think this is more controversial, but I think the reasoning is sound - essentially that other thread is acting as a blocking IO call for this thread, and thus it's right for this thread to block based on it. This is much rarer - as the DNS operation has to be outstanding when we were able to grab the cache lock.