### PR TITLE
[Reviewer: CJR] Make CPP-Common SAS compression configurable

### DIFF
--- a/include/httpclient.h
+++ b/include/httpclient.h
@@ -68,7 +68,8 @@ public:
              bool remote_connection = false,
              long timeout_ms = -1,
              bool log_display_address = false,
-             std::string server_display_address = "");
+             std::string server_display_address = "",
+             bool sas_compress_logs);
 
   HttpClient(bool assert_user,
              HttpResolver* resolver,
@@ -408,4 +409,5 @@ private:
   bool _should_omit_body;
   bool _log_display_address;
   std::string _server_display_address;
+  bool _sas_compress_logs;
 };

--- a/include/httpclient.h
+++ b/include/httpclient.h
@@ -69,7 +69,7 @@ public:
              long timeout_ms = -1,
              bool log_display_address = false,
              std::string server_display_address = "",
-             bool sas_compress_logs);
+             bool sas_compress_logs = true);
 
   HttpClient(bool assert_user,
              HttpResolver* resolver,

--- a/include/utils.h
+++ b/include/utils.h
@@ -645,24 +645,24 @@ namespace Utils
   // is true or false and compresses logs sent to SAS accordingly.
   void add_sas_param_compressed_if_toggled(SAS::Event& event,
                                            const std::string& s,
-                                           const Profile* profle = NULL,
+                                           const SAS::Profile* proflie = NULL,
                                            bool sas_compress_logs = true);
 
   void add_sas_param_compressed_if_toggled(SAS::Event& event,
                                            size_t len,
                                            char* s,
-                                           const Profile* profle = NULL,
+                                           const SAS::Profile* profile = NULL,
                                            bool sas_compress_logs = true);
 
   void add_sas_param_compressed_if_toggled(SAS::Event& event,
                                            size_t len,
                                            uint8_t* s,
-                                           const Profile* profle = NULL,
+                                           const SAS::Profile* profile = NULL,
                                            bool sas_compress_logs = true);
 
   void add_sas_param_compressed_if_toggled(SAS::Event& event,
                                            const char* s,
-                                           const Profile* profle = NULL,
+                                           const SAS::Profile* profile = NULL,
                                            bool sas_compress_logs = true);
 
   /// This hook allows a thread to perform actions when Clearwater code does

--- a/include/utils.h
+++ b/include/utils.h
@@ -6,7 +6,7 @@
  * of the source code repository by which you are accessing this code, then
  * the license outlined in that COPYING file applies to your use.
  * Otherwise no rights are granted except for those provided to you by
- * Metaswitch Networks in a separate written agreement. COMMENT
+ * Metaswitch Networks in a separate written agreement.
  */
 
 #ifndef UTILS_H_
@@ -27,6 +27,7 @@
 #include <arpa/inet.h>
 
 #include "log.h"
+#include "sas.h"
 
 struct IP46Address
 {

--- a/include/utils.h
+++ b/include/utils.h
@@ -6,7 +6,7 @@
  * of the source code repository by which you are accessing this code, then
  * the license outlined in that COPYING file applies to your use.
  * Otherwise no rights are granted except for those provided to you by
- * Metaswitch Networks in a separate written agreement.
+ * Metaswitch Networks in a separate written agreement. COMMENT
  */
 
 #ifndef UTILS_H_
@@ -638,6 +638,31 @@ namespace Utils
 
   bool in_vector(const std::string& element,
                  const std::vector<std::string>& elements);
+
+
+  // These functions check whether sas_compress_logs, set as "Y" or "N" in etc/clearwater/shared_config,
+  // is true or false and compresses logs sent to SAS accordingly.
+  void add_sas_param_compressed_if_toggled(SAS::Event& event,
+                                           const std::string& s,
+                                           const Profile* profle = NULL,
+                                           bool sas_compress_logs = true);
+
+  void add_sas_param_compressed_if_toggled(SAS::Event& event,
+                                           size_t len,
+                                           char* s,
+                                           const Profile* profle = NULL,
+                                           bool sas_compress_logs = true);
+
+  void add_sas_param_compressed_if_toggled(SAS::Event& event,
+                                           size_t len,
+                                           uint8_t* s,
+                                           const Profile* profle = NULL,
+                                           bool sas_compress_logs = true);
+
+  void add_sas_param_compressed_if_toggled(SAS::Event& event,
+                                           const char* s,
+                                           const Profile* profle = NULL,
+                                           bool sas_compress_logs = true);
 
   /// This hook allows a thread to perform actions when Clearwater code does
   /// blocking I/O.

--- a/src/httpclient.cpp
+++ b/src/httpclient.cpp
@@ -1069,12 +1069,18 @@ void HttpClient::sas_log_http_req(SAS::TrailId trail,
 
     if (!_should_omit_body)
     {
-      event.add_compressed_param(request_bytes, &SASEvent::PROFILE_HTTP);
+      Utils::add_sas_param_compressed_if_toggled(event,
+                                                 request_bytes,
+                                                 &SASEvent::PROFILE_HTTP,
+                                                 sas_compress_logs);
     }
     else
     {
       std::string message_to_log = get_obscured_message_to_log(request_bytes);
-      event.add_compressed_param(message_to_log, &SASEvent::PROFILE_HTTP);
+      Utils::add_sas_param_compressed_if_toggled(event,
+                                                 message_to_log,
+                                                 &SASEvent::PROFILE_HTTP,
+                                                 sas_compress_logs);
     }
 
     event.add_var_param(method_str);
@@ -1104,12 +1110,18 @@ void HttpClient::sas_log_http_rsp(SAS::TrailId trail,
 
     if (!_should_omit_body)
     {
-      event.add_compressed_param(response_bytes, &SASEvent::PROFILE_HTTP);
+      Utils::add_sas_param_compressed_if_toggled(event,
+                                                 response_bytes,
+                                                 &SASEvent::PROFILE_HTTP,
+                                                 sas_compress_logs);
     }
     else
     {
       std::string message_to_log = get_obscured_message_to_log(response_bytes);
-      event.add_compressed_param(message_to_log, &SASEvent::PROFILE_HTTP);
+      Utils::add_sas_param_compressed_if_toggled(event,
+                                                 message_to_log,
+                                                 &SASEvent::PROFILE_HTTP,
+                                                 sas_compress_logs);
     }
 
     event.add_var_param(method_str);

--- a/src/httpclient.cpp
+++ b/src/httpclient.cpp
@@ -1072,7 +1072,7 @@ void HttpClient::sas_log_http_req(SAS::TrailId trail,
       Utils::add_sas_param_compressed_if_toggled(event,
                                                  request_bytes,
                                                  &SASEvent::PROFILE_HTTP,
-                                                 sas_compress_logs);
+                                                 _sas_compress_logs);
     }
     else
     {
@@ -1080,7 +1080,7 @@ void HttpClient::sas_log_http_req(SAS::TrailId trail,
       Utils::add_sas_param_compressed_if_toggled(event,
                                                  message_to_log,
                                                  &SASEvent::PROFILE_HTTP,
-                                                 sas_compress_logs);
+                                                 _sas_compress_logs);
     }
 
     event.add_var_param(method_str);
@@ -1113,7 +1113,7 @@ void HttpClient::sas_log_http_rsp(SAS::TrailId trail,
       Utils::add_sas_param_compressed_if_toggled(event,
                                                  response_bytes,
                                                  &SASEvent::PROFILE_HTTP,
-                                                 sas_compress_logs);
+                                                 _sas_compress_logs);
     }
     else
     {
@@ -1121,7 +1121,7 @@ void HttpClient::sas_log_http_rsp(SAS::TrailId trail,
       Utils::add_sas_param_compressed_if_toggled(event,
                                                  message_to_log,
                                                  &SASEvent::PROFILE_HTTP,
-                                                 sas_compress_logs);
+                                                 _sas_compress_logs);
     }
 
     event.add_var_param(method_str);

--- a/src/httpclient.cpp
+++ b/src/httpclient.cpp
@@ -44,7 +44,8 @@ HttpClient::HttpClient(bool assert_user,
                        bool remote_connection,
                        long timeout_ms,
                        bool log_display_address,
-                       std::string server_display_address) :
+                       std::string server_display_address,
+                       bool sas_compress_logs) :
   _assert_user(assert_user),
   _resolver(resolver),
   _load_monitor(load_monitor),
@@ -54,7 +55,8 @@ HttpClient::HttpClient(bool assert_user,
   _conn_pool(load_monitor, stat_table, remote_connection, timeout_ms),
   _should_omit_body(should_omit_body),
   _log_display_address(log_display_address),
-  _server_display_address(server_display_address)
+  _server_display_address(server_display_address),
+  _sas_compress_logs(sas_compress_logs)
 {
   pthread_key_create(&_uuid_thread_local, cleanup_uuid);
   pthread_mutex_init(&_lock, NULL);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -864,7 +864,7 @@ void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
   }
   else
   {
-    event.add_var_param(s, profile);
+    event.add_var_param(s);
   }
 }
 
@@ -880,7 +880,7 @@ void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
   }
   else
   {
-    event.add_var_param(len, s, profile);
+    event.add_var_param(len, s);
   }
 }
 
