### PR TITLE
Naive RAM Recorder

### DIFF
--- a/include/log.h
+++ b/include/log.h
@@ -72,6 +72,7 @@ namespace RamRecorder
 {
   extern bool record_everything;
   void recordEverything();
+  void _record(int level, const char* module, int lineno, const char* context, const char* format, va_list args);
   void record(int level, const char* module, int lineno, const char* format, ...);
   void record_with_context(int level, const char* module, int lineno, char* context, const char* format, ...);
   void write(const char* buffer, size_t length);

--- a/include/log.h
+++ b/include/log.h
@@ -75,6 +75,7 @@ namespace RamRecorder
   void _record(int level, const char* module, int lineno, const char* context, const char* format, va_list args);
   void record(int level, const char* module, int lineno, const char* format, ...);
   void record_with_context(int level, const char* module, int lineno, char* context, const char* format, ...);
+  void reset();
   void write(const char* buffer, size_t length);
   void dump(const std::string& output_dir);
 }

--- a/include/log.h
+++ b/include/log.h
@@ -70,16 +70,11 @@ namespace Log
 
 namespace RamRecorder
 {
-  bool record_everything = false;
-
-  void recordEverything()
-  {
-    record_everything = true;
-  }
-
+  extern bool record_everything;
+  void recordEverything();
   void record(int level, const char* module, int lineno, const char* format, ...);
-  void write(const char* buffer, int length);
-  void dump(std::string output_dir);
+  void write(const char* buffer, size_t length);
+  void dump(const std::string& output_dir);
 }
 
 #endif

--- a/include/log.h
+++ b/include/log.h
@@ -73,6 +73,7 @@ namespace RamRecorder
   extern bool record_everything;
   void recordEverything();
   void record(int level, const char* module, int lineno, const char* format, ...);
+  void record_with_context(int level, const char* module, int lineno, char* context, const char* format, ...);
   void write(const char* buffer, size_t length);
   void dump(const std::string& output_dir);
 }

--- a/include/log.h
+++ b/include/log.h
@@ -16,12 +16,25 @@
 #include "logger.h"
 #include <cstdarg>
 
-#define TRC_ERROR(...) if (Log::enabled(Log::ERROR_LEVEL)) Log::write(Log::ERROR_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
-#define TRC_WARNING(...) if (Log::enabled(Log::WARNING_LEVEL)) Log::write(Log::WARNING_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
-#define TRC_STATUS(...) if (Log::enabled(Log::STATUS_LEVEL)) Log::write(Log::STATUS_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
-#define TRC_INFO(...) if (Log::enabled(Log::INFO_LEVEL)) Log::write(Log::INFO_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
-#define TRC_VERBOSE(...) if (Log::enabled(Log::VERBOSE_LEVEL)) Log::write(Log::VERBOSE_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
-#define TRC_DEBUG(...) if (Log::enabled(Log::DEBUG_LEVEL)) Log::write(Log::DEBUG_LEVEL, __FILE__, __LINE__, __VA_ARGS__)
+#define TRC_RAMTRACE(level, ...) RamRecorder::record(level, __FILE__, __LINE__, ##__VA_ARGS__)
+
+#define TRC_MAYBE_RAMTRACE(...)                                            \
+do {                                                                       \
+  if (RamRecorder::record_everything) {                                    \
+    TRC_RAMTRACE(__VA_ARGS__);                                             \
+  }                                                                        \
+} while (0)
+
+#define TRC_LOG(level, ...) if (Log::enabled(level)) Log::write(level, __FILE__, __LINE__, ##__VA_ARGS__)
+#define TRC_BASE(level, ...) do { TRC_MAYBE_RAMTRACE(level, ##__VA_ARGS__); TRC_LOG(level, ##__VA_ARGS__); } while (0)
+
+#define TRC_ERROR(...) TRC_BASE(Log::ERROR_LEVEL, ##__VA_ARGS__)
+#define TRC_WARNING(...) TRC_BASE(Log::WARNING_LEVEL, ##__VA_ARGS__)
+#define TRC_STATUS(...) TRC_BASE(Log::STATUS_LEVEL, ##__VA_ARGS__)
+#define TRC_INFO(...) TRC_BASE(Log::INFO_LEVEL, ##__VA_ARGS__)
+#define TRC_VERBOSE(...) TRC_BASE(Log::VERBOSE_LEVEL, ##__VA_ARGS__)
+#define TRC_DEBUG(...) TRC_BASE(Log::DEBUG_LEVEL, ##__VA_ARGS__)
+
 #define TRC_BACKTRACE(...) Log::backtrace(__VA_ARGS__)
 #define TRC_BACKTRACE_ADV() Log::backtrace_adv()
 #define TRC_COMMIT() Log::commit()
