### PR TITLE
Add POST method which can take extra headers on the outbound request

### DIFF
--- a/include/httpclient.h
+++ b/include/httpclient.h
@@ -205,6 +205,7 @@ public:
   ///                           data
   /// @param response           Location to store retrieved data
   /// @param body               JSON body to send on the request
+  /// @param extra_req_headers  Extra headers to add to the request
   /// @param trail              SAS trail to use
   /// @param username           Username to assert if assertUser is true, else
   ///                           ignored
@@ -212,6 +213,14 @@ public:
   ///                           can take whitelisted, blacklisted, or all results
   ///
   /// @returns                  HTTP code representing outcome of request
+  virtual long send_post(const std::string& url,
+                         std::map<std::string, std::string>& headers,
+                         std::string& response,
+                         const std::string& body,
+                         const std::vector<std::string>& extra_req_headers,
+                         SAS::TrailId trail,
+                         const std::string& username,
+                         int allowed_host_state);
   virtual long send_post(const std::string& url,
                          std::map<std::string, std::string>& headers,
                          std::string& response,
@@ -228,6 +237,12 @@ public:
   virtual long send_post(const std::string& url,
                          std::map<std::string, std::string>& headers,
                          const std::string& body,
+                         SAS::TrailId trail,
+                         const std::string& username = "");
+  virtual long send_post(const std::string& url,
+                         std::map<std::string, std::string>& headers,
+                         const std::string& body,
+                         const std::vector<std::string>& extra_req_headers,
                          SAS::TrailId trail,
                          const std::string& username = "");
 

--- a/include/httpconnection.h
+++ b/include/httpconnection.h
@@ -228,6 +228,7 @@ public:
   ///                 data
   /// @param response Location to store retrieved data
   /// @param body     JSON body to send on the request
+  /// @param extra_req_headers  Extra headers to add to the request
   /// @param trail    SAS trail to use
   /// @param username Username to assert if assertUser is true, else
   ///                 ignored
@@ -239,10 +240,15 @@ public:
                          const std::string& body,
                          SAS::TrailId trail,
                          const std::string& username = "");
-
   virtual long send_post(const std::string& url_tail,
                          std::map<std::string, std::string>& headers,
                          const std::string& body,
+                         SAS::TrailId trail,
+                         const std::string& username = "");
+  virtual long send_post(const std::string& url_tail,
+                         std::map<std::string, std::string>& headers,
+                         const std::string& body,
+                         const std::vector<std::string>& extra_req_headers,
                          SAS::TrailId trail,
                          const std::string& username = "");
 

--- a/src/httpclient.cpp
+++ b/src/httpclient.cpp
@@ -287,6 +287,25 @@ HTTPCode HttpClient::send_post(const std::string& url,
 
 HTTPCode HttpClient::send_post(const std::string& url,
                                std::map<std::string, std::string>& headers,
+                               const std::string& body,
+                               const std::vector<std::string>& extra_req_headers,
+                               SAS::TrailId trail,
+                               const std::string& username)
+{
+  std::string unused_response;
+  int default_allowed_address_state = BaseResolver::ALL_LISTS;
+  return send_post(url,
+                   headers,
+                   unused_response,
+                   body,
+                   extra_req_headers,
+                   trail,
+                   username,
+                   default_allowed_address_state);
+}
+
+HTTPCode HttpClient::send_post(const std::string& url,
+                               std::map<std::string, std::string>& headers,
                                std::string& response,
                                const std::string& body,
                                SAS::TrailId trail,
@@ -312,13 +331,32 @@ HTTPCode HttpClient::send_post(const std::string& url,
                                int allowed_host_state)
 {
   std::vector<std::string> unused_extra_headers;
+  return send_post(url,
+                   headers,
+                   response,
+                   body,
+                   unused_extra_headers,
+                   trail,
+                   username,
+                   allowed_host_state);
+}
+
+HTTPCode HttpClient::send_post(const std::string& url,
+                               std::map<std::string, std::string>& headers,
+                               std::string& response,
+                               const std::string& body,
+                               const std::vector<std::string>& extra_req_headers,
+                               SAS::TrailId trail,
+                               const std::string& username,
+                               int allowed_host_state)
+{
   HTTPCode status = send_request(RequestType::POST,
                                  url,
                                  body,
                                  response,
                                  username,
                                  trail,
-                                 unused_extra_headers,
+                                 extra_req_headers,
                                  &headers,
                                  allowed_host_state);
   return status;

--- a/src/httpconnection.cpp
+++ b/src/httpconnection.cpp
@@ -130,6 +130,21 @@ HTTPCode HttpConnection::send_post(const std::string& url_tail,
 
 HTTPCode HttpConnection::send_post(const std::string& url_tail,
                                    std::map<std::string, std::string>& headers,
+                                   const std::string& body,
+                                   const std::vector<std::string>& extra_req_headers,
+                                   SAS::TrailId trail,
+                                   const std::string& username)
+{
+  return _client.send_post(_scheme + "://" + _server + url_tail,
+                           headers,
+                           body,
+                           extra_req_headers,
+                           trail,
+                           username);
+}
+
+HTTPCode HttpConnection::send_post(const std::string& url_tail,
+                                   std::map<std::string, std::string>& headers,
                                    std::string& response,
                                    const std::string& body,
                                    SAS::TrailId trail,


### PR DESCRIPTION
Required for Bifrost Twilio integration.  Added following the same pattern elsewhere in httpclient/httpconnection.