### PR TITLE
[Reviewer: AJH] Allow format parameter for SAS logging of memcached requests

### DIFF
--- a/include/localstore.h
+++ b/include/localstore.h
@@ -32,7 +32,6 @@ public:
 
   using Store::get_data;
   using Store::set_data;
-  using Store::Format;
 
   Store::Status get_data(const std::string& table,
                          const std::string& key,
@@ -40,7 +39,7 @@ public:
                          uint64_t& cas,
                          SAS::TrailId trail,
                          bool log_body,
-                         Format data_format=Format::HEX) override;
+                         Store::Format data_format=Store::Format::HEX) override;
 
   Store::Status set_data(const std::string& table,
                          const std::string& key,
@@ -48,14 +47,16 @@ public:
                          uint64_t cas,
                          int expiry,
                          SAS::TrailId trail,
-                         bool log_body) override;
+                         bool log_body,
+                         Store::Format data_format=Store::Format::HEX) override;
 
   Store::Status set_data_without_cas(const std::string& table,
                                      const std::string& key,
                                      const std::string& data,
                                      int expiry,
                                      SAS::TrailId trail,
-                                     bool log_body) override;
+                                     bool log_body,
+                                     Store::Format data_format=Store::Format::HEX) override;
 
   Store::Status delete_data(const std::string& table,
                             const std::string& key,

--- a/include/localstore.h
+++ b/include/localstore.h
@@ -32,13 +32,15 @@ public:
 
   using Store::get_data;
   using Store::set_data;
+  using Store::Format;
 
   Store::Status get_data(const std::string& table,
                          const std::string& key,
                          std::string& data,
                          uint64_t& cas,
                          SAS::TrailId trail,
-                         bool log_body) override;
+                         bool log_body,
+                         Format data_format=Format::HEX) override;
 
   Store::Status set_data(const std::string& table,
                          const std::string& key,

--- a/include/memcachedstore.h
+++ b/include/memcachedstore.h
@@ -126,6 +126,7 @@ public:
 
   using Store::get_data;
   using Store::set_data;
+  using Store::Format;
 
   /// Gets the data for the specified table and key.
   Store::Status get_data(const std::string& table,
@@ -133,7 +134,8 @@ public:
                          std::string& data,
                          uint64_t& cas,
                          SAS::TrailId trail,
-                         bool log_body);
+                         bool log_body,
+                         Format data_format=Format::HEX);
 
   /// Sets the data for the specified table and key.
   Store::Status set_data(const std::string& table,

--- a/include/memcachedstore.h
+++ b/include/memcachedstore.h
@@ -126,7 +126,6 @@ public:
 
   using Store::get_data;
   using Store::set_data;
-  using Store::Format;
 
   /// Gets the data for the specified table and key.
   Store::Status get_data(const std::string& table,
@@ -135,7 +134,7 @@ public:
                          uint64_t& cas,
                          SAS::TrailId trail,
                          bool log_body,
-                         Format data_format=Format::HEX);
+                         Store::Format data_format=Store::Format::HEX);
 
   /// Sets the data for the specified table and key.
   Store::Status set_data(const std::string& table,
@@ -144,7 +143,8 @@ public:
                          uint64_t cas,
                          int expiry,
                          SAS::TrailId trail,
-                         bool log_body);
+                         bool log_body,
+                         Store::Format data_format=Store::Format::HEX);
 
   /// Sets the data for the specified table and key without performing CAS
   Store::Status set_data_without_cas(const std::string& table,
@@ -152,7 +152,8 @@ public:
                                      const std::string& data,
                                      int expiry,
                                      SAS::TrailId,
-                                     bool log_body);
+                                     bool log_body,
+                                     Store::Format data_format=Store::Format::HEX);
 
   /// Deletes the data for the specified table and key.
   Store::Status delete_data(const std::string& table,

--- a/include/store.h
+++ b/include/store.h
@@ -97,9 +97,10 @@ public:
                                  const std::string& data,
                                  uint64_t cas,
                                  int expiry,
-                                 SAS::TrailId trail = 0)
+                                 SAS::TrailId trail = 0,
+                                 Format data_format = Format::HEX)
   {
-    return set_data(table, key, data, cas, expiry, trail, true);
+    return set_data(table, key, data, cas, expiry, trail, true, data_format);
   }
 
   /// Sets the data for the specified key in the specified namespace.
