### PR TITLE
[Reviewer: Ellie] Diameter peer connection alarm

### DIFF
--- a/include/communicationmonitor.h
+++ b/include/communicationmonitor.h
@@ -14,6 +14,7 @@
 
 #include "alarm.h"
 #include "base_communication_monitor.h"
+#include "utils.h"
 
 /// @class CommunicationMonitor
 ///
@@ -41,7 +42,6 @@ public:
 
 private:
   virtual void track_communication_changes(unsigned long now_ms);
-  unsigned long current_time_ms();
 
   Alarm* _alarm;
   std::string _sender;

--- a/include/cpp_common_pd_definitions.h
+++ b/include/cpp_common_pd_definitions.h
@@ -106,29 +106,56 @@ static const PDLog2<const char*, const char*> CL_CM_CONNECTION_CLEARED
   "None."
 );
 
-static const PDLog3<const char*, const char*, const char*> CL_RM_CONNECTION_ERROR
+static const PDLog CL_DNS_FILE_MALFORMED
 (
   PDLogBase::CL_CPP_COMMON_ID + 11,
-  LOG_INFO,
-  "Connections between %s and %s applications at %s have failed.",
-  "At least one of the Diameter peers is not contactable and the number of contactabble "
-  "instances is strictly less than expected (two unless changed through configuration)",
-  "This process was unable to contact some instances of the application "
-  "it's trying to connect to",
-  "(1). Check that the application this process is trying to connect to is running."
-  "(2). Check the configuration in /etc/clearwater is correct."
-  "(3). Check that this process has connectivity to the application it's trying to connect to."
+  LOG_ERR,
+  "DNS config file is malformed.",
+  "The DNS config file /etc/clearwater/dns.json is invalid JSON.",
+  "The DNS config file will be ignored, and all DNS queries will be directed at "
+  "the DNS server rather than using any local overrides.",
+  "(1). Check the DNS config file for correctness."
+  "(2). Upload the corrected config with "
+  "/usr/share/clearwater/clearwater-config-manager/scripts/upload_dns_json"
 );
 
-static const PDLog2<const char*, const char*> CL_RM_CONNECTION_CLEARED
+static const PDLog CL_DNS_FILE_DUPLICATES
 (
   PDLogBase::CL_CPP_COMMON_ID + 12,
   LOG_INFO,
-  "Some connections between %s and %s have been restored.",
-  "Either all known Diameter peers are conntactable, or there are enough contactable peers (two "
-  "unless changed through configuration) to provide the required level of Diameter peer resilience.",
-  "Normal.",
-  "None."
+  "Duplicate entries found in the DNS config file",
+  "The DNS config file /etc/clearwater/dns.json contains duplicate entries.",
+  "Only the first of the duplicates will be used - the others will be ignored.",
+  "(1). Check the DNS config file for duplicates."
+  "(2). Upload the corrected config with "
+  "/usr/share/clearwater/clearwater-config-manager/scripts/upload_dns_json"
+);
+
+static const PDLog CL_DNS_FILE_MISSING
+(
+  PDLogBase::CL_CPP_COMMON_ID + 13,
+  LOG_ERR,
+  "DNS config file is missing.",
+  "The DNS config file /etc/clearwater/dns.json is not present.",
+  "The DNS config file will be ignored, and all DNS queries will be directed at "
+  "the DNS server rather than using any local overrides.",
+  "(1). Replace the missing DNS config file if desired."
+  "(2). Upload the corrected config with "
+  "/usr/share/clearwater/clearwater-config-manager/scripts/upload_dns_json "
+  "(if no config file is present, no DNS overrides will be applied)"
+);
+
+static const PDLog CL_DNS_FILE_BAD_ENTRY
+(
+  PDLogBase::CL_CPP_COMMON_ID + 14,
+  LOG_ERR,
+  "DNS config file has a malformed entry.",
+  "The DNS config file /etc/clearwater/dns.json contains a malformed entry.",
+  "The malformed entry will be ignored. Other, correctly formed, entries will "
+  "still be used.",
+  "(1). Check the DNS config file for correctness."
+  "(2). Upload the corrected config with "
+  "/usr/share/clearwater/clearwater-config-manager/scripts/upload_dns_json"
 );
 
 #endif

