### PR TITLE
adding a lock to the IPCountTable

### DIFF
--- a/include/snmp_ip_count_table.h
+++ b/include/snmp_ip_count_table.h
@@ -70,6 +70,7 @@ public:
   virtual void remove(std::string key) = 0;
 protected:
   IPCountTable() {};
+  pthread_mutex_t _map_lock = PTHREAD_MUTEX_INITIALIZER;
 };
 
 }

--- a/src/snmp_ip_count_table.cpp
+++ b/src/snmp_ip_count_table.cpp
@@ -70,7 +70,6 @@ public:
     }
   }
 
-  // IPCountRow* get(std::string key) { return ManagedTable<IPCountRow, std::string>::get(key); };
   IPCountRow* get(std::string key)
   {
     pthread_mutex_lock(&_map_lock);
@@ -78,21 +77,20 @@ public:
     pthread_mutex_unlock(&_map_lock);
     return ret;
   };
-  // void add(std::string key) { ManagedTable<IPCountRow, std::string>::add(key); };
+
   void add(std::string key)
   {
     pthread_mutex_lock(&_map_lock);
     ManagedTable<IPCountRow, std::string>::add(key);
     pthread_mutex_unlock(&_map_lock);
   };
-  // void remove(std::string key) { ManagedTable<IPCountRow, std::string>::remove(key); };
+
   void remove(std::string key)
   {
     pthread_mutex_lock(&_map_lock);
     ManagedTable<IPCountRow, std::string>::remove(key);
     pthread_mutex_unlock(&_map_lock);
   };
-
 
 };
 

--- a/src/snmp_ip_count_table.cpp
+++ b/src/snmp_ip_count_table.cpp
@@ -70,14 +70,35 @@ public:
     }
   }
 
-  IPCountRow* get(std::string key) { return ManagedTable<IPCountRow, std::string>::get(key); };
-  void add(std::string key) { ManagedTable<IPCountRow, std::string>::add(key); };
-  void remove(std::string key) { ManagedTable<IPCountRow, std::string>::remove(key); };
+  // IPCountRow* get(std::string key) { return ManagedTable<IPCountRow, std::string>::get(key); };
+  IPCountRow* get(std::string key)
+  {
+    pthread_mutex_lock(&_map_lock);
+    IPCountRow* ret = ManagedTable<IPCountRow, std::string>::get(key);
+    pthread_mutex_unlock(&_map_lock);
+    return ret
+  };
+  // void add(std::string key) { ManagedTable<IPCountRow, std::string>::add(key); };
+  void add(std::string key)
+  {
+    pthread_mutex_lock(&_map_lock);
+    ManagedTable<IPCountRow, std::string>::add(key);
+    pthread_mutex_unlock(&_map_lock);
+  };
+  // void remove(std::string key) { ManagedTable<IPCountRow, std::string>::remove(key); };
+  void remove(std::string key)
+  {
+    pthread_mutex_lock(&_map_lock);
+    ManagedTable<IPCountRow, std::string>::remove(key);
+    pthread_mutex_unlock(&_map_lock);
+  };
+
+
 };
 
 IPCountTable* IPCountTable::create(std::string name, std::string oid)
 {
   return new IPCountTableImpl(name, oid);
 }
-
+  pthread_mutex_t _map_lock = PTHREAD_MUTEX_INITIALIZER;
 }

--- a/src/snmp_ip_count_table.cpp
+++ b/src/snmp_ip_count_table.cpp
@@ -100,5 +100,5 @@ IPCountTable* IPCountTable::create(std::string name, std::string oid)
 {
   return new IPCountTableImpl(name, oid);
 }
-  pthread_mutex_t _map_lock = PTHREAD_MUTEX_INITIALIZER;
+
 }

--- a/src/snmp_ip_count_table.cpp
+++ b/src/snmp_ip_count_table.cpp
@@ -76,7 +76,7 @@ public:
     pthread_mutex_lock(&_map_lock);
     IPCountRow* ret = ManagedTable<IPCountRow, std::string>::get(key);
     pthread_mutex_unlock(&_map_lock);
-    return ret
+    return ret;
   };
   // void add(std::string key) { ManagedTable<IPCountRow, std::string>::add(key); };
   void add(std::string key)


### PR DESCRIPTION
This adds a lock so only one thread can access the IPCountTable at a time.
I've run this through fv-test (SNMPTest.*) branch snmp_threading and it passes all tests. 
(Hit memory leak though:
```
Error: some memory errors have been detected
InvalidRead
InvalidRead
InvalidRead
InvalidRead
InvalidWrite
InvalidWrite
```
)