@@ -121,7 +122,8 @@ public:
                           uint64_t cas,
                           int expiry,
                           SAS::TrailId trail,
-                          bool log_body) = 0;
+                          bool log_body,
+                          Format data_format = Format::HEX) = 0;
 
   /// Sets the data for the specified key in the specified namespace, without
   /// performing a Compare And Swap (CAS) check.
@@ -139,7 +141,8 @@ public:
                                       const std::string& data,
                                       int expiry,
                                       SAS::TrailId trail,
-                                      bool log_body) = 0;
+                                      bool log_body,
+                                      Format data_format = Format::HEX) = 0;
 
   /// Delete the data for the specified key in the specified namespace.
   ///

--- a/include/store.h
+++ b/include/store.h
@@ -38,38 +38,47 @@ public:
   /// do so would open us up to DoS attacks.
   static const uint32_t MAX_DATA_LENGTH=1024*64;
 
+  /// Format for logging data
+  /// These values are passed to SAS for it to decide how to display the data.
+  /// -  If you change the enum you must also update the resource bundle.
+  typedef enum {HEX=1, JSON=2} Format;
+
   /// Gets the data for the specified key in the specified namespace.
   ///
-  /// @return         Status value indicating the result of the read.
-  /// @param table    Name of the table to retrive the data.
-  /// @param key      Key of the data record to retrieve.
-  /// @param data     String to return the data.
-  /// @param cas      Variable to return the CAS value of the data.
-  /// @param trail    SAS Trail on which to log the data
+  /// @return            Status value indicating the result of the read.
+  /// @param table       Name of the table to retrive the data.
+  /// @param key         Key of the data record to retrieve.
+  /// @param data        String to return the data.
+  /// @param cas         Variable to return the CAS value of the data.
+  /// @param trail       SAS Trail on which to log the data
+  /// @param data_format Data format for logging purposes (optional)
   virtual Store::Status get_data(const std::string& table,
                                  const std::string& key,
                                  std::string& data,
                                  uint64_t& cas,
-                                 SAS::TrailId trail = 0)
+                                 SAS::TrailId trail = 0,
+                                 Format data_format=Format::HEX)
   {
-    return get_data(table, key, data, cas, trail, true);
+    return get_data(table, key, data, cas, trail, true, data_format);
   }
 
   /// Gets the data for the specified key in the specified namespace.
   ///
-  /// @return         Status value indicating the result of the read.
-  /// @param table    Name of the table to retrive the data.
-  /// @param key      Key of the data record to retrieve.
-  /// @param data     String to return the data.
-  /// @param cas      Variable to return the CAS value of the data.
-  /// @param trail    SAS Trail on which to log the data
-  /// @param log_body Should we log the body to SAS?
+  /// @return            Status value indicating the result of the read.
+  /// @param table       Name of the table to retrive the data.
+  /// @param key         Key of the data record to retrieve.
+  /// @param data        String to return the data.
+  /// @param cas         Variable to return the CAS value of the data.
+  /// @param trail       SAS Trail on which to log the data
+  /// @param log_body    Should we log the body to SAS?
+  /// @param data_format Data format for logging purposes (optional)
   virtual Status get_data(const std::string& table,
                           const std::string& key,
                           std::string& data,
                           uint64_t& cas,
                           SAS::TrailId trail,
-                          bool log_body) = 0;
+                          bool log_body,
+                          Format data_format=Format::HEX) = 0;
 
   /// Sets the data for the specified key in the specified namespace.
   ///