--- a/include/cpp_common_pd_definitions.h
+++ b/include/cpp_common_pd_definitions.h
@@ -158,4 +158,29 @@ static const PDLog CL_DNS_FILE_BAD_ENTRY
   "/usr/share/clearwater/clearwater-config-manager/scripts/upload_dns_json"
 );
 
+static const PDLog3<const char*, const char*, const char*> CL_CM_CONNECTION_PARTIAL_ERROR_EXPLICIT
+(
+  PDLogBase::CL_CPP_COMMON_ID + 15,
+  LOG_INFO,
+  "Connections between %s and %s applications at %s have failed.",
+  "This process was unable to contact some instances of the application "
+  "it's trying to connect to, but did make some successful contact",
+  "This process was unable to contact some instances of the application "
+  "it's trying to connect to",
+  "(1). Check that the application this process is trying to connect to is running."
+  "(2). Check the configuration in /etc/clearwater is correct."
+  "(3). Check that this process has connectivity to the application it's trying to connect to."
+);
+
+static const PDLog3<const char*, const char*, const char*> CL_CM_CONNECTION_PARTIAL_CLEARED_EXPLICIT
+(
+  PDLogBase::CL_CPP_COMMON_ID + 16,
+  LOG_INFO,
+  "Connection between %s and %s applications%s has been restored.",
+  "This process can now contact at least one instance of the application it's "
+  "trying to connect to.",
+  "Normal.",
+  "None."
+);
+
 #endif

--- a/include/cpp_common_pd_definitions.h
+++ b/include/cpp_common_pd_definitions.h
@@ -106,65 +106,13 @@ static const PDLog2<const char*, const char*> CL_CM_CONNECTION_CLEARED
   "None."
 );
 
-static const PDLog CL_DNS_FILE_MALFORMED
+static const PDLog3<const char*, const char*, const char*> CL_RM_CONNECTION_ERROR
 (
   PDLogBase::CL_CPP_COMMON_ID + 11,
-  LOG_ERR,
-  "DNS config file is malformed.",
-  "The DNS config file /etc/clearwater/dns.json is invalid JSON.",
-  "The DNS config file will be ignored, and all DNS queries will be directed at "
-  "the DNS server rather than using any local overrides.",
-  "(1). Check the DNS config file for correctness."
-  "(2). Upload the corrected config with "
-  "/usr/share/clearwater/clearwater-config-manager/scripts/upload_dns_json"
-);
-
-static const PDLog CL_DNS_FILE_DUPLICATES
-(
-  PDLogBase::CL_CPP_COMMON_ID + 12,
-  LOG_INFO,
-  "Duplicate entries found in the DNS config file",
-  "The DNS config file /etc/clearwater/dns.json contains duplicate entries.",
-  "Only the first of the duplicates will be used - the others will be ignored.",
-  "(1). Check the DNS config file for duplicates."
-  "(2). Upload the corrected config with "
-  "/usr/share/clearwater/clearwater-config-manager/scripts/upload_dns_json"
-);
-
-static const PDLog CL_DNS_FILE_MISSING
-(
-  PDLogBase::CL_CPP_COMMON_ID + 13,
-  LOG_ERR,
-  "DNS config file is missing.",
-  "The DNS config file /etc/clearwater/dns.json is not present.",
-  "The DNS config file will be ignored, and all DNS queries will be directed at "
-  "the DNS server rather than using any local overrides.",
-  "(1). Replace the missing DNS config file if desired."
-  "(2). Upload the corrected config with "
-  "/usr/share/clearwater/clearwater-config-manager/scripts/upload_dns_json "
-  "(if no config file is present, no DNS overrides will be applied)"
-);
-
-static const PDLog CL_DNS_FILE_BAD_ENTRY
-(
-  PDLogBase::CL_CPP_COMMON_ID + 14,
-  LOG_ERR,
-  "DNS config file has a malformed entry.",
-  "The DNS config file /etc/clearwater/dns.json contains a malformed entry.",
-  "The malformed entry will be ignored. Other, correctly formed, entries will "
-  "still be used.",
-  "(1). Check the DNS config file for correctness."
-  "(2). Upload the corrected config with "
-  "/usr/share/clearwater/clearwater-config-manager/scripts/upload_dns_json"
-);
-
-static const PDLog3<const char*, const char*, const char*> CL_CM_CONNECTION_PARTIAL_ERROR_EXPLICIT
-(
-  PDLogBase::CL_CPP_COMMON_ID + 15,
   LOG_INFO,
   "Connections between %s and %s applications at %s have failed.",
-  "This process was unable to contact some instances of the application "
-  "it's trying to connect to, but did make some successful contact",
+  "At least one of the Diameter peers is not contactable and the number of contactabble "
+  "instances is strictly less than expected (two unless changed through configuration)",
   "This process was unable to contact some instances of the application "
   "it's trying to connect to",
   "(1). Check that the application this process is trying to connect to is running."
@@ -172,13 +120,13 @@ static const PDLog3<const char*, const char*, const char*> CL_CM_CONNECTION_PART
   "(3). Check that this process has connectivity to the application it's trying to connect to."
 );
 
