### PR TITLE
[Reviewer: AJH] Common sas_write log callback

### DIFF
--- a/include/log.h
+++ b/include/log.h
@@ -50,13 +50,6 @@ namespace Log
   Logger* setLogger(Logger *log);
   void write(int level, const char *module, int line_number, const char *fmt, ...);
   void _write(int level, const char *module, int line_number, const char *fmt, va_list args);
-  void write_sas_log(const char* sas_level_str,
-                     int32_t log_id_len,
-                     unsigned char* log_id,
-                     int32_t sas_ip_len,
-                     unsigned char* sas_ip,
-                     int32_t msg_len,
-                     unsigned char* msg);
   void backtrace(const char* fmt, ...);
   void backtrace_adv();
   void commit();

--- a/include/log.h
+++ b/include/log.h
@@ -50,6 +50,13 @@ namespace Log
   Logger* setLogger(Logger *log);
   void write(int level, const char *module, int line_number, const char *fmt, ...);
   void _write(int level, const char *module, int line_number, const char *fmt, va_list args);
+  void write_sas_log(sasclient_log_level_t sas_level,
+                     int32_t log_id_len,
+                     unsigned char* log_id,
+                     int32_t sas_ip_len,
+                     unsigned char* sas_ip,
+                     int32_t msg_len,
+                     unsigned char* msg);
   void backtrace(const char* fmt, ...);
   void backtrace_adv();
   void commit();

--- a/include/log.h
+++ b/include/log.h
@@ -50,7 +50,7 @@ namespace Log
   Logger* setLogger(Logger *log);
   void write(int level, const char *module, int line_number, const char *fmt, ...);
   void _write(int level, const char *module, int line_number, const char *fmt, va_list args);
