### PR TITLE
[Reviewer: Alex] Fix clearwater fv test

### DIFF
--- a/src/snmp_agent.cpp
+++ b/src/snmp_agent.cpp
@@ -95,6 +95,7 @@ void Agent::start(void)
 void Agent::stop(void)
 {
   pthread_cancel(_thread);
+  pthread_join(_thread, NULL);
 
   pthread_mutex_lock(&_netsnmp_lock);
   snmp_shutdown(_name.c_str());


### PR DESCRIPTION
Alex,

Please can you review this fix to clearwater-fv-test (and any other SNMPTest-using suites)?  As discussed, I've migrated to use `SNMP::Agent`.

Thanks,

Matt