-static const PDLog3<const char*, const char*, const char*> CL_CM_CONNECTION_PARTIAL_CLEARED_EXPLICIT
+static const PDLog2<const char*, const char*> CL_RM_CONNECTION_CLEARED
 (
-  PDLogBase::CL_CPP_COMMON_ID + 16,
+  PDLogBase::CL_CPP_COMMON_ID + 12,
   LOG_INFO,
-  "Connection between %s and %s applications%s has been restored.",
-  "This process can now contact at least one instance of the application it's "
-  "trying to connect to.",
+  "Some connections between %s and %s have been restored.",
+  "Either all known Diameter peers are conntactable, or there are enough contactable peers (two "
+  "unless changed through configuration) to provide the required level of Diameter peer resilience.",
   "Normal.",
   "None."
 );

--- a/include/realmmanager.h
+++ b/include/realmmanager.h
@@ -27,8 +27,8 @@ public:
                int max_peers,
                DiameterResolver* resolver,
                Alarm* alarm,
-               const PDLog* ALARM_CLEAR_LOG,
-               const PDLog1<const char*>* ALARM_ERROR_LOG);
+               const PDLog& peer_comm_restored_log,
+               const PDLog1<const char*>& peer_comm_error_log);
   virtual ~RealmManager();
 
   void start();
@@ -55,8 +55,8 @@ private:
   
   // Helper functions that modify the _failed_peers map. Both return true if
   // modified, false otherwise.
-  bool add_to_failed_peers(Diameter::Peer* peer);
-  bool remove_from_failed_peers(Diameter::Peer* peer);
+  bool try_add_to_failed_peers(Diameter::Peer* peer);
+  bool try_remove_from_failed_peers(Diameter::Peer* peer);
 
   void remove_old_failed_peers(unsigned long now_ms = 0);
 
@@ -82,9 +82,9 @@ private:
   DiameterResolver* _resolver;
   Alarm* _peer_connection_alarm;
   std::map<std::string, Diameter::Peer*> _peers;
-  std::map<AddrInfo, const unsigned long> _failed_peers;
-  const PDLog* _ALARM_CLEAR_LOG;
-  const PDLog1<const char*>* _ALARM_ERROR_LOG;
+  std::map<AddrInfo, unsigned long> _failed_peers;
+  const PDLog& _peer_comm_restored_log;
+  const PDLog1<const char*>& _peer_comm_error_log;
   volatile bool _terminating;
 };
 

