### PR TITLE
Standardise ordering of DNS records when static cache is involved

### DIFF
--- a/include/dnscachedresolver.h
+++ b/include/dnscachedresolver.h
@@ -140,7 +140,7 @@ private:
   /// Performs the actual DNS query.
   void inner_dns_query(const std::vector<std::string>& domains,
                        int dnstype,
-                       std::vector<DnsResult>& results,
+                       std::map<std::string, DnsResult>& results,
                        SAS::TrailId trail);
 
   void dns_response(const std::string& domain,

--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -267,7 +267,7 @@ void DnsCachedResolver::dns_query(const std::vector<std::string>& domains,
   // The vector of results must match the order of domains passed in.
   for (const std::string& domain : domains)
   {
-    results.push_back(result_map[domain]);
+    results.push_back(result_map.at(domain));
   }
 
   pthread_mutex_unlock(&_cache_lock);

--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -232,11 +232,10 @@ void DnsCachedResolver::dns_query(const std::vector<std::string>& domains,
   // a DNS lookup for.
   std::vector<std::string> query_required;
 
-  // This map lets us keep track of which canonical domains map to which
-  // queried domains.
+  // Maps domain passed in -> canonical domain
   std::map<std::string, std::string> canonical_map;
 
-  // This map lets us keep track of which results are for which domains.
+  // Maps canonical domain -> result of DNS query
   std::map<std::string, DnsResult> result_map;
 
   pthread_mutex_lock(&_cache_lock);

--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -267,7 +267,7 @@ void DnsCachedResolver::dns_query(const std::vector<std::string>& domains,
   // The vector of results must match the order of domains passed in.
   for (const std::string& domain : domains)
   {
-    results.push_back(results_map[domain]);
+    results.push_back(result_map[domain]);
   }
 
   pthread_mutex_unlock(&_cache_lock);

--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -282,7 +282,7 @@ void DnsCachedResolver::dns_query(const std::vector<std::string>& domains,
     {
       TRC_DEBUG("Found result for query %s (canonical domain: %s)",
                 domain.c_str(),
-                canonical_domain);
+                canonical_domain.c_str());
       results.push_back(result_map.at(canonical_domain));
     }
   }

--- a/src/dnscachedresolver.cpp
+++ b/src/dnscachedresolver.cpp
@@ -251,7 +251,7 @@ void DnsCachedResolver::dns_query(const std::vector<std::string>& domains,
     {
       // There were some DNS records in the static cache - we use these in
       // preference to a DNS lookup.
-      result_map.insert(std:pair<std:string, DnsResult>(domain, static_result));
+      result_map.insert(std::pair<std::string, DnsResult>(domain, static_result));
     }
     else
     {

--- a/src/static_dns_cache.cpp
+++ b/src/static_dns_cache.cpp
@@ -63,11 +63,15 @@ StaticDnsCache::~StaticDnsCache()
 //   ]
 // }
 //
-// Currently, the only supported record object is CNAME:
+// Currently, the only supported record objects are CNAME and A:
 //
 // {
 //   "rrtype": "CNAME",
 //   "target": <target>
+// }
+// {
+//   "rrtype": "A",
+//   "targets": [<target1>, <target2>, ...]
 // }
 void StaticDnsCache::reload_static_records()
 {
@@ -297,7 +301,6 @@ DnsResult StaticDnsCache::get_static_dns_records(std::string domain,
   {
     TRC_DEBUG("No static records found matching %s", domain.c_str());
   }
-
 
   // In the case where we didn't find anything that matches, found_records will
   // be empty.


### PR DESCRIPTION
This code makes sure that the results of `DnsCachedResolver::dns_query()` come through in the order that the queries were sent in. I've tested that this passes the test written for this case in cpp-common-test.