--- a/src/localstore.cpp
+++ b/src/localstore.cpp
@@ -157,7 +157,8 @@ Store::Status LocalStore::set_data_without_cas(const std::string& table,
                                                const std::string& data,
                                                int expiry,
                                                SAS::TrailId trail,
-                                               bool log_body)
+                                               bool log_body,
+                                               Store::Format data_format)
 {
   TRC_DEBUG("set_data_without_cas table=%s key=%s expiry=%d",
             table.c_str(), key.c_str(), expiry);
@@ -171,7 +172,8 @@ Store::Status LocalStore::set_data(const std::string& table,
                                    uint64_t cas,
                                    int expiry,
                                    SAS::TrailId trail,
-                                   bool log_body)
+                                   bool log_body,
+                                   Store::Format data_format)
 {
   TRC_DEBUG("set_data table=%s key=%s CAS=%ld expiry=%d",
             table.c_str(), key.c_str(), cas, expiry);

--- a/src/localstore.cpp
+++ b/src/localstore.cpp
@@ -88,7 +88,8 @@ Store::Status LocalStore::get_data(const std::string& table,
                                    std::string& data,
                                    uint64_t& cas,
                                    SAS::TrailId trail,
-                                   bool log_body)
+                                   bool log_body,
+                                   Format data_format)
 {
   TRC_DEBUG("get_data table=%s key=%s", table.c_str(), key.c_str());
   Store::Status status = Store::Status::NOT_FOUND;

--- a/src/memcachedstore.cpp
+++ b/src/memcachedstore.cpp
@@ -462,7 +462,8 @@ Store::Status TopologyNeutralMemcachedStore::set_data(const std::string& table,
                                                       uint64_t cas,
                                                       int expiry,
                                                       SAS::TrailId trail,
-                                                      bool log_body)
+                                                      bool log_body,
+                                                      Store::Format data_format)
 {
   TRC_DEBUG("Writing %d bytes to table %s key %s, CAS = %ld, expiry = %d",
             data.length(), table.c_str(), key.c_str(), cas, expiry);
@@ -515,6 +516,12 @@ Store::Status TopologyNeutralMemcachedStore::set_data(const std::string& table,
 
     start.add_static_param(cas);
     start.add_static_param(expiry);
+
+    if (log_body)
+    {
+      start.add_static_param(data_format);
+    }
+  
     SAS::report_event(start);
   }
 
@@ -571,7 +578,8 @@ Store::Status TopologyNeutralMemcachedStore::set_data_without_cas(const std::str
                                                                   const std::string& data,
                                                                   int expiry,
                                                                   SAS::TrailId trail,
-                                                                  bool log_body)
+                                                                  bool log_body,
+                                                                  Store::Format data_format)
 {
   TRC_DEBUG("Writing %d bytes to table %s key %s, expiry = %d",
             data.length(), table.c_str(), key.c_str(), expiry);
@@ -600,6 +608,12 @@ Store::Status TopologyNeutralMemcachedStore::set_data_without_cas(const std::str
     }
 
     start.add_static_param(expiry);
+
+    if (log_body)
+    {
+      start.add_static_param(data_format);
+    }
+
     SAS::report_event(start);
   }
 

--- a/src/memcachedstore.cpp
+++ b/src/memcachedstore.cpp
@@ -317,7 +317,8 @@ Store::Status TopologyNeutralMemcachedStore::get_data(const std::string& table,
                                                       std::string& data,
                                                       uint64_t& cas,
                                                       SAS::TrailId trail,
-                                                      bool log_body)
+                                                      bool log_body,
+                                                      Format data_format)
 {
   Store::Status status;
   std::vector<AddrInfo> targets;
@@ -379,6 +380,12 @@ Store::Status TopologyNeutralMemcachedStore::get_data(const std::string& table,
         }
 
         got_data.add_static_param(cas);
+
+        if (log_body)
+        {
+          got_data.add_static_param(data_format);
+        }
+     
         SAS::report_event(got_data);
       }
 