@@ -53,6 +66,20 @@ namespace Log
   void backtrace(const char* fmt, ...);
   void backtrace_adv();
   void commit();
+}
+
+namespace RamRecorder
+{
+  bool record_everything = false;
+
+  void recordEverything()
+  {
+    record_everything = true;
+  }
+
+  void record(int level, const char* module, int lineno, const char* format, ...);
+  void write(const char* buffer, int length);
+  void dump(std::string output_dir);
 }
 
 #endif

--- a/include/logger.h
+++ b/include/logger.h
@@ -19,6 +19,19 @@
 #include <pthread.h>
 #include <atomic>
 
+/// Encodes the time as needed by the logger.
+typedef struct
+{
+  int year;
+  int mon;
+  int mday;
+  int hour;
+  int min;
+  int sec;
+  int msec;
+  int yday;
+} timestamp_t;
+
 class Logger
 {
 public:
@@ -53,27 +66,16 @@ public:
   // threads are running - generally from a signal handler.
   virtual void backtrace_advanced();
 
+  static void get_timestamp(timestamp_t& ts, struct timespec& timespec);
+  static void format_timestamp(const timestamp_t& ts, char* buf, size_t len);
+
 protected:
   virtual void gettime_monotonic(struct timespec* ts);
   virtual void gettime(struct timespec* ts);
 
-private:
-  /// Encodes the time as needed by the logger.
-  typedef struct
-  {
-    int year;
-    int mon;
-    int mday;
-    int hour;
-    int min;
-    int sec;
-    int msec;
-    int yday;
-  } timestamp_t;
-
   void get_timestamp(timestamp_t& ts);
+private:
   void write_log_file(const char* data, const timestamp_t& ts);
-  void format_timestamp(const timestamp_t& ts, char* buf, size_t len);
   void cycle_log_file(const timestamp_t& ts);
 
   // Two methods to use with pthread_cleanup_push to release the lock if the logging thread is

--- a/src/diameterstack.cpp
+++ b/src/diameterstack.cpp
@@ -695,6 +695,7 @@ void Stack::logger(int fd_log_level, const char* fmt, va_list args)
       break;
   }
   Log::_write(log_level, "freeDiameter", 0, fmt, args);
+  RamRecorder::record(log_level, "freeDiameter", 0, fmt, args);
 }
 
 void Stack::set_trail_id(struct msg* fd_msg, SAS::TrailId trail)

--- a/src/diameterstack.cpp
+++ b/src/diameterstack.cpp
@@ -694,8 +694,11 @@ void Stack::logger(int fd_log_level, const char* fmt, va_list args)
       log_level = Log::DEBUG_LEVEL;
       break;
   }
+
+  va_list argsb;
+  va_copy(argsb, args);
   Log::_write(log_level, "freeDiameter", 0, fmt, args);
-  RamRecorder::record(log_level, "freeDiameter", 0, fmt, args);
+  RamRecorder::_record(log_level, "freeDiameter", 0, nullptr, fmt, argsb);
 }
 
 void Stack::set_trail_id(struct msg* fd_msg, SAS::TrailId trail)

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -382,7 +382,7 @@ void RamRecorder::dump(const std::string& output_dir)
     if (buffer_end == buffer_start)
     {
       // No bufffered data
-      fprintf(file, "No recorded logs");
+      fprintf(file, "No recorded logs\n");
     }
     else if (buffer_end > buffer_start)
     {

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -407,11 +407,11 @@ void RamRecorder::dump(const std::string& output_dir)
     pthread_mutex_unlock(&RamRecorder::lock);
 
     fprintf(file, "==========\n");
+
+    fclose(file);
   }
   else
   {
-    printf("Failed to open file to dump RAM buffer!");
+    TRC_ERROR("Failed to open file to dump RAM buffer!\n");
   }
