### PR TITLE
[Reviewer: Mat] Improve HTTP error messages

### DIFF
--- a/include/httpclient.h
+++ b/include/httpclient.h
@@ -364,7 +364,8 @@ private:
                           const std::string& method_str,
                           const std::string& url,
                           CURLcode code,
-                          uint32_t instance_id);
+                          uint32_t instance_id,
+                          const char* error);
 
   void sas_log_bad_retry_after_value(SAS::TrailId trail,
                                      const std::string value,


### PR DESCRIPTION
Mat,

We've been seeing a bunch of HTTP connection errors (most of which are mitigated by https://github.com/Metaswitch/curl/pull/2). This commits the extra logging that I've been using to diagnose the failures, which I think is generally useful:

- Include error message from libcurl in the warning log, and the SAS log if
  it's available.

- Include time the HTTP request was sent in the log, to debug timeout
  errors.