### PR TITLE
Specify source address for HTTP and Memcached clients

### DIFF
--- a/include/http_connection_pool.h
+++ b/include/http_connection_pool.h
@@ -52,7 +52,8 @@ public:
   HttpConnectionPool(LoadMonitor* load_monitor,
                      SNMP::IPCountTable* stat_table,
                      bool remote_connection = false,
-                     long timeout_ms = -1);
+                     long timeout_ms = -1,
+                     const std::string& source_address = "");
 
   ~HttpConnectionPool()
   {
@@ -84,5 +85,23 @@ protected:
   // Determines an appropriate absolute HTTP request timeout in ms given the
   // target latency for requests that the downstream components will be using
   long calc_req_timeout_from_latency(int latency_us);
+
+  // Callbacks that are uses when the user has specified that connections be
+  // made from a specific source address.
+  //
+  // cURL allows the user to specify a callback that is called when cURL needs a
+  // socket to connect with. If a source address is specified, we implement this
+  // callback , and provide a socket that is bound to the specified address.
+  //
+  // `open_socket_fn` is the static method that is passed to cURL. `open_socket`
+  // is a member method that actually does the work.
+  static curl_socket_t open_socket_fn(void *clientp,
+                                      curlsocktype purpose,
+                                      struct curl_sockaddr *address);
+
+  curl_socket_t open_socket(curlsocktype purpose,
+                            struct curl_sockaddr *address);
+
+  std::string _source_address;
 };
 #endif

--- a/include/httpclient.h
+++ b/include/httpclient.h
@@ -70,7 +70,8 @@ public:
              bool remote_connection = false,
              long timeout_ms = -1,
              bool log_display_address = false,
-             std::string server_display_address = "");
+             std::string server_display_address = "",
+             const std::string& source_address = "");
 
   HttpClient(bool assert_user,
              HttpResolver* resolver,

--- a/include/httpconnection.h
+++ b/include/httpconnection.h
@@ -40,7 +40,8 @@ public:
                  bool remote_connection = false,
                  long timeout_ms = -1,
                  bool log_display_address = false,
-                 std::string server_display_address = "") :
+                 std::string server_display_address = "",
+                 const std::string& source_address = "") :
     _scheme(scheme),
     _server(server),
     _client(assert_user,
@@ -53,7 +54,8 @@ public:
             remote_connection,
             timeout_ms,
             log_display_address,
-            server_display_address)
+            server_display_address,
+            source_address)
   {
     TRC_STATUS("Configuring HTTP Connection");
     TRC_STATUS("  Connection created for server %s", _server.c_str());

--- a/include/memcachedstore.h
+++ b/include/memcachedstore.h
@@ -120,7 +120,8 @@ public:
   TopologyNeutralMemcachedStore(const std::string& target_domain,
                                 AstaireResolver* resolver,
                                 bool remote_store,
-                                BaseCommunicationMonitor* comm_monitor = NULL);
+                                BaseCommunicationMonitor* comm_monitor = NULL,
+                                const std::string& source_address = "");
 
   ~TopologyNeutralMemcachedStore() {}
 

