### PR TITLE
[Reviewer: RND] Enhance DNS diagnostics

### DIFF
--- a/include/dnscachedresolver.h
+++ b/include/dnscachedresolver.h
@@ -122,6 +122,8 @@ private:
     std::string domain;
     int dnstype;
     int expires;
+    std::string original_time;
+    SAS::TrailId original_trail;
     std::vector<DnsRRecord*> records;
   };
 
@@ -172,7 +174,7 @@ private:
   DnsCacheEntryPtr create_cache_entry(const std::string& domain, int dnstype);
   void add_to_expiry_list(DnsCacheEntryPtr ce);
   void expire_cache();
-  void add_record_to_cache(DnsCacheEntryPtr ce, DnsRRecord* rr);
+  void add_record_to_cache(DnsCacheEntryPtr ce, DnsRRecord* rr, SAS::TrailId trail);
   void clear_cache_entry(DnsCacheEntryPtr ce);
 
 

--- a/include/dnscachedresolver.h
+++ b/include/dnscachedresolver.h
@@ -125,6 +125,24 @@ private:
     std::string original_time;
     SAS::TrailId original_trail;
     std::vector<DnsRRecord*> records;
+
+    void update_timestamp() {
+      struct timespec timespec;
+      struct tm dt;
+      char timestamp[100];
+      clock_gettime(CLOCK_REALTIME, &timespec);
+      gmtime_r(&timespec.tv_sec, &dt);
+      snprintf(timestamp, 100,
+               "%2.2d:%2.2d:%2.2d.%3.3d UTC",
+               dt.tm_hour,
+               dt.tm_min,
+               dt.tm_sec,
+               (int)(timespec.tv_nsec / 1000000));
+
+      this->original_time = timestamp;
+
+
+    }
   };
 
   class DnsCacheKeyCompare
@@ -171,7 +189,7 @@ private:
   bool caching_enabled(int rrtype);
 
   DnsCacheEntryPtr get_cache_entry(const std::string& domain, int dnstype);
-  DnsCacheEntryPtr create_cache_entry(const std::string& domain, int dnstype);
+  DnsCacheEntryPtr create_cache_entry(const std::string& domain, int dnstype, SAS::TrailId trail);
   void add_to_expiry_list(DnsCacheEntryPtr ce);
   void expire_cache();
   void add_record_to_cache(DnsCacheEntryPtr ce, DnsRRecord* rr, SAS::TrailId trail);

--- a/include/sasevent.h
+++ b/include/sasevent.h
@@ -22,7 +22,7 @@ namespace SASEvent {
   // Jenkins job "update-sas-resources".
   //
   // !!!DO NOT EDIT THE FOLLOWING LINE MANUALLY!!!
-  const std::string CURRENT_RESOURCE_BUNDLE_DATESTAMP = "20180111";
+  const std::string CURRENT_RESOURCE_BUNDLE_DATESTAMP = "20180116-applescrumble";
   const std::string RESOURCE_BUNDLE_NAME = "org.projectclearwater";
   const std::string CURRENT_RESOURCE_BUNDLE =
                  RESOURCE_BUNDLE_NAME + "." + CURRENT_RESOURCE_BUNDLE_DATESTAMP;
@@ -149,6 +149,7 @@ namespace SASEvent {
   const int BASERESOLVE_NO_ALLOWED_RECORDS = COMMON_BASE + 0x000208;
   const int BASERESOLVE_IP_ALLOWED = COMMON_BASE + 0x000209;
   const int BASERESOLVE_IP_NOT_ALLOWED = COMMON_BASE + 0x00020A;
+  const int DNS_CACHE_USED = COMMON_BASE + 0x00020B;
 
   const int CASS_CONNECT_FAIL = COMMON_BASE + 0x0300;
   const int CASS_TIMEOUT = COMMON_BASE + 0x0301;

--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -605,7 +605,9 @@ void DnsCachedResolver::inner_dns_query(const std::vector<std::string>& domains,
   }
 }
 
-/// Adds or updates an entry in the cache.
+/// Adds or updates an entry in the cache. This function is only used in unit
+/// tests, to insert entries into the cache so we aren't using a real DNS
+/// lookup.
 void DnsCachedResolver::add_to_cache(const std::string& domain,
                                      int dnstype,
                                      std::vector<DnsRRecord*>& records)
@@ -632,6 +634,7 @@ void DnsCachedResolver::add_to_cache(const std::string& domain,
   // Copy all the records across to the cache entry.
   for (size_t ii = 0; ii < records.size(); ++ii)
   {
+    // We don't have a trail ID available as this is test code - use trail ID 0.
     add_record_to_cache(ce, records[ii], 0);
   }
 
@@ -1252,13 +1255,13 @@ void DnsCachedResolver::DnsTsx::ares_callback(int status, int timeouts, unsigned
 {
   if (timeouts > 0)
   {
+    TRC_ERROR("Resolution of %s timed out", _domain.c_str());
     SAS::Event event(_trail, SASEvent::DNS_TIMEOUT, 0);
     event.add_static_param(_dnstype);
     event.add_static_param(timeouts);
     event.add_var_param(_domain);
     SAS::report_event(event);
   }
-  TRC_ERROR("Resolution of %s timed out", _domain.c_str());
 
   _channel->resolver->dns_response(_domain, _dnstype, status, abuf, alen, _trail);
   --_channel->pending_queries;


### PR DESCRIPTION
I'm not going to merge these into master yet, but I've already merged these into sprout's apple_scrumble branch and pushed.

These changes:

* enhance the SAS logs to note when a record was pulled from the DNS cache, and what time and trail ID to use to look for the original query
* add engineering logs (i.e. in /var/log/$COMPONENT/) when:
    * we make a DNS query (i.e. actually out on the network, not the local cache)
    * we get a DNS timeout
    * we get a DNS response
    * we successfully parse it

This compiles; I've not, yet, tested live.