### PR TITLE
[Reviewer: Richard] DnsCachedResolver should respect TTL on SOA records when we get NXDOMAIN

### DIFF
--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -839,7 +839,7 @@ void DnsCachedResolver::dns_response(const std::string& domain,
     {
       // NXDOMAIN, indicating that the DNS entry has been definitively removed
       // (rather than a DNS server failure). Clear the cache for this
-      // entry.
+      // entry and if there's a TTL on the SOA, use that.
       if (trail != 0)
       {
         SAS::Event event(trail, SASEvent::DNS_NOT_FOUND, 0);
@@ -849,6 +849,24 @@ void DnsCachedResolver::dns_response(const std::string& domain,
       }
 
       clear_cache_entry(ce);
+
+      DnsParser parser(abuf, alen);
+      if (parser.parse())
+      {
+        while (!parser.authorities().empty())
+        {
+          DnsRRecord* rr = parser.authorities().front();
+          parser.authorities().pop_front();
+
+          if (rr->rrtype() == ns_t_soa)
+          {
+            // Clamp the expiry time to be no more than the default TTL from now
+            int max_expires = DEFAULT_NEGATIVE_CACHE_TTL + time(NULL);
+            ce->expires = std::min(rr->expires(), max_expires);
+            break;
+          }
+        }
+      }
     }
     else
     {
@@ -1198,7 +1216,7 @@ void DnsCachedResolver::DnsTsx::ares_callback(int status, int timeouts, unsigned
     event.add_var_param(_domain);
     SAS::report_event(event);
   }
-  
+
   _channel->resolver->dns_response(_domain, _dnstype, status, abuf, alen, _trail);
   --_channel->pending_queries;
   delete this;


### PR DESCRIPTION
See https://github.com/Metaswitch/clearwater-issues/issues/2906

Previously, we would get an SOA record with an NXDOMAIN response, but ignore the TTL and just set it to our default (300s) in the cache.

This changes that behaviour to check for an SOA and use the TTL from that if we have one. It's clamped to 300s so that we'll retry after 5 mins, like we used to, but this means we can retry faster if we should be doing so.

I've live tested:
* lookups that return NXDOMAIN and an SOA get the correct TTL in the cache
* this doesn't affect other errors from the DNS server (tested by misconfiguring the signaling dns server in config, and verifying that we don't go down this code path and we get the default expiry time)