### PR TITLE
[Reviewer: CJR] CPP-Common - Disable Clientside SAS Compression

### DIFF
--- a/src/diameterstack.cpp
+++ b/src/diameterstack.cpp
@@ -971,7 +971,7 @@ void Stack::fd_sas_log_diameter_message(enum fd_hook_type type,
   }
 
   struct fd_cnx_rcvdata* data = (struct fd_cnx_rcvdata*)other;
-  event.add_compressed_param(data->length, data->buffer, &SASEvent::PROFILE_LZ4);
+  event.add_var_param(data->length, data->buffer);
 
   SAS::report_event(event);
 
@@ -1146,11 +1146,11 @@ void Transaction::on_timeout(void* data, DiamId_t to, size_t to_len, struct msg*
 
     if (fd_msg_bufferize(*req, &buf, &len) == 0)
     {
-      event.add_compressed_param(len, buf, &SASEvent::PROFILE_LZ4);
+      event.add_var_param(len, buf);
     }
     else
     {
-      event.add_compressed_param("unknown", &SASEvent::PROFILE_LZ4);
+      event.add_var_param("unknown");
     }
 
     SAS::report_event(event);

--- a/src/httpclient.cpp
+++ b/src/httpclient.cpp
@@ -1067,12 +1067,12 @@ void HttpClient::sas_log_http_req(SAS::TrailId trail,
 
     if (!_should_omit_body)
     {
-      event.add_compressed_param(request_bytes, &SASEvent::PROFILE_HTTP);
+      event.add_var_param(request_bytes);
     }
     else
     {
       std::string message_to_log = get_obscured_message_to_log(request_bytes);
-      event.add_compressed_param(message_to_log, &SASEvent::PROFILE_HTTP);
+      event.add_var_param(message_to_log);
     }
 
     event.add_var_param(method_str);
@@ -1102,12 +1102,12 @@ void HttpClient::sas_log_http_rsp(SAS::TrailId trail,
 
     if (!_should_omit_body)
     {
-      event.add_compressed_param(response_bytes, &SASEvent::PROFILE_HTTP);
+      event.add_var_param(response_bytes);
     }
     else
     {
       std::string message_to_log = get_obscured_message_to_log(response_bytes);
-      event.add_compressed_param(message_to_log, &SASEvent::PROFILE_HTTP);
+      event.add_var_param(message_to_log);
     }
 
     event.add_var_param(method_str);

--- a/src/httpstack.cpp
+++ b/src/httpstack.cpp
@@ -570,7 +570,7 @@ void HttpStack::SasLogger::log_req_event(SAS::TrailId trail,
 
   if (!omit_body)
   {
-    event.add_compressed_param(req.get_rx_message(), &SASEvent::PROFILE_HTTP);
+    event.add_var_param(req.get_rx_message());
   }
   else
   {
@@ -578,14 +578,13 @@ void HttpStack::SasLogger::log_req_event(SAS::TrailId trail,
     {
       // We are omitting the body but there wasn't one in the messaage. Just log
       // the headers.
-      event.add_compressed_param(req.get_rx_header(), &SASEvent::PROFILE_HTTP);
+      event.add_var_param(req.get_rx_header());
     }
     else
     {
       // There was a body that we need to omit. Add a fake body to the header
       // explaining that the body was intentionally not logged.
-      event.add_compressed_param(req.get_rx_header() + BODY_OMITTED,
-                                 &SASEvent::PROFILE_HTTP);
+      event.add_var_param(req.get_rx_header() + BODY_OMITTED);
     }
   }
 
@@ -610,7 +609,7 @@ void HttpStack::SasLogger::log_rsp_event(SAS::TrailId trail,
 
   if (!omit_body)
   {
-    event.add_compressed_param(req.get_tx_message(rc), &SASEvent::PROFILE_HTTP);
+    event.add_var_param(req.get_tx_message(rc));
   }
   else
   {
@@ -618,14 +617,13 @@ void HttpStack::SasLogger::log_rsp_event(SAS::TrailId trail,
     {
       // We are omitting the body but there wasn't one in the messaage. Just log
       // the headers.
-      event.add_compressed_param(req.get_tx_header(rc), &SASEvent::PROFILE_HTTP);
+      event.add_var_param(req.get_tx_header(rc));
     }
     else
     {
       // There was a body that we need to omit. Add a fake body to the header
       // explaining that the body was intentionally not logged.
-      event.add_compressed_param(req.get_tx_header(rc) + BODY_OMITTED,
-                                 &SASEvent::PROFILE_HTTP);
+      event.add_var_param(req.get_tx_header(rc) + BODY_OMITTED);
     }
   }
 


### PR DESCRIPTION
Changed all instances of `add_compressed_param` to `add_var_param`