--- a/include/realmmanager.h
+++ b/include/realmmanager.h
@@ -55,10 +55,10 @@ private:
   
   // Helper functions that modify the _failed_peers map. Both return true if
   // modified, false otherwise.
-  bool try_add_to_failed_peers(Diameter::Peer* peer);
-  bool try_remove_from_failed_peers(Diameter::Peer* peer);
+  bool add_to_failed_peers(Diameter::Peer* peer);
+  bool remove_from_failed_peers(Diameter::Peer* peer);
 
-  void remove_old_failed_peers(unsigned long now_ms = 0);
+  void remove_old_failed_peers();
 
   // We use a read/write lock to read and update the _peers map (defined below).
   // However, we read this map on every single Diameter message, so we want to

--- a/include/realmmanager.h
+++ b/include/realmmanager.h
@@ -16,6 +16,7 @@
 
 #include "diameterstack.h"
 #include "diameterresolver.h"
+#include "pdlog.h"
 
 class RealmManager
 {
@@ -25,9 +26,9 @@ public:
                std::string host,
                int max_peers,
                DiameterResolver* resolver,
-               Alarm* alarm=NULL,
-               std::string sender="",
-               std::string receiver="");
+               Alarm* alarm,
+               const PDLog* ALARM_CLEAR_LOG,
+               const PDLog1<const char*>* ALARM_ERROR_LOG);
   virtual ~RealmManager();
 
   void start();
@@ -40,33 +41,22 @@ public:
   void srv_priority_cb(struct fd_list* candidates);
 
   static const int DEFAULT_BLACKLIST_DURATION;
+  static const unsigned int FAILED_PEERS_TIMEOUT_MS = 24*3600*1000;
 
 private:
   void thread_function();
   static void* thread_function(void* realm_manager_ptr);
 
   void manage_connections(int& ttl);
+  void monitor_connections(const bool& failed_peers_changed);
 
-  // utility function that turns the std::map _failed_peers into a csv string
+  // Utility function that turns the std::map _failed_peers into a CSV string
   std::string create_failed_peers_string();
-
-  /// -------------------------- Alarm mechanics -------------------------- ///
-  // The _peer_connection_alarm is used to monitor the connection to diameter
-  // peers. The parameter controlling the mechanics of the alarm is _max_peers.
-  // We keep track of the peers we failed to connect to using the map
-  // _failed_peers. We add the failed peer together with a timestamp to this
-  // map, so that we can remove stale failed peers which no longer get returned
-  // by the DNS (see Step 8 in manage_connections).
-  // We raise the alarm whenever we get a callback and the number of connected
-  // peers (num_connected_peers) is strictly less than _max_peers.
-  // We clear the alarm whenever we get a callback and, either the number of
-  // connected peers is at least _max_peers, or there are no failed peers.
-  // This ensures we clear the alarm if the total number of available peers is
-  // less than _max_peers and we successfully connect to all of them.
-  // We also make ENT logs specifying the ip addresses of the failed peers,
-  // thus helping us diagnose which peers we failed to connect to.
-  /// --------------------------------------------------------------------- ///
-  void manage_alarm(const int failed_peers_changed);
+  
+  // Helper functions that modify the _failed_peers map. Both return true if
+  // modified, false otherwise.
+  bool add_to_failed_peers(Diameter::Peer* peer);
+  bool remove_from_failed_peers(Diameter::Peer* peer);
 
   // We use a read/write lock to read and update the _peers map (defined below).
   // However, we read this map on every single Diameter message, so we want to
@@ -81,7 +71,6 @@ private:
   pthread_mutex_t _main_thread_lock;
   pthread_rwlock_t _peers_lock;
 
-  Alarm* _peer_connection_alarm;
   Diameter::Stack* _stack;
   std::string _realm;
   std::string _host;