@@ -896,7 +896,7 @@ void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
   }
   else
   {
-    event.add_var_param(len, s, profile);
+    event.add_var_param(len, s);
   }
 }
 
@@ -911,7 +911,7 @@ void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
   }
   else
   {
-    event.add_var_param(s, profile);
+    event.add_var_param(s);
   }
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -855,8 +855,8 @@ void Utils::calculate_diameter_timeout(int target_latency_us,
 // is disabled in etc/clearwater/shared_config.
 void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
                                                 const std::string& s,
-                                                const SAS::Profile* profile = NULL,
-                                                bool sas_compress_logs = true)
+                                                const SAS::Profile* profile,
+                                                bool sas_compress_logs)
 {
   if (sas_compress_logs)
   {
@@ -871,8 +871,8 @@ void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
 void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
                                                 size_t len,
                                                 char* s,
-                                                const SAS::Profile* profile = NULL,
-                                                bool sas_compress_logs = true)
+                                                const SAS::Profile* profile,
+                                                bool sas_compress_logs)
 {
   if (sas_compress_logs)
   {
@@ -887,8 +887,8 @@ void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
 void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
                                                 size_t len,
                                                 uint8_t* s,
-                                                const SAS::Profile* profile = NULL,
-                                                bool sas_compress_logs = true)
+                                                const SAS::Profile* profile,
+                                                bool sas_compress_logs)
 {
   if (sas_compress_logs)
   {
@@ -902,8 +902,8 @@ void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
 
 void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
                                                 const char* s,
-                                                const SAS::Profile* profile = NULL,
-                                                bool sas_compress_logs = true)
+                                                const SAS::Profile* profile,
+                                                bool sas_compress_logs)
 {
   if (sas_compress_logs)
   {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -32,6 +32,7 @@
 
 #include "utils.h"
 #include "log.h"
+#include "sas.h"
 
 bool Utils::parse_http_url(
     const std::string& url,
@@ -854,7 +855,7 @@ void Utils::calculate_diameter_timeout(int target_latency_us,
 
 // Functions to add a var param to a SAS event, compressed or not, depending on whether compression
 // is disabled in etc/clearwater/shared_config.
-void Utils::add_sas_param_compressed_if_toggled(&SAS::Event event,
+void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
                                                 const std::string& s,
                                                 const Profile* profle = NULL,
                                                 bool sas_compress_logs = true)
@@ -869,7 +870,7 @@ void Utils::add_sas_param_compressed_if_toggled(&SAS::Event event,
   }
 }
 
-void Utils::add_sas_param_compressed_if_toggled(&SAS::Event event,
+void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
                                                 size_t len,
                                                 char* s,
                                                 const Profile* profle = NULL,
@@ -885,7 +886,7 @@ void Utils::add_sas_param_compressed_if_toggled(&SAS::Event event,
   }
 }
 
-void Utils::add_sas_param_compressed_if_toggled(&SAS::Event event,
+void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
                                                 size_t len,
                                                 uint8_t* s,
                                                 const Profile* profle = NULL,
@@ -901,7 +902,7 @@ void Utils::add_sas_param_compressed_if_toggled(&SAS::Event event,
   }
 }
 
-void Utils::add_sas_param_compressed_if_toggled(&SAS::Event event,
+void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
                                                 const char* s,
                                                 const Profile* profle = NULL,
                                                 bool sas_compress_logs = true)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -866,6 +866,7 @@ void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
   {
     event.add_var_param(s);
   }
+  event.add_static_param(sas_compress_logs);
 }
 
 void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
@@ -882,6 +883,7 @@ void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
   {
     event.add_var_param(len, s);
   }
+  event.add_static_param(sas_compress_logs);
 }
 
 void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
@@ -898,6 +900,7 @@ void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
   {
     event.add_var_param(len, s);
   }
+  event.add_static_param(sas_compress_logs);
 }
 
 void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
