### PR TITLE
Add in diameter logging

### DIFF
--- a/src/diameterstack.cpp
+++ b/src/diameterstack.cpp
@@ -696,7 +696,7 @@ void Stack::logger(int fd_log_level, const char* fmt, va_list args)
   }
   
   Log::_write(log_level, "freeDiameter", 0, fmt, args);
-  Log::ramTrace(0, fmt, args);
+  TRC_RAMTRACE(fmt, args);
 }
 
 void Stack::set_trail_id(struct msg* fd_msg, SAS::TrailId trail)

--- a/src/diameterstack.cpp
+++ b/src/diameterstack.cpp
@@ -694,7 +694,9 @@ void Stack::logger(int fd_log_level, const char* fmt, va_list args)
       log_level = Log::DEBUG_LEVEL;
       break;
   }
+  
   Log::_write(log_level, "freeDiameter", 0, fmt, args);
+  Log::ramTrace(0, fmt, args);
 }
 
 void Stack::set_trail_id(struct msg* fd_msg, SAS::TrailId trail)


### PR DESCRIPTION
Richard, 

Can you confirm you're happy with this change please?  I'm not entirely convinced that calling the TRC_RAMTRACE function is the right option but I think it's the best we can do (equally I'm not convinced by calling direct into Log::_write() which feels like an internal function). 

Testing: Run a call through the system and confirm diameter logs appear (in progress).