### PR TITLE
Make exception handling more robust

### DIFF
--- a/include/log.h
+++ b/include/log.h
@@ -22,7 +22,7 @@
 #define TRC_INFO(...) if (Log::enabled(Log::INFO_LEVEL)) Log::write(Log::INFO_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
 #define TRC_VERBOSE(...) if (Log::enabled(Log::VERBOSE_LEVEL)) Log::write(Log::VERBOSE_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
 #define TRC_DEBUG(...) if (Log::enabled(Log::DEBUG_LEVEL)) Log::write(Log::DEBUG_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
-#define TRC_BACKTRACE() Log::backtrace()
+#define TRC_BACKTRACE(...) Log::backtrace(__VA_ARGS__)
 #define TRC_BACKTRACE_ADV() Log::backtrace_adv()
 #define TRC_COMMIT() Log::commit()
 
@@ -50,7 +50,7 @@ namespace Log
   Logger* setLogger(Logger *log);
   void write(int level, const char *module, int line_number, const char *fmt, ...);
   void _write(int level, const char *module, int line_number, const char *fmt, va_list args);
-  void backtrace();
+  void backtrace(const char* fmt, ...);
   void backtrace_adv();
   void commit();
 }

--- a/include/log.h
+++ b/include/log.h
@@ -22,8 +22,9 @@
 #define TRC_INFO(...) if (Log::enabled(Log::INFO_LEVEL)) Log::write(Log::INFO_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
 #define TRC_VERBOSE(...) if (Log::enabled(Log::VERBOSE_LEVEL)) Log::write(Log::VERBOSE_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
 #define TRC_DEBUG(...) if (Log::enabled(Log::DEBUG_LEVEL)) Log::write(Log::DEBUG_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
-#define TRC_BACKTRACE(...) Log::backtrace(__VA_ARGS__)
-#define TRC_COMMIT(...) Log::commit()
+#define TRC_BACKTRACE() Log::backtrace()
+#define TRC_BACKTRACE_ADV() Log::backtrace_adv()
+#define TRC_COMMIT() Log::commit()
 
 namespace Log
 {
@@ -49,7 +50,8 @@ namespace Log
   Logger* setLogger(Logger *log);
   void write(int level, const char *module, int line_number, const char *fmt, ...);
   void _write(int level, const char *module, int line_number, const char *fmt, va_list args);
-  void backtrace(const char *fmt, ...);
+  void backtrace();
+  void backtrace_adv();
   void commit();
 }
 

--- a/include/logger.h
+++ b/include/logger.h
@@ -35,10 +35,23 @@ public:
   virtual void flush();
   virtual void commit();
 
-  // Dumps a backtrace.  Note that this is not thread-safe and should only be
-  // called when no other threads are running - generally from a signal
-  // handler.
-  virtual void backtrace(const char* data);
+  // Dump a simple backtrace (using functionality available from within the
+  // process). This is fast but not very good - in particular it doesn't print out
+  // function names or arguments.
+  //
+  // This function is called from a signal handler and so can
+  // only use functions that are safe to be called from one.  In particular,
+  // locking functions are _not_ safe to call from signal handlers, so this
+  // function is not thread-safe.
+  virtual void backtrace_simple();
+
+  // Dump an advanced backtrace using GDB. This captures function names and
+  // arguments but stops the process temporarily. Because of this it should only
+  // be used when the process is about to exit.
+  //
+  // Note that this is not thread-safe and should only be called when no other
+  // threads are running - generally from a signal handler.
+  virtual void backtrace_advanced();
 
 protected:
   virtual void gettime_monotonic(struct timespec* ts);

--- a/include/logger.h
+++ b/include/logger.h
@@ -73,6 +73,7 @@ private:
 
   void get_timestamp(timestamp_t& ts);
   void write_log_file(const char* data, const timestamp_t& ts);
+  void format_timestamp(const timestamp_t& ts, char* buf, size_t len);
   void cycle_log_file(const timestamp_t& ts);
 
   // Two methods to use with pthread_cleanup_push to release the lock if the logging thread is
@@ -90,7 +91,6 @@ private:
   std::string _filename;
   std::string _directory;
   pthread_mutex_t _lock;
-  std::atomic<bool> _dumping_adv_backtrace;
 
   /// Defines how frequently (in seconds) we will try to reopen a log
   /// file when we have previously failed to use it.

--- a/include/logger.h
+++ b/include/logger.h
@@ -43,7 +43,7 @@ public:
   // only use functions that are safe to be called from one.  In particular,
   // locking functions are _not_ safe to call from signal handlers, so this
   // function is not thread-safe.
