### PR TITLE
[Reviewer: Sathiyan] Have all requests cost a token

### DIFF
--- a/include/load_monitor.h
+++ b/include/load_monitor.h
@@ -81,9 +81,11 @@ class LoadMonitor
 
     // Tests whether a request can be admitted.
     //
-    // @param trail     - The SAS trail associated with this request
-    // @returns         - Whether the request can be admitted.
-    virtual bool admit_request(SAS::TrailId trail);
+    // @param trail        - The SAS trail associated with this request
+    // @param allow_anyway - Whether the request should be allowed even if
+    //                       there aren't enough tokens
+    // @returns            - Whether the request can be admitted.
+    virtual bool admit_request(SAS::TrailId trail, bool allow_anyway = false);
 
     // This is called after a request that the load monitor is interested in
     // completes successfully. It adds the latency of the request to the

--- a/src/load_monitor.cpp
+++ b/src/load_monitor.cpp
@@ -133,7 +133,8 @@ bool LoadMonitor::admit_request(SAS::TrailId trail, bool allow_anyway)
 
   if (_bucket.get_token() || allow_anyway)
   {
-    // Got a token from the bucket, so admit the request.
+    // Admit the request - we either got a token from the bucket, or we're
+    // meant to accept the request anyway.
     _accepted += 1;
 
     SAS::Event accept(trail, SASEvent::LOAD_MONITOR_ACCEPTED_REQUEST, 0);

--- a/src/load_monitor.cpp
+++ b/src/load_monitor.cpp
@@ -87,7 +87,7 @@ LoadMonitor::LoadMonitor(uint64_t init_target_latency_us,
   _penalties(0),
   _adjust_count(0),
   _token_rate_table(token_rate_table),
-  _smoothed_latency_scalar(0),
+  _smoothed_latency_scalar(smoothed_latency_scalar),
   _target_latency_scalar(target_latency_scalar),
   _penalties_scalar(penalties_scalar),
   _token_rate_scalar(token_rate_scalar)

--- a/test_utils/mockloadmonitor.hpp
+++ b/test_utils/mockloadmonitor.hpp
@@ -21,7 +21,7 @@ public:
   MockLoadMonitor() : LoadMonitor(0, 0, 0.0, 0.0, 0.0) {}
   virtual ~MockLoadMonitor() {}
 
-  MOCK_METHOD1(admit_request, bool(SAS::TrailId id));
+  MOCK_METHOD2(admit_request, bool(SAS::TrailId id, bool admit_anyway));
   MOCK_METHOD0(incr_penalties, void());
   MOCK_METHOD2(request_complete, void(uint64_t latency,
                                       SAS::TrailId id));


### PR DESCRIPTION
This adds a method to the load monitor to allow all requests to cost a token, but have certain requests be allowed anyway even if there aren't any tokens.

This also smoothes out the latency calculations so that the average latency is calculated from the requests that make up the 20 requests before a recalculation.

Tested in UTs, and shortly under overload.