--- a/src/memcachedstore.cpp
+++ b/src/memcachedstore.cpp
@@ -373,16 +373,11 @@ Store::Status TopologyNeutralMemcachedStore::get_data(const std::string& table,
 
         SAS::Event got_data(trail, event, 0);
         got_data.add_var_param(fqkey);
-
-        if (log_body)
-        {
-          got_data.add_var_param(data);
-        }
-
         got_data.add_static_param(cas);
 
         if (log_body)
         {
+          got_data.add_var_param(data);
           got_data.add_static_param(data_format);
         }
      
@@ -506,19 +501,14 @@ Store::Status TopologyNeutralMemcachedStore::set_data(const std::string& table,
 
     SAS::Event start(trail, event, 0);
     start.add_var_param(fqkey);
+    start.add_static_param(cas);
+    start.add_static_param(expiry);
 
     if (log_body)
     {
       // Note that we do this _after_ policing the maximum length which means
       // that data is less than the maximum 64k supported by SAS.
       start.add_var_param(data);
-    }
-
-    start.add_static_param(cas);
-    start.add_static_param(expiry);
-
-    if (log_body)
-    {
       start.add_static_param(data_format);
     }
   
@@ -601,16 +591,11 @@ Store::Status TopologyNeutralMemcachedStore::set_data_without_cas(const std::str
 
     SAS::Event start(trail, event, 0);
     start.add_var_param(fqkey);
-
-    if (log_body)
-    {
-      start.add_var_param(data);
-    }
-
     start.add_static_param(expiry);
 
     if (log_body)
     {
+      start.add_var_param(data);
       start.add_static_param(data_format);
     }
 

--- a/test_utils/mock_store.h
+++ b/test_utils/mock_store.h
@@ -32,7 +32,20 @@ public:
                                 std::string& data,
                                 uint64_t& cas,
                                 SAS::TrailId trail,
+                                Format data_format));
+  MOCK_METHOD6(get_data, Status(const std::string& table,
+                                const std::string& key,
+                                std::string& data,
+                                uint64_t& cas,
+                                SAS::TrailId trail,
                                 bool log_body));
+  MOCK_METHOD7(get_data, Status(const std::string& table,
+                                const std::string& key,
+                                std::string& data,
+                                uint64_t& cas,
+                                SAS::TrailId trail,
+                                bool log_body,
+                                Format data_format));
   MOCK_METHOD6(set_data, Status(const std::string& table,
                                 const std::string& key,
                                 const std::string& data,
@@ -45,7 +58,22 @@ public:
                                 uint64_t cas,
                                 int expiry,
                                 SAS::TrailId trail,
+                                Format data_format));
+  MOCK_METHOD7(set_data, Status(const std::string& table,
+                                const std::string& key,
+                                const std::string& data,
+                                uint64_t cas,
+                                int expiry,
+                                SAS::TrailId trail,
                                 bool log_body));
+  MOCK_METHOD8(set_data, Status(const std::string& table,
+                                const std::string& key,
+                                const std::string& data,
+                                uint64_t cas,
+                                int expiry,
+                                SAS::TrailId trail,
+                                bool log_body,
+                                Format data_format));
   MOCK_METHOD6(set_data_without_cas,
                Status(const std::string& table,
                       const std::string& key,
@@ -53,6 +81,14 @@ public:
                       int expiry,
                       SAS::TrailId trail,
                       bool log_body));
+  MOCK_METHOD7(set_data_without_cas,
+               Status(const std::string& table,
+                      const std::string& key,
+                      const std::string& data,
+                      int expiry,
+                      SAS::TrailId trail,
+                      bool log_body,
+                      Format data_format));
   MOCK_METHOD3(delete_data, Status(const std::string& table,
                                    const std::string& key,
                                    SAS::TrailId trail));


### PR DESCRIPTION
Add parameter to allow caller to specify the format of data being added/retrieved from memcached for use when logging to SAS.