@@ -89,12 +78,11 @@ private:
   pthread_t _thread;
   pthread_cond_t _cond;
   DiameterResolver* _resolver;
+  Alarm* _peer_connection_alarm;
   std::map<std::string, Diameter::Peer*> _peers;
   std::map<AddrInfo, const unsigned long> _failed_peers;
-  std::string _sender;
-  std::string _receiver;
-  unsigned long _failed_peers_timeout_ms = 24*3600*1000;
+  const PDLog* _ALARM_CLEAR_LOG;
+  const PDLog1<const char*>* _ALARM_ERROR_LOG;
   volatile bool _terminating;
 };
-
 #endif

--- a/include/realmmanager.h
+++ b/include/realmmanager.h
@@ -27,8 +27,8 @@ public:
                int max_peers,
                DiameterResolver* resolver,
                Alarm& alarm,
-               const PDLog& peer_comm_restored_log,
-               const PDLog1<const char*>& peer_comm_error_log);
+               PDLog peer_comm_restored_log,
+               PDLog1<const char*> peer_comm_error_log);
   virtual ~RealmManager();
 
   void start();
@@ -83,8 +83,8 @@ private:
   Alarm& _peer_connection_alarm;
   std::map<std::string, Diameter::Peer*> _peers;
   std::map<AddrInfo, unsigned long> _failed_peers;
-  const PDLog& _peer_comm_restored_log;
-  const PDLog1<const char*>& _peer_comm_error_log;
+  PDLog _peer_comm_restored_log;
+  PDLog1<const char*> _peer_comm_error_log;
   volatile bool _terminating;
 };
 

--- a/include/realmmanager.h
+++ b/include/realmmanager.h
@@ -26,7 +26,7 @@ public:
                std::string host,
                int max_peers,
                DiameterResolver* resolver,
-               Alarm* alarm,
+               Alarm& alarm,
                const PDLog& peer_comm_restored_log,
                const PDLog1<const char*>& peer_comm_error_log);
   virtual ~RealmManager();
@@ -80,7 +80,7 @@ private:
   pthread_t _thread;
   pthread_cond_t _cond;
   DiameterResolver* _resolver;
-  Alarm* _peer_connection_alarm;
+  Alarm& _peer_connection_alarm;
   std::map<std::string, Diameter::Peer*> _peers;
   std::map<AddrInfo, unsigned long> _failed_peers;
   const PDLog& _peer_comm_restored_log;

--- a/include/realmmanager.h
+++ b/include/realmmanager.h
@@ -58,6 +58,8 @@ private:
   bool add_to_failed_peers(Diameter::Peer* peer);
   bool remove_from_failed_peers(Diameter::Peer* peer);
 
+  void remove_old_failed_peers(unsigned long now_ms = 0);
+
   // We use a read/write lock to read and update the _peers map (defined below).
   // However, we read this map on every single Diameter message, so we want to
   // minimise blocking. Therefore we only grab the write lock when we are ready
@@ -85,4 +87,5 @@ private:
   const PDLog1<const char*>* _ALARM_ERROR_LOG;
   volatile bool _terminating;
 };
+
 #endif

--- a/include/utils.h
+++ b/include/utils.h
@@ -241,6 +241,13 @@ namespace Utils
     }
   }
 
+  inline unsigned long current_time_ms()
+  {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec * 1000 + (ts.tv_nsec / 1000000);
+  }
+
   std::string strip_uri_scheme(const std::string& uri);
   std::string remove_visual_separators(const std::string& number);
   bool is_user_numeric(const std::string& user);