-  void write_sas_log(sasclient_log_level_t sas_level,
+  void write_sas_log(const char* sas_level_str,
                      int32_t log_id_len,
                      unsigned char* log_id,
                      int32_t sas_ip_len,

--- a/include/saslogger.h
+++ b/include/saslogger.h
@@ -15,6 +15,12 @@
 
 #include "sas.h"
 
-void sas_write(SAS::log_level_t sas_level, const char *module, int line_number, const char *fmt, ...);
+void sas_write(sasclient_log_level_t level,
+               int32_t log_id_len,
+               unsigned char* log_id,
+               int32_t sas_ip_len,
+               unsigned char* sas_ip,
+               int32_t msg_len,
+               unsigned char* msg);
 
 #endif

--- a/include/saslogger.h
+++ b/include/saslogger.h
@@ -15,7 +15,7 @@
 
 #include "sas.h"
 
-void sas_write(sasclient_log_level_t sas_level,
+void sas_write(sas_log_level_t sas_level,
                int32_t log_id_len,
                unsigned char* log_id,
                int32_t sas_ip_len,

--- a/include/saslogger.h
+++ b/include/saslogger.h
@@ -15,7 +15,7 @@
 
 #include "sas.h"
 
-void sas_write(sas_log_level_t sas_level,
+void sas_write(SAS::sas_log_level_t sas_level,
                int32_t log_id_len,
                unsigned char* log_id,
                int32_t sas_ip_len,

--- a/include/saslogger.h
+++ b/include/saslogger.h
@@ -15,7 +15,7 @@
 
 #include "sas.h"
 
-void sas_write(sasclient_log_level_t level,
+void sas_write(sasclient_log_level_t sas_level,
                int32_t log_id_len,
                unsigned char* log_id,
                int32_t sas_ip_len,

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -162,13 +162,13 @@ void Log::write_sas_log(const char* sas_level_str,
 
   pthread_t thread = pthread_self();
 
-  if (!log_id == NULL)
+  if (log_id != NULL)
   {
-    written = snprintf(logline, MAX_LOGLINE - 2, "[%lx] %d,", thread, sas_level_str);
+    written = snprintf(logline, MAX_LOGLINE - 2, "[%lx] %s,", thread, sas_level_str);
     written += snprintf(logline + strlen(logline), MAX_LOGLINE - 2, "%.*s,", log_id_len, log_id);
   }
 
-  if (!sap_ip == NULL)
+  if (sas_ip != NULL)
   {
     written += snprintf(logline + strlen(logline), MAX_LOGLINE - 2, "%.*s,", sas_ip_len, sas_ip);
   }

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -94,7 +94,7 @@ void Log::_write(int level, const char *module, int line_number, const char *fmt
 
   pthread_t thread = pthread_self();
 
-  written = snprintf(logline, MAX_LOGLINE -2, "[%lx] ", thread);
+  written = snprintf(logline, MAX_LOGLINE -2, "[%lx] %s ", thread, log_level[level]);
   int bytes_available = MAX_LOGLINE - written - 2;
 
   // If no module is supplied then all the information in the log is supplied in the fmt
@@ -106,11 +106,11 @@ void Log::_write(int level, const char *module, int line_number, const char *fmt
 
     if (line_number)
     {
-      written += snprintf(logline + written, bytes_available, "%s %s:%d: ", log_level[level], module, line_number);
+      written += snprintf(logline + written, bytes_available, "%s:%d: ", module, line_number);
     }
     else
     {
-      written += snprintf(logline + written, bytes_available, "%s %s: ", log_level[level], module);
+      written += snprintf(logline + written, bytes_available, "%s: ", module);
     }
   }
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -166,7 +166,7 @@ void Log::write_sas_log(const char* sas_level_str,
 
   if (log_id != NULL)
   {
-    written += snprintf(logline, strlen(logline), MAX_LOGLINE - 2, "%s, ", sas_level_str);
+    written += snprintf(logline + strlen(logline), MAX_LOGLINE - 2, "%s, ", sas_level_str);
     written += snprintf(logline + strlen(logline), MAX_LOGLINE - 2, "%.*s,", log_id_len, log_id);
   }
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -162,9 +162,11 @@ void Log::write_sas_log(const char* sas_level_str,
 
   pthread_t thread = pthread_self();
 
+  written = snprintf(logline, MAX_LOGLINE - 2, "[%lx] ", thread);
+
   if (log_id != NULL)
   {
-    written = snprintf(logline, MAX_LOGLINE - 2, "[%lx] %s,", thread, sas_level_str);
+    written += snprintf(logline, strlen(logline), MAX_LOGLINE - 2, "%s, ", sas_level_str);
     written += snprintf(logline + strlen(logline), MAX_LOGLINE - 2, "%.*s,", log_id_len, log_id);
   }
 
@@ -173,7 +175,7 @@ void Log::write_sas_log(const char* sas_level_str,
     written += snprintf(logline + strlen(logline), MAX_LOGLINE - 2, "%.*s,", sas_ip_len, sas_ip);
   }
 
-  written += snprintf(logline + strlen(logline), MAX_LOGLINE - 2, "%.*s\n", msg_len, msg);
+  written += snprintf(logline + strlen(logline), MAX_LOGLINE - 2, "%.*s", msg_len, msg);
 
 
   // snprintf and vsnprintf return the bytes that would have been

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -136,7 +136,7 @@ void Log::_write(int level, const char *module, int line_number, const char *fmt
 
 }
 
-void Log::write_sas_log(sasclient_log_level_t level,
+void Log::write_sas_log(const char* sas_level_str,
                         int32_t log_id_len,
                         unsigned char* log_id,
                         int32_t sas_ip_len,
@@ -164,7 +164,7 @@ void Log::write_sas_log(sasclient_log_level_t level,
 
   if (!log_id == NULL)
   {
-    written = snprintf(logline, MAX_LOGLINE - 2, "[%lx] %d,", thread, sas_level);
+    written = snprintf(logline, MAX_LOGLINE - 2, "[%lx] %d,", thread, sas_level_str);
     written += snprintf(logline + strlen(logline), MAX_LOGLINE - 2, "%.*s,", log_id_len, log_id);
   }
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -136,6 +136,73 @@ void Log::_write(int level, const char *module, int line_number, const char *fmt
 
 }
 
+void Log::write_sas_log(sasclient_log_level_t level,
+                        int32_t log_id_len,
+                        unsigned char* log_id,
+                        int32_t sas_ip_len,
+                        unsigned char* sas_ip,
+                        int32_t msg_len,
+                        unsigned char* msg)
+{
+  pthread_mutex_lock(&Log::serialization_lock);
+  if (!Log::logger)
+  {
+    // LCOV_EXCL_START
+    pthread_mutex_unlock(&Log::serialization_lock);
+    return;
+    // LCOV_EXCL_STOP
+  }
+
+  pthread_cleanup_push(release_lock, 0);
+
+  char logline[MAX_LOGLINE];
+
+  int written = 0;
+  int truncated = 0;
+
+  pthread_t thread = pthread_self();
+
+  if (!log_id == NULL)
+  {
+    written = snprintf(logline, MAX_LOGLINE - 2, "[%lx] %d,", thread, sas_level);
+    written += snprintf(logline + strlen(logline), MAX_LOGLINE - 2, "%.*s,", log_id_len, log_id);
+  }
+
+  if (!sap_ip == NULL)
+  {
+    written += snprintf(logline + strlen(logline), MAX_LOGLINE - 2, "%.*s,", sas_ip_len, sas_ip);
+  }
+
+  written += snprintf(logline + strlen(logline), MAX_LOGLINE - 2, "%.*s\n", msg_len, msg);
+
+
+  // snprintf and vsnprintf return the bytes that would have been
+  // written if their second argument was large enough, so we need to
+  // reduce the size of written to compensate if it is too large.
+  written = std::min(written, MAX_LOGLINE - 2);
+
+  if (written > (MAX_LOGLINE - 2))
+  {
+    truncated = written - (MAX_LOGLINE - 2);
+    written = MAX_LOGLINE - 2;
+  }
+
+  // Add a new line and null termination.
+  logline[written] = '\n';
+  logline[written+1] = '\0';
+
+  Log::logger->write(logline);
+  if (truncated > 0)
+  {
+    char buf[128];
+    snprintf(buf, 128, "Previous log was truncated by %d characters\n", truncated);
+    Log::logger->write(buf);
+  }
+  pthread_cleanup_pop(0);
+  pthread_mutex_unlock(&Log::serialization_lock);
+
+}
+
 // LCOV_EXCL_START Only used in exceptional signal handlers - not hit in UT
 
 void Log::backtrace(const char *fmt, ...)

--- a/src/saslogger.cpp
+++ b/src/saslogger.cpp
@@ -35,31 +35,31 @@ void sas_write(SAS::sas_log_level_t sas_level,
   // to print the log.
   // Covert the sasclient_log_level_t to a string so we can easily write it to the logline array.
   switch (sas_level) {
-    case SASCLIENT_LOG_CRITICAL:
+    case SAS::SASCLIENT_LOG_CRITICAL:
       level = Log::ERROR_LEVEL;
       sas_level_str = "Critical";
       break;
-    case SASCLIENT_LOG_ERROR:
+    case SAS::SASCLIENT_LOG_ERROR:
       level = Log::ERROR_LEVEL;
       sas_level_str = "Error";
       break;
-    case SASCLIENT_LOG_WARNING:
+    case SAS::SASCLIENT_LOG_WARNING:
       level = Log::WARNING_LEVEL;
       sas_level_str = "Warning";
       break;
-    case SASCLIENT_LOG_INFO:
+    case SAS::SASCLIENT_LOG_INFO:
       level = Log::STATUS_LEVEL;
       sas_level_str = "Info";
       break;
-    case SASCLIENT_LOG_DEBUG:
+    case SAS::SASCLIENT_LOG_DEBUG:
       level = Log::DEBUG_LEVEL;
       sas_level_str = "Debug";
       break;
-    case SASCLIENT_LOG_TRACE:
+    case SAS::SASCLIENT_LOG_TRACE:
       level = Log::DEBUG_LEVEL;
       sas_level_str = "Trace";
       break;
-    case SASCLIENT_LOG_STATS:
+    case SAS::SASCLIENT_LOG_STATS:
       level = Log::INFO_LEVEL;
       sas_level_str = "Info";
       break;

--- a/src/saslogger.cpp
+++ b/src/saslogger.cpp
@@ -23,7 +23,7 @@ void sas_write(sasclient_log_level_t level,
                int32_t sas_ip_len,
                unsigned char* sas_ip,
                int32_t msg_len,
-               unsigned char* msg);
+               unsigned char* msg)
 {
   int level;
 

--- a/src/saslogger.cpp
+++ b/src/saslogger.cpp
@@ -11,6 +11,7 @@
  */
 
 #include <cstdarg>
+#include <string>
 
 #include "log.h"
 #include "saslogger.h"
@@ -26,33 +27,45 @@ void sas_write(sasclient_log_level_t sas_level,
                unsigned char* msg)
 {
   int level;
+  std::string sas_level_str;
+
   // Convert the sasclient_log_level_t to the common log level to determine if we need
   // to print the log.
+  // Covert the sasclient_log_level_t to a char* to pass to write_sas_log() as the Log namespace
+  // has no knowledge of SAS-Client specific types.
   switch (sas_level) {
     case SASCLIENT_LOG_CRITICAL:
       level = Log::ERROR_LEVEL;
+      sas_level_str = "CRIT";
       break;
     case SASCLIENT_LOG_ERROR:
       level = Log::ERROR_LEVEL;
+      sas_level_str = "ERR";
       break;
     case SASCLIENT_LOG_WARNING:
       level = Log::WARNING_LEVEL;
+      sas_level_str = "WARN";
       break;
     case SASCLIENT_LOG_INFO:
       level = Log::INFO_LEVEL;
+      sas_level_str = "INFO";
       break;
     case SASCLIENT_LOG_DEBUG:
       level = Log::DEBUG_LEVEL;
+      sas_level_str = "DBG";
       break;
     case SASCLIENT_LOG_TRACE:
       level = Log::DEBUG_LEVEL;
+      sas_level_str = "TRC";
       break;
     case SASCLIENT_LOG_STATS:
       level = Log::INFO_LEVEL;
+      sas_level_str = "STAT";
       break;
     default:
       TRC_ERROR("Unknown SAS log level %d, treating as error level", sas_level);
       level = Log::ERROR_LEVEL;
+      sas_level_str = "ERR";
     }
 
   if (level > Log::loggingLevel)
@@ -60,7 +73,7 @@ void sas_write(sasclient_log_level_t sas_level,
     return;
   }
 
-  Log::write_sas_log(sas_level,
+  Log::write_sas_log(sas_level_str.c_str(),
                      log_id_len,
                      log_id,
                      sas_ip_len,

--- a/src/saslogger.cpp
+++ b/src/saslogger.cpp
@@ -78,9 +78,9 @@ void sas_write(SAS::sas_log_level_t sas_level,
   // Array comfortably larger than any expected log. Log::_write outputs a warning
   // if the resulting log to be logged is truncated due to being too long.
   int array_size = 10000;
-  char logline[array_size]
+  char logline[array_size];
 
- snsprintf(logline, array_size, "%s, ", sas_level_str);
+  snprintf(logline, array_size, "%s, ", sas_level_str);
 
   if (log_id != NULL)
   {

--- a/src/saslogger.cpp
+++ b/src/saslogger.cpp
@@ -47,7 +47,7 @@ void sas_write(sasclient_log_level_t sas_level,
       sas_level_str = "Warning";
       break;
     case SASCLIENT_LOG_INFO:
-      level = Log::INFO_LEVEL;
+      level = Log::STATUS_LEVEL;
       sas_level_str = "Info";
       break;
     case SASCLIENT_LOG_DEBUG:

--- a/src/saslogger.cpp
+++ b/src/saslogger.cpp
@@ -80,7 +80,7 @@ void sas_write(SAS::sas_log_level_t sas_level,
   int array_size = 10000;
   char logline[array_size];
 
-  snprintf(logline, array_size, "%s, ", sas_level_str);
+  snprintf(logline, array_size, "%s, ", (char*)sas_level_str.c_str());
 
   if (log_id != NULL)
   {
@@ -102,7 +102,7 @@ void sas_write(SAS::sas_log_level_t sas_level,
               NULL,
               0,
               logline,
-              empty_va_list)
+              empty_va_list);
 }
 
 // LCOV_EXCL_STOP

--- a/src/saslogger.cpp
+++ b/src/saslogger.cpp
@@ -27,82 +27,40 @@ void sas_write(SAS::sas_log_level_t sas_level,
                unsigned char* msg)
 {
   int level;
-  std::string sas_level_str;
 
-  // Write all of the args to msg, then pass to
-
-  // Convert the sasclient_log_level_t to the common log level to determine if we need
-  // to print the log.
-  // Covert the sasclient_log_level_t to a string so we can easily write it to the logline array.
+  // Convert the sasclient_log_level_t to the common log level.
   switch (sas_level) {
     case SAS::SASCLIENT_LOG_CRITICAL:
       level = Log::ERROR_LEVEL;
-      sas_level_str = "Critical";
       break;
     case SAS::SASCLIENT_LOG_ERROR:
       level = Log::ERROR_LEVEL;
-      sas_level_str = "Error";
       break;
     case SAS::SASCLIENT_LOG_WARNING:
       level = Log::WARNING_LEVEL;
-      sas_level_str = "Warning";
       break;
     case SAS::SASCLIENT_LOG_INFO:
       level = Log::STATUS_LEVEL;
-      sas_level_str = "Info";
       break;
     case SAS::SASCLIENT_LOG_DEBUG:
       level = Log::DEBUG_LEVEL;
-      sas_level_str = "Debug";
       break;
     case SAS::SASCLIENT_LOG_TRACE:
       level = Log::DEBUG_LEVEL;
-      sas_level_str = "Trace";
       break;
     case SAS::SASCLIENT_LOG_STATS:
       level = Log::INFO_LEVEL;
-      sas_level_str = "Info";
       break;
     default:
       TRC_ERROR("Unknown SAS log level %d, treating as error level", sas_level);
       level = Log::ERROR_LEVEL;
-      sas_level_str = "Error";
     }
 
-  // Check if we actually need to print the recieved log.
-  if (level > Log::loggingLevel)
-  {
-    return;
-  }
-
-  // Array comfortably larger than any expected log. Log::_write outputs a warning
-  // if the resulting log to be logged is truncated due to being too long.
-  int array_size = 10000;
-  char logline[array_size];
-
-  snprintf(logline, array_size, "%s, ", (char*)sas_level_str.c_str());
-
-  if (log_id != NULL)
-  {
-   snprintf(logline + strlen(logline), array_size, "%.*s,", log_id_len, log_id);
-  }
-
-  if (sas_ip != NULL)
-  {
-   snprintf(logline + strlen(logline), array_size, "%.*s,", sas_ip_len, sas_ip);
-  }
-
- snprintf(logline + strlen(logline), array_size, "%.*s", msg_len, msg);
-
-  // Set level to 0, so that the log level check in Log::write passes. Pass in an empty va_list
-  // to Log::_write, as we don't need to format our msg any further.
-  level = 0;
-  va_list empty_va_list;
   Log::_write(level,
               NULL,
               0,
-              logline,
-              empty_va_list);
+              "%.*s %.*s %.*s",
+              log_id_len, log_id, sas_ip_len, sas_ip, msg_len, msg);
 }
 
 // LCOV_EXCL_STOP

--- a/src/saslogger.cpp
+++ b/src/saslogger.cpp
@@ -11,7 +11,6 @@
  */
 
 #include <cstdarg>
-#include <string>
 
 #include "log.h"
 #include "saslogger.h"

--- a/src/saslogger.cpp
+++ b/src/saslogger.cpp
@@ -56,7 +56,7 @@ void sas_write(SAS::sas_log_level_t sas_level,
       level = Log::ERROR_LEVEL;
     }
 
-  Log::_write(level,
+  Log::write(level,
               NULL,
               0,
               "%.*s %.*s %.*s",

--- a/src/saslogger.cpp
+++ b/src/saslogger.cpp
@@ -57,10 +57,10 @@ void sas_write(SAS::sas_log_level_t sas_level,
     }
 
   Log::write(level,
-              NULL,
-              0,
-              "%.*s %.*s %.*s",
-              log_id_len, log_id, sas_ip_len, sas_ip, msg_len, msg);
+             NULL,
+             0,
+             "%.*s %.*s %.*s",
+             log_id_len, log_id, sas_ip_len, sas_ip, msg_len, msg);
 }
 
 // LCOV_EXCL_STOP

--- a/src/saslogger.cpp
+++ b/src/saslogger.cpp
@@ -36,36 +36,36 @@ void sas_write(sasclient_log_level_t sas_level,
   switch (sas_level) {
     case SASCLIENT_LOG_CRITICAL:
       level = Log::ERROR_LEVEL;
-      sas_level_str = "CRIT";
+      sas_level_str = "Critical";
       break;
     case SASCLIENT_LOG_ERROR:
       level = Log::ERROR_LEVEL;
-      sas_level_str = "ERR";
+      sas_level_str = "Error";
       break;
     case SASCLIENT_LOG_WARNING:
       level = Log::WARNING_LEVEL;
-      sas_level_str = "WARN";
+      sas_level_str = "Warning";
       break;
     case SASCLIENT_LOG_INFO:
       level = Log::INFO_LEVEL;
-      sas_level_str = "INFO";
+      sas_level_str = "Info";
       break;
     case SASCLIENT_LOG_DEBUG:
       level = Log::DEBUG_LEVEL;
-      sas_level_str = "DBG";
+      sas_level_str = "Debug";
       break;
     case SASCLIENT_LOG_TRACE:
       level = Log::DEBUG_LEVEL;
-      sas_level_str = "TRC";
+      sas_level_str = "Trace";
       break;
     case SASCLIENT_LOG_STATS:
       level = Log::INFO_LEVEL;
-      sas_level_str = "STAT";
+      sas_level_str = "Info";
       break;
     default:
       TRC_ERROR("Unknown SAS log level %d, treating as error level", sas_level);
       level = Log::ERROR_LEVEL;
-      sas_level_str = "ERR";
+      sas_level_str = "Error";
     }
 
   if (level > Log::loggingLevel)

--- a/src/saslogger.cpp
+++ b/src/saslogger.cpp
@@ -18,7 +18,7 @@
 
 // LCOV_EXCL_START
 
-void sas_write(sas_log_level_t sas_level,
+void sas_write(SAS::sas_log_level_t sas_level,
                int32_t log_id_len,
                unsigned char* log_id,
                int32_t sas_ip_len,

--- a/src/saslogger.cpp
+++ b/src/saslogger.cpp
@@ -17,38 +17,107 @@
 
 // LCOV_EXCL_START
 
-void sas_write(SAS::log_level_t sas_level, const char *module, int line_number, const char *fmt, ...)
+void sas_write(sasclient_log_level_t level,
+               int32_t log_id_len,
+               unsigned char* log_id,
+               int32_t sas_ip_len,
+               unsigned char* sas_ip,
+               int32_t msg_len,
+               unsigned char* msg);
 {
   int level;
-  va_list args;
 
+  // Convert the sasclient_log_level_t to the common log level to determine if we need
+  // to print the log.
   switch (sas_level) {
-    case SAS::LOG_LEVEL_DEBUG:
-      level = Log::DEBUG_LEVEL;
+    case SAS::SASCLIENT_LOG_CRITICAL:
+      level = Log::ERROR_LEVEL;
       break;
-    case SAS::LOG_LEVEL_VERBOSE:
-      level = Log::VERBOSE_LEVEL;
+    case SAS::SASCLIENT_LOG_ERROR:
+      level = Log::ERROR_LEVEL;
       break;
-    case SAS::LOG_LEVEL_INFO:
-      level = Log::INFO_LEVEL;
-      break;
-    case SAS::LOG_LEVEL_STATUS:
-      level = Log::STATUS_LEVEL;
-      break;
-    case SAS::LOG_LEVEL_WARNING:
+    case SAS::SASCLIENT_LOG_WARNING:
       level = Log::WARNING_LEVEL;
       break;
-    case SAS::LOG_LEVEL_ERROR:
-      level = Log::ERROR_LEVEL;
+    case SAS::SASCLIENT_LOG_INFO:
+      level = Log::INFO_LEVEL;
+      break;
+    case SAS::SASCLIENT_LOG_DEBUG:
+      level = Log::DEBUG_LEVEL;
+      break;
+    case SAS::SASCLIENT_LOG_TRACE:
+      level = Log::DEBUG_LEVEL;
+      break;
+    case SAS::SASCLIENT_LOG_STATS:
+      level = Log::INFO_LEVEL;
       break;
     default:
       TRC_ERROR("Unknown SAS log level %d, treating as error level", sas_level);
       level = Log::ERROR_LEVEL;
     }
 
-  va_start(args, fmt);
-  Log::_write(level, module, line_number, fmt, args);
-  va_end(args);
+  if (level > Log::loggingLevel)
+  {
+    return;
+  }
+
+  pthread_mutex_lock(&Log::serialization_lock);
+  if (!Log::logger)
+  {
+    // LCOV_EXCL_START
+    pthread_mutex_unlock(&Log::serialization_lock);
+    return;
+    // LCOV_EXCL_STOP
+  }
+
+  pthread_cleanup_push(release_lock, 0);
+
+  char logline[MAX_LOGLINE];
+
+  int written = 0;
+  int truncated = 0;
+
+  pthread_t thread = pthread_self();
+
+  if (!log_id == NULL)
+  {
+    written = snprintf(logline, MAX_LOGLINE - 2, "[%lx] %d,", thread, sas_level);
+    written += snprintf(logline + strlen(logline), MAX_LOGLINE - 2, "%.*s,", log_id_len, log_id);
+  }
+
+  if (!sap_ip == NULL)
+  {
+    written += snprintf(logline + strlen(logline), MAX_LOGLINE - 2, "%.*s,", sas_ip_len, sas_ip);
+  }
+
+  written += snprintf(logline + strlen(logline), MAX_LOGLINE - 2, "%.*s\n", msg_len, msg);
+
+
+  // snprintf and vsnprintf return the bytes that would have been
+  // written if their second argument was large enough, so we need to
+  // reduce the size of written to compensate if it is too large.
+  written = std::min(written, MAX_LOGLINE - 2);
+
+  if (written > (MAX_LOGLINE - 2))
+  {
+    truncated = written - (MAX_LOGLINE - 2);
+    written = MAX_LOGLINE - 2;
+  }
+
+  // Add a new line and null termination.
+  logline[written] = '\n';
+  logline[written+1] = '\0';
+
+  Log::logger->write(logline);
+  if (truncated > 0)
+  {
+    char buf[128];
+    snprintf(buf, 128, "Previous log was truncated by %d characters\n", truncated);
+    Log::logger->write(buf);
+  }
+  pthread_cleanup_pop(0);
+  pthread_mutex_unlock(&Log::serialization_lock);
+
 }
 
 // LCOV_EXCL_STOP

--- a/src/saslogger.cpp
+++ b/src/saslogger.cpp
@@ -17,7 +17,7 @@
 
 // LCOV_EXCL_START
 
-void sas_write(sasclient_log_level_t level,
+void sas_write(sasclient_log_level_t sas_level,
                int32_t log_id_len,
                unsigned char* log_id,
                int32_t sas_ip_len,
@@ -30,25 +30,25 @@ void sas_write(sasclient_log_level_t level,
   // Convert the sasclient_log_level_t to the common log level to determine if we need
   // to print the log.
   switch (sas_level) {
-    case SAS::SASCLIENT_LOG_CRITICAL:
+    case SASCLIENT_LOG_CRITICAL:
       level = Log::ERROR_LEVEL;
       break;
-    case SAS::SASCLIENT_LOG_ERROR:
+    case SASCLIENT_LOG_ERROR:
       level = Log::ERROR_LEVEL;
       break;
-    case SAS::SASCLIENT_LOG_WARNING:
+    case SASCLIENT_LOG_WARNING:
       level = Log::WARNING_LEVEL;
       break;
-    case SAS::SASCLIENT_LOG_INFO:
+    case SASCLIENT_LOG_INFO:
       level = Log::INFO_LEVEL;
       break;
-    case SAS::SASCLIENT_LOG_DEBUG:
+    case SASCLIENT_LOG_DEBUG:
       level = Log::DEBUG_LEVEL;
       break;
-    case SAS::SASCLIENT_LOG_TRACE:
+    case SASCLIENT_LOG_TRACE:
       level = Log::DEBUG_LEVEL;
       break;
-    case SAS::SASCLIENT_LOG_STATS:
+    case SASCLIENT_LOG_STATS:
       level = Log::INFO_LEVEL;
       break;
     default:


### PR DESCRIPTION
Creation of a new logging callback that will be compatible with all sas-clients. 

- saslogger.cpp checks to see if we need to write the received log, and converts the sasclient log level to a string.

- log.cpp writes the sas_ip and log_id if they are present. If not, all the log information will be contained in the msg component, so that will be the only arg written. 

PR for changes to the PC sas-client to interact with the new callback is [here](https://github.com/Metaswitch/sas-client/pull/83). 