-  virtual void backtrace_simple();
+  virtual void backtrace_simple(const char* data);
 
   // Dump an advanced backtrace using GDB. This captures function names and
   // arguments but stops the process temporarily. Because of this it should only

--- a/include/logger.h
+++ b/include/logger.h
@@ -17,6 +17,7 @@
 
 #include <string>
 #include <pthread.h>
+#include <atomic>
 
 class Logger
 {
@@ -76,6 +77,7 @@ private:
   std::string _filename;
   std::string _directory;
   pthread_mutex_t _lock;
+  std::atomic<bool> _dumping_adv_backtrace;
 
   /// Defines how frequently (in seconds) we will try to reopen a log
   /// file when we have previously failed to use it.

--- a/src/exception_handler.cpp
+++ b/src/exception_handler.cpp
@@ -14,6 +14,7 @@
 #include <unistd.h>
 #include <cstdlib>
 #include <signal.h>
+#include <string.h>
 
 #include "exception_handler.h"
 #include "health_checker.h"
@@ -109,6 +110,9 @@ void ExceptionHandler::dump_one_core()
       // Unset the SIGABRT handler so we don't try to handle the abort call
       // below.
       signal(SIGABRT, SIG_DFL);
+
+      // We're in the child process so we can safely get advanced stack trace.
+      TRC_BACKTRACE_ADV();
 
       // Ensure the log files are complete - the core file created by abort()
       // below will trigger the log files to be copied to the diags bundle

--- a/src/exception_handler.cpp
+++ b/src/exception_handler.cpp
@@ -100,6 +100,13 @@ void ExceptionHandler::dump_one_core()
       // Unset the SIGABRT handler so we don't try to print a stack trace.
       signal(SIGABRT, SIG_DFL);
 
+      // Dump an advanced backtrace.
+      TRC_BACKTRACE_ADV();
+
+      // Ensure the log files are complete - the core file created by abort()
+      // below will trigger the log files to be copied to the diags bundle
+      TRC_COMMIT();
+
       // Now abort to generate the corefile.
       abort();
     }

--- a/src/exception_handler.cpp
+++ b/src/exception_handler.cpp
@@ -17,6 +17,7 @@
 
 #include "exception_handler.h"
 #include "health_checker.h"
+#include "log.h"
 
 pthread_key_t _jmp_buf;
 
@@ -88,9 +89,15 @@ void ExceptionHandler::dump_one_core()
 
   if (!dumped_core && _dumped_core.compare_exchange_strong(dumped_core, true))
   {
+    TRC_STATUS("Dumping core file");
+
     if (!fork())
     {
       abort();
     }
+  }
+  else
+  {
+    TRC_STATUS("Not dumping core file - core has already been dumped for this process");
   }
 }