--- a/src/communicationmonitor.cpp
+++ b/src/communicationmonitor.cpp
@@ -26,7 +26,7 @@ CommunicationMonitor::CommunicationMonitor(Alarm* alarm,
   _set_confirm_ms(set_confirm_sec * 1000),
   _previous_state(0)
 {
-  _next_check = current_time_ms() + _set_confirm_ms;
+  _next_check = Utils::current_time_ms() + _set_confirm_ms;
 }
 
 CommunicationMonitor::~CommunicationMonitor()
@@ -36,7 +36,7 @@ CommunicationMonitor::~CommunicationMonitor()
 
 void CommunicationMonitor::track_communication_changes(unsigned long now_ms)
 {
-  now_ms = now_ms ? now_ms : current_time_ms();
+  now_ms = now_ms ? now_ms : Utils::current_time_ms();
 
   if (now_ms > _next_check)
   {
@@ -154,13 +154,4 @@ void CommunicationMonitor::track_communication_changes(unsigned long now_ms)
 
     pthread_mutex_unlock(&_lock);
   }
-}
-
-unsigned long CommunicationMonitor::current_time_ms()
-{
-  struct timespec ts;
-
-  clock_gettime(CLOCK_MONOTONIC, &ts);
-
-  return ts.tv_sec * 1000 + (ts.tv_nsec / 1000000);
 }

--- a/src/realmmanager.cpp
+++ b/src/realmmanager.cpp
@@ -21,16 +21,16 @@ RealmManager::RealmManager(Diameter::Stack* stack,
                            int max_peers,
                            DiameterResolver* resolver,
                            Alarm* alarm,
-                           std::string sender,
-                           std::string receiver) :
-                           _peer_connection_alarm(alarm),
+                           const PDLog* ALARM_CLEAR_LOG,
+                           const PDLog1<const char*>* ALARM_ERROR_LOG) :
                            _stack(stack),
                            _realm(realm),
                            _host(host),
                            _max_peers(max_peers),
                            _resolver(resolver),
