### PR TITLE
Allow the user of a chronos connection to specify an address to connect from

### DIFF
--- a/include/chronosconnection.h
+++ b/include/chronosconnection.h
@@ -25,7 +25,8 @@ public:
   ChronosConnection(const std::string& chronos,
                     std::string callback_host,
                     HttpResolver* resolver,
-                    BaseCommunicationMonitor* comm_monitor);
+                    BaseCommunicationMonitor* comm_monitor,
+                    const std::string& source_address = "");
   virtual ~ChronosConnection();
 
   virtual HTTPCode send_delete(const std::string& delete_id,

--- a/src/chronosconnection.cpp
+++ b/src/chronosconnection.cpp
@@ -26,13 +26,23 @@ const std::map<std::string, uint32_t> ChronosConnection::EMPTY_TAGS = std::map<s
 ChronosConnection::ChronosConnection(const std::string& server,
                                      std::string callback_host,
                                      HttpResolver* resolver,
-                                     BaseCommunicationMonitor* comm_monitor) :
+                                     BaseCommunicationMonitor* comm_monitor,
+                                     const std::string& source_address) :
   _callback_host(callback_host),
   _http(new HttpConnection(server,
                            false,
                            resolver,
+                           nullptr,
+                           nullptr,
                            SASEvent::HttpLogLevel::DETAIL,
-                           comm_monitor))
+                           comm_monitor,
+                           "http",
+                           false,
+                           false,
+                           -1,
+                           false,
+                           "",
+                           source_address))
 {
 }
 


### PR DESCRIPTION
This is needed to allow S4s to use the right address in the FV tests. 

I've tested that this doesn't break anything by running the FV tests. As previously discussed, it would be best to test this against the net split infrastructure we're going to add to the FVs. 