--- a/src/exception_handler.cpp
+++ b/src/exception_handler.cpp
@@ -95,13 +95,20 @@ void ExceptionHandler::dump_one_core()
   {
     TRC_STATUS("Dumping core file");
 
-    if (!fork())
-    {
-      // Unset the SIGABRT handler so we don't try to print a stack trace.
-      signal(SIGABRT, SIG_DFL);
+    int rc = fork();
 
-      // Dump an advanced backtrace.
-      TRC_BACKTRACE_ADV();
+    if (rc < 0)
+    {
+      TRC_WARNING("Unable to fork to produce a core file. Error: %d %s",
+                  errno, strerror(errno));
+    }
+    else if (rc == 0)
+    {
+      // In the child process.
+
+      // Unset the SIGABRT handler so we don't try to handle the abort call
+      // below.
+      signal(SIGABRT, SIG_DFL);
 
       // Ensure the log files are complete - the core file created by abort()
       // below will trigger the log files to be copied to the diags bundle

--- a/src/exception_handler.cpp
+++ b/src/exception_handler.cpp
@@ -68,15 +68,18 @@ void* ExceptionHandler::delayed_exit_thread_func(void* det)
   // Wait for a random time up to the _ttl. This thread was detached when it
   // was created, so we can safely call sleep
   int sleep_time = rand() % ((ExceptionHandler*)det)->_ttl;
+  TRC_WARNING("Delayed exit will shutdown this process in %d seconds", sleep_time);
   sleep(sleep_time);
 
   // Raise a SIGQUIT if needed.
   if (((ExceptionHandler*)det)->_attempt_quiesce)
   {
+    TRC_WARNING("Delayed exit attempting to quiesce process");
     raise(SIGQUIT);
     sleep(10);
   }
 
+  TRC_WARNING("Delayed exit shutting down process");
   exit(1);
 }
 

--- a/src/exception_handler.cpp
+++ b/src/exception_handler.cpp
@@ -97,6 +97,10 @@ void ExceptionHandler::dump_one_core()
 
     if (!fork())
     {
+      // Unset the SIGABRT handler so we don't try to print a stack trace.
+      signal(SIGABRT, SIG_DFL);
+
+      // Now abort to generate the corefile.
       abort();
     }
   }

--- a/src/exception_handler.cpp
+++ b/src/exception_handler.cpp
@@ -26,7 +26,8 @@ ExceptionHandler::ExceptionHandler(int ttl,
                                    HealthChecker* health_checker) :
   _ttl(ttl),
   _attempt_quiesce(attempt_quiesce),
-  _health_checker(health_checker)
+  _health_checker(health_checker),
+  _dumped_core(false)
 {
   pthread_key_create(&_jmp_buf, NULL);
 }

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -138,28 +138,24 @@ void Log::_write(int level, const char *module, int line_number, const char *fmt
 
 // LCOV_EXCL_START Only used in exceptional signal handlers - not hit in UT
 
-void Log::backtrace(const char *fmt, ...)
+void Log::backtrace()
 {
   if (!Log::logger)
   {
     return;
   }
 
-  va_list args;
-  char logline[MAX_LOGLINE];
-  va_start(args, fmt);
-  // snprintf and vsnprintf return the bytes that would have been
-  // written if their second argument was large enough, so we need to
-  // reduce the size of written to compensate if it is too large.
-  int written = vsnprintf(logline, MAX_LOGLINE - 2, fmt, args);
-  written = std::min(written, MAX_LOGLINE - 2);
-  va_end(args);
+  Log::logger->backtrace_simple();
+}
 
-  // Add a new line and null termination.
-  logline[written] = '\n';
-  logline[written+1] = '\0';
+void Log::backtrace_adv()
+{
+  if (!Log::logger)
+  {
+    return;
+  }
 
-  Log::logger->backtrace(logline);
+  Log::logger->backtrace_advanced();
 }
 
 void Log::commit()

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -272,11 +272,12 @@ void Logger::cycle_log_file(const timestamp_t& ts)
 // only use functions that are safe to be called from one.  In particular,
 // locking functions are _not_ safe to call from signal handlers, so this
 // function is not thread-safe.
-void Logger::backtrace_simple()
+void Logger::backtrace_simple(const char* data)
 {
   // If the file exists, dump a header and then the backtrace.
   if (_fd != NULL)
   {
+    fprintf(_fd, "\n%s", data);
     fprintf(_fd, "\nBasic stack dump:\n");
     fflush(_fd);
     void *stack[MAX_BACKTRACE_STACK_ENTRIES];

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -278,6 +278,7 @@ void Logger::backtrace_simple()
     void *stack[MAX_BACKTRACE_STACK_ENTRIES];
     size_t num_entries = ::backtrace(stack, MAX_BACKTRACE_STACK_ENTRIES);
     backtrace_symbols_fd(stack, num_entries, fileno(_fd));
+    fprintf(_fd, "\n");
 
     fflush(_fd);
 


### PR DESCRIPTION
Hi Ellie, please can you review this PR that makes our exception handling behavior more robust? 

Prior to these changes, every time we hit a handled exception we:

* Dumped a core file.
* Logged basic stack trace to the log file.
* Logged advanced stack trace to the log file. 

I've changed this so that we:

* Dump a core file on the **first** handled exception. 
* Log basic stack trace to the log file. 
* Log advanced stack trace for the **first** handled exception. This comes with some restrictions:
  * It is generated from the core dumping process (which means we only get the stack from the trace that hit the exception). This was necessary to avoid stopping the sprout process while generating the trace. 
  * Advanced stack trace is now logged to stderr (which gets captured to a log file). This is necessary because now that we're logging the stack trace from another process, the stack got completely interleaved with other logs being generated from the main process, making the stack basically unreadable. 

To test this I hacked sprout to crash in the sproutlet proxy, then ran the basic call live tests (`rake test[...'] SIGNUP_CODE=... TESTS='Basic Call - *' TRANSPORT=TCP`). The sprout log and stderr files looked sensible (and are attached to the PR) and I checked that we dumped a core on the first unhandled exception (though this is often truncated when monit restarts the sprout process). 

I've also tried aborting sprout `sudo service sprout abort` and checked that I get basic stack dump to the log file, a full stack dump (including all threads ) to stderr, and a non-truncated core file. 
