### PR TITLE
Make the DnsCachedResolver port configurable. 

### DIFF
--- a/include/dnscachedresolver.h
+++ b/include/dnscachedresolver.h
@@ -52,10 +52,18 @@ private:
 class DnsCachedResolver
 {
 public:
-  DnsCachedResolver(const std::vector<IP46Address>& dns_servers, int timeout = DEFAULT_TIMEOUT, const std::string& filename = "");
-  DnsCachedResolver(const std::vector<std::string>& dns_servers, int timeout = DEFAULT_TIMEOUT, const std::string& filename = "");
-  DnsCachedResolver(const std::string& dns_server, int port, int timeout = DEFAULT_TIMEOUT, const std::string& filename = "");
-  DnsCachedResolver(const std::string& dns_server) : DnsCachedResolver(dns_server, DEFAULT_PORT) {};
+  DnsCachedResolver(const std::vector<IP46Address>& dns_servers,
+                    int timeout = DEFAULT_TIMEOUT,
+                    const std::string& filename = NO_DNS_FILE,
+                    int port = DEFAULT_PORT);
+  DnsCachedResolver(const std::vector<std::string>& dns_servers,
+                    int timeout = DEFAULT_TIMEOUT,
+                    const std::string& filename = NO_DNS_FILE,
+                    int port = DEFAULT_PORT);
+  DnsCachedResolver(const std::string& dns_server,
+                    int timeout = DEFAULT_TIMEOUT,
+                    const std::string& filename = NO_DNS_FILE,
+                    int port = DEFAULT_PORT);
   ~DnsCachedResolver();
 
   /// Queries a single DNS record.
@@ -91,6 +99,10 @@ public:
 
   // Maximum number of DNS servers to poll for a single query
   static const int MAX_DNS_SERVER_POLL = 3;
+
+  // Constant that makes it clear what is going on when calling code wants to
+  // construct a resolver with no DNS file.
+  static constexpr const char* NO_DNS_FILE = "";
 
 private:
   void init(const std::vector<IP46Address>& dns_server);

--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -158,8 +158,9 @@ void DnsCachedResolver::init_from_server_ips(const std::vector<std::string>& dns
 
 DnsCachedResolver::DnsCachedResolver(const std::vector<IP46Address>& dns_servers,
                                      int timeout,
-                                     const std::string& filename) :
-  _port(DEFAULT_PORT),
+                                     const std::string& filename,
+                                     int port) :
+  _port(port),
   _timeout(timeout),
   _cache(),
   _dns_config_file(filename),
@@ -170,8 +171,9 @@ DnsCachedResolver::DnsCachedResolver(const std::vector<IP46Address>& dns_servers
 
 DnsCachedResolver::DnsCachedResolver(const std::vector<std::string>& dns_servers,
                                      int timeout,
-                                     const std::string& filename) :
-  _port(DEFAULT_PORT),
+                                     const std::string& filename,
+                                     int port) :
+  _port(port),
   _timeout(timeout),
   _cache(),
   _dns_config_file(filename),
@@ -181,9 +183,9 @@ DnsCachedResolver::DnsCachedResolver(const std::vector<std::string>& dns_servers
 }
 
 DnsCachedResolver::DnsCachedResolver(const std::string& dns_server,
-                                     int port,
                                      int timeout,
-                                     const std::string& filename) :
+                                     const std::string& filename,
+                                     int port) :
   _port(port),
   _timeout(timeout),
   _cache(),


### PR DESCRIPTION
This is needed so that the FV tests can run a DNS server on a non-default port.

As part of this change I've effectively removed this constructor for the resolver. I've done a search on github and I'm fairly confident that the only project using this constructor is the FV tests, which I have fixed up in a separate PR.

```cpp
DnsCachedResolver(const std::string& dns_server, int port, int timeout = DEFAULT_TIMEOUT, const std::string& filename = "");
```