-
-  fclose(file);
 }

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -122,12 +122,12 @@ static void log_helper(char* logline,
   // snprintf and vsnprintf return the bytes that would have been
   // written if their second argument was large enough, so we need to
   // reduce the size of written to compensate if it is too large.
-  written = std::min(written, MAX_LOGLINE - 2);
+  written = std::min(written, MAX_LOGLINE - 1);
 
-  bytes_available = MAX_LOGLINE - written - 2;
+  bytes_available = MAX_LOGLINE - written - 1;
   written += vsnprintf(logline + written, bytes_available, fmt, args);
 
-  if (written > (MAX_LOGLINE - 2))
+  if (written > (MAX_LOGLINE - 1))
   {
     truncated = written - (MAX_LOGLINE - 2);
     written = MAX_LOGLINE - 2;

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -328,9 +328,11 @@ void RamRecorder::write(const char* message, size_t length)
       // Reset the end of the buffer to cycle round
       char* new_buffer_end = buffer;
 
-      if (buffer_end < buffer_start)
+      if ((buffer_end < buffer_start) ||
+          (buffer_start == new_buffer_end))
       {
-        // The end has caught back up with the start
+        // The end has caught back up with the start,
+        // or is about to
         buffer_start = buffer + 1;
       }
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -163,7 +163,7 @@ void Log::_write(int level, const char *module, int line_number, const char *fmt
   log_helper(logline, written, truncated, level, module, line_number, nullptr, fmt, args);
 
   // Add a null termination.
-  logline[written+1] = '\0';
+  logline[written] = '\0';
 
   Log::logger->write(logline);
   if (truncated > 0)

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -257,7 +257,7 @@ void RamRecorder::_record(int level, const char* module, int lineno, const char*
   if (truncated)
   {
     char buf[128];
-    int len = snprintf(buf, 128, "Previous log was truncated by %d characters\n", truncated);
+    int len = snprintf(buf, 128, "Earlier log was truncated by %d characters\n", truncated);
     RamRecorder::write(buf, len);
   }
 }
@@ -356,6 +356,7 @@ void RamRecorder::dump(const std::string& output_dir)
     if (buffer_end == buffer_start)
     {
       // No bufffered data
+      fprintf(file, "No recorded logs");
     }
     else if (buffer_end > buffer_start)
     {

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -293,6 +293,15 @@ void RamRecorder::record_with_context(int level, const char* module, int lineno,
   va_end(args);
 }
 
+void RamRecorder::reset()
+{
+  RamRecorder::record_everything = false;
+  pthread_mutex_lock(&RamRecorder::lock);
+  buffer_end = buffer;
+  buffer_start = buffer;
+  pthread_mutex_unlock(&RamRecorder::lock);
+}
+
 void RamRecorder::write(const char* message, size_t length)
 {
   pthread_mutex_lock(&RamRecorder::lock);

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -243,7 +243,7 @@ void RamRecorder::recordEverything()
   RamRecorder::record_everything = true;
 }
 
-static void _record(int level, const char* module, int lineno, const char* context, const char* format, va_list args)
+void RamRecorder::_record(int level, const char* module, int lineno, const char* context, const char* format, va_list args)
 {
   int written;
   int truncated;

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -172,8 +172,13 @@ void Logger::write(const char* data)
 void Logger::get_timestamp(timestamp_t& ts)
 {
   struct timespec timespec;
-  struct tm dt;
   gettime(&timespec);
+  get_timestamp(ts, timespec);
+}
+
+void Logger::get_timestamp(timestamp_t& ts, struct timespec& timespec)
+{
+  struct tm dt;
   gmtime_r(&timespec.tv_sec, &dt);
   ts.year = dt.tm_year;
   ts.mon = dt.tm_mon;


### PR DESCRIPTION
UTs are in https://github.com/Metaswitch/cpp-common-test/pull/88

This adds a naive RAM buffer which we store logs in from the SIP Stack and Diameter stack (and configurable from everywhere).