--- a/include/memcachedstore.h
+++ b/include/memcachedstore.h
@@ -73,7 +73,8 @@ protected:
   // instantiated directly.
   BaseMemcachedStore(bool binary,
                      bool remote_store,
-                     BaseCommunicationMonitor* comm_monitor);
+                     BaseCommunicationMonitor* comm_monitor,
+                     const std::string& source_address = "");
 
   // Perform a get request to a single replica.
   memcached_return_t get_from_replica(memcached_st* replica,

--- a/src/http_connection_pool.cpp
+++ b/src/http_connection_pool.cpp
@@ -16,11 +16,13 @@
 HttpConnectionPool::HttpConnectionPool(LoadMonitor* load_monitor,
                                        SNMP::IPCountTable* stat_table,
                                        bool remote_connection,
-                                       long timeout_ms) :
+                                       long timeout_ms,
+                                       const std::string& source_address) :
   ConnectionPool<CURL*>(MAX_IDLE_TIME_S),
   _stat_table(stat_table),
   _connection_timeout_ms(remote_connection ? REMOTE_CONNECTION_LATENCY_MS :
-                                             LOCAL_CONNECTION_LATENCY_MS)
+                                             LOCAL_CONNECTION_LATENCY_MS),
+  _source_address(source_address)
 {
   if (timeout_ms != -1)
   {
@@ -77,6 +79,14 @@ CURL* HttpConnectionPool::create_connection(AddrInfo target)
                    HttpClient::Recorder::debug_callback);
 
   curl_easy_setopt(conn, CURLOPT_VERBOSE, 1L);
+
+  // If we've been asked to connect from a specific address, get cURL to ask us
+  // when starting up a new socket.
+  if (!_source_address.empty())
+  {
+    curl_easy_setopt(conn, CURLOPT_OPENSOCKETFUNCTION, &HttpConnectionPool::open_socket_fn);
+    curl_easy_setopt(conn, CURLOPT_OPENSOCKETDATA, this);
+  }
 
   increment_statistic(target, conn);
 
@@ -158,4 +168,66 @@ void HttpConnectionPool::release_connection(ConnectionInfo<CURL*>* conn_info,
 long HttpConnectionPool::calc_req_timeout_from_latency(int latency_us)
 {
   return _connection_timeout_ms + std::max(1, (latency_us * TIMEOUT_LATENCY_MULTIPLIER) / 1000);
+}
+
+curl_socket_t HttpConnectionPool::open_socket_fn(void *clientp,
+                                                 curlsocktype purpose,
+                                                 struct curl_sockaddr *address)
+{
+  HttpConnectionPool* pool = static_cast<HttpConnectionPool*>(clientp);
+  return pool->open_socket(purpose, address);
+}
+
+curl_socket_t HttpConnectionPool::open_socket(curlsocktype purpose,
+                                              struct curl_sockaddr *address)
+{
+  int fd = socket(address->family, address->socktype, address->protocol);
+
+  if (fd <= 0)
+  {
+    TRC_ERROR("Error creating socket %d (%s)", errno, strerror(errno));
+    return -1;
+  }
+
+  TRC_DEBUG("Bind socket %d to address %s", fd, _source_address.c_str());
+
+  struct sockaddr_storage sa_storage = {0};
+  size_t sa_size = 0;
+
+  if (address->family == AF_INET)
+  {
+    struct sockaddr_in* sa = (struct sockaddr_storage*)&sa_storage;
+    sa_size = sizeof(*sa);
+
+    sa->sin_family = address->family;
+    int rc = inet_pton(address->family, _source_address.c_str(), &sa->sin_addr);
+  }
+  else
+  {
+    struct sockaddr_in6 sa = (struct sockaddr_storage*)&sa_storage;
+    sa_size = sizeof(*sa);
+
+    sa.sin6_family = address->family;
+    int rc = inet_pton(address->family, _source_address.c_str(), &sa.sin6_addr);
+  }
+
+  if (rc == 1)
+  {
+    rc = bind(fd, (const struct sockaddr*)&sa_storage, sa_size);
+
+    if (rc != 0)
+    {
+      TRC_ERROR("Error %d (%s) trying to bind to address %s in family %d",
+                errno, strerror(errno), _source_address.c_str(), address->family);
+      return -1;
+    }
+  }
+  else
+  {
+    TRC_ERROR("inet_pton() returned %d when parsing address %s in family %d",
+              rc, _source_address.c_str(), address->family);
+    return -1;
+  }
+
+  return fd;
 }

--- a/src/http_connection_pool.cpp
+++ b/src/http_connection_pool.cpp
@@ -193,22 +193,23 @@ curl_socket_t HttpConnectionPool::open_socket(curlsocktype purpose,
 
   struct sockaddr_storage sa_storage = {0};
   size_t sa_size = 0;
+  int rc;
 
   if (address->family == AF_INET)
   {
-    struct sockaddr_in* sa = (struct sockaddr_storage*)&sa_storage;
+    struct sockaddr_in* sa = (struct sockaddr_in*)&sa_storage;
     sa_size = sizeof(*sa);
 
     sa->sin_family = address->family;
-    int rc = inet_pton(address->family, _source_address.c_str(), &sa->sin_addr);
+    rc = inet_pton(address->family, _source_address.c_str(), &sa->sin_addr);
   }
   else
   {
-    struct sockaddr_in6 sa = (struct sockaddr_storage*)&sa_storage;
+    struct sockaddr_in6* sa = (struct sockaddr_in6*)&sa_storage;
     sa_size = sizeof(*sa);
 
-    sa.sin6_family = address->family;
-    int rc = inet_pton(address->family, _source_address.c_str(), &sa.sin6_addr);
+    sa->sin6_family = address->family;
+    rc = inet_pton(address->family, _source_address.c_str(), &sa->sin6_addr);
   }
 
   if (rc == 1)

--- a/src/httpclient.cpp
+++ b/src/httpclient.cpp
@@ -44,14 +44,15 @@ HttpClient::HttpClient(bool assert_user,
                        bool remote_connection,
                        long timeout_ms,
                        bool log_display_address,
-                       std::string server_display_address) :
+                       std::string server_display_address,
+                       const std::string& source_address) :
   _assert_user(assert_user),
   _resolver(resolver),
   _load_monitor(load_monitor),
   _sas_log_level(sas_log_level),
   _comm_monitor(comm_monitor),
   _stat_table(stat_table),
-  _conn_pool(load_monitor, stat_table, remote_connection, timeout_ms),
+  _conn_pool(load_monitor, stat_table, remote_connection, timeout_ms, source_address),
   _should_omit_body(should_omit_body),
   _log_display_address(log_display_address),
   _server_display_address(server_display_address)

--- a/src/memcachedstore.cpp
+++ b/src/memcachedstore.cpp
@@ -63,7 +63,7 @@ BaseMemcachedStore::BaseMemcachedStore(bool binary,
 
   if (!source_address.empty())
   {
-    _options += " --SOURCE-ADDRESS=" + source_address;
+    _options += " --SOURCE-ADDRESS=\"" + source_address + "\"";
   }
 
   TRC_DEBUG("Memcached options: %s", _options.c_str());

--- a/src/memcachedstore.cpp
+++ b/src/memcachedstore.cpp
@@ -265,7 +265,7 @@ TopologyNeutralMemcachedStore(const std::string& target_domain,
 {
   if (!source_address.empty())
   {
-    _options += ("--SOURCE-ADDRESS=" + source_address);
+    _options += " --SOURCE-ADDRESS=" + source_address;
   }
 
   TRC_DEBUG("Final memcached options: %s", _options.c_str());

--- a/src/memcachedstore.cpp
+++ b/src/memcachedstore.cpp
@@ -38,7 +38,7 @@ static const std::string TOMBSTONE = "";
 BaseMemcachedStore::BaseMemcachedStore(bool binary,
                                        bool remote_store,
                                        BaseCommunicationMonitor* comm_monitor,
-                                       const std::string& source_address = "") :
+                                       const std::string& source_address) :
   _binary(binary),
   _options(),
   _comm_monitor(comm_monitor),


### PR DESCRIPTION
This PR adds the capability for the user of the HTTP and Memcached clients to specify what IP address the client should establish TCP connections from. This is useful as:

* It allows the FV tests to simulate realistic network conditions such as netsplits and latency. 
* It opens the way for source-based IP routing which might be useful in future. 

Tested by running a simple FV test and checking the network traffic in wireshark. 