@@ -913,6 +916,7 @@ void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
   {
     event.add_var_param(s);
   }
+  event.add_static_param(sas_compress_logs);
 }
 
 // Check whether an element is in a vector

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -855,7 +855,7 @@ void Utils::calculate_diameter_timeout(int target_latency_us,
 // is disabled in etc/clearwater/shared_config.
 void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
                                                 const std::string& s,
-                                                const Profile* profle = NULL,
+                                                const SAS::Profile* profile = NULL,
                                                 bool sas_compress_logs = true)
 {
   if (sas_compress_logs)
@@ -871,7 +871,7 @@ void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
 void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
                                                 size_t len,
                                                 char* s,
-                                                const Profile* profle = NULL,
+                                                const SAS::Profile* profile = NULL,
                                                 bool sas_compress_logs = true)
 {
   if (sas_compress_logs)
@@ -887,7 +887,7 @@ void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
 void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
                                                 size_t len,
                                                 uint8_t* s,
-                                                const Profile* profle = NULL,
+                                                const SAS::Profile* profile = NULL,
                                                 bool sas_compress_logs = true)
 {
   if (sas_compress_logs)
@@ -902,7 +902,7 @@ void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
 
 void Utils::add_sas_param_compressed_if_toggled(SAS::Event& event,
                                                 const char* s,
-                                                const Profile* profle = NULL,
+                                                const SAS::Profile* profile = NULL,
                                                 bool sas_compress_logs = true)
 {
   if (sas_compress_logs)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -31,8 +31,6 @@
 #include <boost/regex.hpp>
 
 #include "utils.h"
-#include "log.h"
-#include "sas.h"
 
 bool Utils::parse_http_url(
     const std::string& url,

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -127,7 +127,7 @@ std::string Utils::url_unescape(const std::string& s)
   return r;
 }
 
-// The following function quotes strings in SIP headers as described by RFC 3261 
+// The following function quotes strings in SIP headers as described by RFC 3261
 // Section 25.1
 std::string Utils::quote_string(const std::string& s)
 {
@@ -852,6 +852,70 @@ void Utils::calculate_diameter_timeout(int target_latency_us,
   diameter_timeout_ms = std::ceil(target_latency_us/500);
 }
 
+// Functions to add a var param to a SAS event, compressed or not, depending on whether compression
+// is disabled in etc/clearwater/shared_config.
+void Utils::add_sas_param_compressed_if_toggled(&SAS::Event event,
+                                                const std::string& s,
+                                                const Profile* profle = NULL,
+                                                bool sas_compress_logs = true)
+{
+  if (sas_compress_logs)
+  {
+    event.add_compressed_param(s, profile);
+  }
+  else
+  {
+    event.add_var_param(s, profile);
+  }
+}
+
+void Utils::add_sas_param_compressed_if_toggled(&SAS::Event event,
+                                                size_t len,
+                                                char* s,
+                                                const Profile* profle = NULL,
+                                                bool sas_compress_logs = true)
+{
+  if (sas_compress_logs)
+  {
+    event.add_compressed_param(len, s, profile);
+  }
+  else
+  {
+    event.add_var_param(len, s, profile);
+  }
+}
+
+void Utils::add_sas_param_compressed_if_toggled(&SAS::Event event,
+                                                size_t len,
+                                                uint8_t* s,
+                                                const Profile* profle = NULL,
+                                                bool sas_compress_logs = true)
+{
+  if (sas_compress_logs)
+  {
+    event.add_compressed_param(len, s, profile);
+  }
+  else
+  {
+    event.add_var_param(len, s, profile);
+  }
+}
+
+void Utils::add_sas_param_compressed_if_toggled(&SAS::Event event,
+                                                const char* s,
+                                                const Profile* profle = NULL,
+                                                bool sas_compress_logs = true)
+{
+  if (sas_compress_logs)
+  {
+    event.add_compressed_param(s, profile);
+  }
+  else
+  {
+    event.add_var_param(s, profile);
+  }
+}
+
 // Check whether an element is in a vector
 bool Utils::in_vector(const std::string& element,
                const std::vector<std::string>& vec)
@@ -903,3 +967,5 @@ void Utils::IOHook::io_completes(const std::string& reason)
 }
 
 thread_local std::vector<Utils::IOHook*> Utils::IOHook::_hooks = {};
+
+


### PR DESCRIPTION
Kept separate to Jack's [branch ](https://github.com/Metaswitch/cpp-common/compare/optional_compression_httpstack) for now for ease of looking at changes. 

- Functions added to utils.h that pass on the args to either add_var_param or add_compressed_param based on a boolean read in from shared_config. 
- httpclient changed to have a boolean member for toggling sas compression. When httpclient is constructed this should be set to the value read in from sharred_config.  