-                           _sender(sender),
-                           _receiver(receiver),
+                           _peer_connection_alarm(alarm),
+                           _ALARM_CLEAR_LOG(ALARM_CLEAR_LOG),
+                           _ALARM_ERROR_LOG(ALARM_ERROR_LOG),
                            _terminating(false)
 {
   pthread_mutex_init(&_main_thread_lock, NULL);
@@ -62,7 +62,6 @@ void RealmManager::start()
 
 RealmManager::~RealmManager()
 {
-  delete _peer_connection_alarm;
   pthread_mutex_destroy(&_main_thread_lock);
   pthread_cond_destroy(&_cond);
 
@@ -82,35 +81,62 @@ void RealmManager::stop()
 
 std::string RealmManager::create_failed_peers_string()
 {
-  std::map<AddrInfo, const unsigned long>::iterator ii;
   std::string failed_peers_string = "";
   std::string sep = "";
-  for (ii = _failed_peers.begin(); ii != _failed_peers.end(); ++ii)
+  for (std::pair<AddrInfo, const unsigned long> failed_peer : _failed_peers)
   {
-    failed_peers_string += sep + Utils::ip_addr_to_arpa((ii->first).address);
+    failed_peers_string += sep + Utils::ip_addr_to_arpa(failed_peer.first.address);
     sep = ", ";
   }
   return failed_peers_string;
 }
 
-void RealmManager::manage_alarm(const int failed_peers_changed)
+bool RealmManager::add_to_failed_peers(Diameter::Peer* peer)
+{
+  // map::insert returns true if inserted, false otherwise
+  return _failed_peers.insert(std::pair<AddrInfo, const unsigned long>
+                              (peer->addr_info(),
+                              Utils::current_time_ms())).second; 
+}
+
+bool RealmManager::remove_from_failed_peers(Diameter::Peer* peer)
+{
+  // map::erase returns the number of elements erased
+  return (bool)_failed_peers.erase(peer->addr_info());
+}
+
+// This function is responsible for monitoring diameter peer connections.
+//
+// The _peer_connection_alarm is used to monitor the connection to diameter
+// peers. The parameter controlling the mechanics of the alarm is _max_peers.
+// We keep track of the peers we failed to connect to using the map
+// _failed_peers. We add the failed peer together with a timestamp to this
+// map, so that we can remove stale failed peers which no longer get returned
+// by the DNS (see Step 8 in manage_connections).
+// We raise the alarm whenever we get a callback and the number of connected
+// peers (num_connected_peers) is strictly less than _max_peers.
+// We clear the alarm whenever we get a callback and, either the number of
+// connected peers is at least _max_peers, or there are no failed peers.
+// This ensures we clear the alarm if the total number of available peers is
+// less than _max_peers and we successfully connect to all of them.
+// We also make ENT logs specifying the ip addresses of the failed peers,
+// thus helping us diagnose which peers we failed to connect to.
+void RealmManager::monitor_connections(const bool& failed_peers_changed)
 {
   if (_peer_connection_alarm)
   {
     // First find the number of connected peers.
     int num_connected_peers = 0;
-    for (std::map<std::string, Diameter::Peer*>::iterator ii = _peers.begin();
-          ii != _peers.end();
-          ii++)
+    for (std::pair<std::string, Diameter::Peer*> peer : _peers)
     {
-      if ((ii->second)->connected())
+      if ((peer.second)->connected())
       {
         num_connected_peers++;
       }
     }
 
     const bool clear_alarm = (num_connected_peers >= _max_peers) ||
-                            _failed_peers.empty();
+                              _failed_peers.empty();
 
     if (_peer_connection_alarm->get_alarm_state() == AlarmState::ALARMED)
     {
@@ -118,16 +144,14 @@ void RealmManager::manage_alarm(const int failed_peers_changed)
       if (clear_alarm)
       {
         _peer_connection_alarm->clear();
-        CL_RM_CONNECTION_CLEARED.log(_sender.c_str(), _receiver.c_str());
+        _ALARM_CLEAR_LOG->log();
       }
       else if (failed_peers_changed)
       {
         // We either failed to connect to a new peer or we successfully connected
         // to a previously uncontactable peer. Make an ENT log updating the ip
         // addresses of the uncontactable peers.
-        CL_RM_CONNECTION_ERROR.log(_sender.c_str(),
-                                  _receiver.c_str(),
-                                  create_failed_peers_string().c_str());
+        _ALARM_ERROR_LOG->log(create_failed_peers_string().c_str());
       }
     }
     else
@@ -136,9 +160,7 @@ void RealmManager::manage_alarm(const int failed_peers_changed)
       if (!clear_alarm)
       {
         _peer_connection_alarm->set();
-        CL_RM_CONNECTION_ERROR.log(_sender.c_str(),
-                                  _receiver.c_str(),
-                                  create_failed_peers_string().c_str());
+        _ALARM_ERROR_LOG->log(create_failed_peers_string().c_str());
       }
     }
   }
@@ -164,10 +186,10 @@ void RealmManager::peer_connection_cb(bool connection_success,
                  realm.c_str());
         pthread_rwlock_unlock(&_peers_lock);
         pthread_rwlock_wrlock(&_peers_lock);
-        const int was_failed = _failed_peers.erase(peer->addr_info());
+        bool was_already_failed = remove_from_failed_peers(peer);
         peer->set_connected();
 
-        manage_alarm(was_failed);
+        monitor_connections(was_already_failed);
       }
       else
       {
@@ -180,12 +202,11 @@ void RealmManager::peer_connection_cb(bool connection_success,
         _resolver->blacklist(peer->addr_info());
         pthread_rwlock_unlock(&_peers_lock);
         pthread_rwlock_wrlock(&_peers_lock);
-        const bool wasnt_failed = _failed_peers.insert(std::pair<AddrInfo, const unsigned long>
-                                  (peer->addr_info(), Utils::current_time_ms())).second;        
+        bool wasnt_already_failed = add_to_failed_peers(peer);
         delete peer;
         _peers.erase(ii);
 
-        manage_alarm((int)wasnt_failed);
+        monitor_connections(wasnt_already_failed);
 
         pthread_cond_signal(&_cond);
       }
@@ -197,13 +218,11 @@ void RealmManager::peer_connection_cb(bool connection_success,
 
       pthread_rwlock_unlock(&_peers_lock);
       pthread_rwlock_wrlock(&_peers_lock);
-      const bool wasnt_failed = _failed_peers.insert(std::pair<AddrInfo, const unsigned long>
-                                (peer->addr_info(), Utils::current_time_ms())).second;
-
+      bool wasnt_already_failed = add_to_failed_peers(peer);
       delete peer;
       _peers.erase(ii);
 
-      manage_alarm((int)wasnt_failed);
+      monitor_connections(wasnt_already_failed);
 
       pthread_cond_signal(&_cond);
     }
@@ -481,7 +500,7 @@ void RealmManager::manage_connections(int& ttl)
   for (std::map<AddrInfo, const unsigned long>::iterator ii = _failed_peers.begin();
                                                          ii != _failed_peers.end();)
   {
-    if (ii->second + _failed_peers_timeout_ms <= current_time)
+    if (ii->second + FAILED_PEERS_TIMEOUT_MS <= current_time)
     {
       _failed_peers.erase(ii++);
     }

--- a/src/realmmanager.cpp
+++ b/src/realmmanager.cpp
@@ -21,8 +21,8 @@ RealmManager::RealmManager(Diameter::Stack* stack,
                            int max_peers,
                            DiameterResolver* resolver,
                            Alarm& alarm,
-                           const PDLog& peer_comm_restored_log,
-                           const PDLog1<const char*>& peer_comm_error_log) :
+                           PDLog peer_comm_restored_log,
+                           PDLog1<const char*> peer_comm_error_log) :
                            _stack(stack),
                            _realm(realm),
                            _host(host),
@@ -79,6 +79,7 @@ void RealmManager::stop()
   _stack->unregister_rt_out_cb("realmmanager");
 }
 
+// This function is only safe to call when holding the _peers_lock.
 std::string RealmManager::create_failed_peers_string()
 {
   std::string failed_peers_string = "";
@@ -96,6 +97,8 @@ std::string RealmManager::create_failed_peers_string()
 // This function adds a new peer to the _failed_peers map or, if the peer is
 // already failed, updates the peer in the map. Returns false if the peer was
 // in the map already, otherwise returns true.
+//
+// This function is only safe to call when holding the _peers_lock.
 bool RealmManager::add_to_failed_peers(Diameter::Peer* peer)
 {
   if (_failed_peers.find(peer->addr_info()) == _failed_peers.end())
@@ -116,6 +119,8 @@ bool RealmManager::add_to_failed_peers(Diameter::Peer* peer)
 
 // This function ensures that the peer is not in _failed_peers map, removing
 // it if necessary. It returns whether the peer was in the map at the start.
+//
+// This function is only safe to call when holding the _peers_lock.
 bool RealmManager::remove_from_failed_peers(Diameter::Peer* peer)
 {
   if (_failed_peers.find(peer->addr_info()) == _failed_peers.end())
@@ -131,6 +136,7 @@ bool RealmManager::remove_from_failed_peers(Diameter::Peer* peer)
   }
 }
 
+// This function is only safe to call when holding the _peers_lock.
 void RealmManager::remove_old_failed_peers()
 {
   unsigned long current_time = Utils::current_time_ms();


### PR DESCRIPTION
Hi Ellie.

Here is the PR for the diameter peer connection alarm we have discussed before. Would you mind reviewing it please?
As we agreed, the alarm gets raised directly from the realm manager without using the communication monitor. For the alarm mechanics see the block comment in realmmanager.h.

There are related PRs in homestead and ralf referenced bellow that implement the process specific details of the alarm.

I have also added some UTs to test my fix - see PR in cpp-common-test referenced bellow.

I have tested my fix by running make full_test in cpp-common-test, homestead and in ralf. I also did a live test to check the behaviour of the ENT logs is as expected.