### PR TITLE
IO Trap Infrastructure. 

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -694,6 +694,20 @@ namespace Utils
     IOStartedCallback _io_started_cb;
     IOCompletedCallback _io_completed_cb;
   };
+
+  class IOMonitor
+  {
+  public:
+    static void io_starts(const std::string& reason);
+    static void io_completes(const std::string& reason);
+    static bool thread_doing_overt_io();
+    static bool thread_allows_covert_io();
+    static void set_thread_allows_covert_io(bool allowed);
+
+  private:
+    static thread_local int _overt_io_depth;
+    static thread_local bool _covert_io_allowed;
+  };
 } // namespace Utils
 
 /// Helper macros to make it easier to invoke an I/O hook, and that means the
@@ -709,10 +723,15 @@ namespace Utils
 #define CW_IO_STARTS(REASON)                                                   \
   {                                                                            \
     std::string description = REASON;                                          \
+    Utils::IOMonitor::io_starts(description);                                  \
     Utils::IOHook::io_starts(description);
 
 #define CW_IO_COMPLETES()                                                      \
     Utils::IOHook::io_completes(description);                                  \
+    Utils::IOMonitor::io_completes(description);                               \
   }
+
+#define CW_IO_CALLS_REQUIRED()                                                 \
+  Utils::IOMonitor::set_thread_allows_covert_io(false)
 
 #endif /* UTILS_H_ */

--- a/include/utils.h
+++ b/include/utils.h
@@ -695,17 +695,49 @@ namespace Utils
     IOCompletedCallback _io_completed_cb;
   };
 
+  /// Class that is used to monitor how a thread does IO.
+  ///
+  /// This class uses a couple of terms:
+  ///
+  /// -  "Overt IO". This is IO that the thread has notified the IOMonitor of,
+  ///    via a call to CW_IO_STARTS.
+  /// -  "Covert IO". This is IO where the thread has not notified the
+  ///    IOMonitor.
+  ///
+  /// By default a thread is allowed to do covert IO. This setting can be
+  /// changed on a per-thread basis by calling CW_IO_CALLS_REQUIRED.
+  ///
+  /// There are no instances of this class - it is simply used as a wrapper to
+  /// prevent access to some private static per-thread variables, and to provide
+  /// a namespace for some static methods.
   class IOMonitor
   {
   public:
+    /// Called to signal the start of an I/O operation.
+    /// @param reason - The reason for the I/O operation.
     static void io_starts(const std::string& reason);
+
+    /// Called to signal the completion of an I/O operation.
+    /// @param reason - The reason for the I/O operation.
     static void io_completes(const std::string& reason);
+
+    /// @return whether the thread is currently doing overt IO i.e. whether it
+    /// has called CW_IO_STARTS (without a matching call to CW_IO_COMPLETES).
     static bool thread_doing_overt_io();
+
+    /// @return whether the thread is allowed to do covert IO.
     static bool thread_allows_covert_io();
+
+    /// Sets whether a thread is allowed to do covert IO. Code should typically
+    /// not call this method directly, but use CW_IO_CALLS_REQUIRED instead.
     static void set_thread_allows_covert_io(bool allowed);
 
   private:
+    // Variable tracking (# CW_IO_STARTS calls) - (# CW_IO_COMPLETES) calls. Any
+    // IO done while this is non-zero is overt.
     static thread_local int _overt_io_depth;
+
+    // Whether this thread is allows to do covert IO.
     static thread_local bool _covert_io_allowed;
   };
 } // namespace Utils
@@ -731,6 +763,8 @@ namespace Utils
     Utils::IOMonitor::io_completes(description);                               \
   }
 
+/// Helper macro to flag that a thread must call CW_IO_(STARTS|COMPLETES) when
+/// doing IO.
 #define CW_IO_CALLS_REQUIRED()                                                 \
   Utils::IOMonitor::set_thread_allows_covert_io(false)
 

--- a/src/io_trap.cpp
+++ b/src/io_trap.cpp
@@ -9,6 +9,8 @@
  * Metaswitch Networks in a separate written agreement.
  */
 
+// LCOV_EXCL_START
+
 // C header files must be included with C linkage to prevent name mangling.
 extern "C" {
 #include <sys/types.h>
@@ -210,3 +212,5 @@ extern "C" int __poll(struct pollfd *fds, nfds_t nfds, int timeout)
 {
   HANDLE_NON_FD_CALL(__poll, fds, nfds, timeout);
 }
+
+// LCOV_EXCL_STOP

--- a/src/io_trap.cpp
+++ b/src/io_trap.cpp
@@ -1,0 +1,90 @@
+/**
+ * @file io_trap.cpp
+ *
+ * Copyright (C) Metaswitch Networks 2018
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+extern "C" {
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <stdlib.h>
+#include <dlfcn.h>
+}
+
+#include <atomic>
+#include "utils.h"
+
+static void maybe_abort()
+{
+  // Abort if we want to trap unexpected IO, and this IO is unexpected.
+  if (!Utils::IOMonitor::thread_doing_overt_io() &&
+      !Utils::IOMonitor::thread_allows_covert_io())
+  {
+    abort();
+  }
+}
+
+#define INTERPOSE(FUNCTION, ...)                                               \
+  using FunctionType = decltype(&FUNCTION);                                    \
+  static std::atomic<FunctionType> real_function(nullptr);                     \
+  if (!real_function)                                                          \
+  {                                                                            \
+    real_function = (FunctionType)dlsym(RTLD_NEXT, #FUNCTION);                 \
+  }                                                                            \
+                                                                               \
+  maybe_abort();                                                               \
+                                                                               \
+  return real_function(__VA_ARGS__)
+
+
+extern "C" ssize_t recv(int sockfd, void *buf, size_t len, int flags)
+{
+  INTERPOSE(recv, sockfd, buf, len, flags);
+}
+
+extern "C" ssize_t recvfrom(int sockfd, void *buf, size_t len, int flags,
+                            struct sockaddr *dest_addr, socklen_t* addrlen)
+{
+  INTERPOSE(recvfrom, sockfd, buf, len, flags, dest_addr, addrlen);
+}
+
+extern "C" ssize_t recvmsg(int sockfd, struct msghdr *msg, int flags)
+{
+  INTERPOSE(recvmsg, sockfd, msg, flags);
+}
+
+extern "C" ssize_t send(int sockfd, const void *buf, size_t len, int flags)
+{
+  INTERPOSE(send, sockfd, buf, len, flags);
+}
+
+extern "C" ssize_t sendto(int sockfd, const void *buf, size_t len, int flags,
+                          const struct sockaddr *dest_addr, socklen_t addrlen)
+{
+  INTERPOSE(sendto, sockfd, buf, len, flags, dest_addr, addrlen);
+}
+
+extern "C" ssize_t sendmsg(int sockfd, const struct msghdr *msg, int flags)
+{
+  INTERPOSE(sendmsg, sockfd, msg, flags);
+}
+
+extern "C" int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
+{
+  INTERPOSE(connect, sockfd, addr, addrlen);
+}
+
+extern "C" int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
+{
+  INTERPOSE(accept, sockfd, addr, addrlen);
+}
+
+extern "C" int accept4(int sockfd, struct sockaddr *addr, socklen_t *addrlen, int flags)
+{
+  INTERPOSE(accept4, sockfd, addr, addrlen, flags);
+}

--- a/src/io_trap.cpp
+++ b/src/io_trap.cpp
@@ -23,6 +23,14 @@ extern "C" {
 #include <atomic>
 #include "utils.h"
 
+static void on_library_load() __attribute__((constructor));
+
+void on_library_load() {
+  printf("*** IO trap loaded ***\n");
+  printf("Unsetting LD_PRELOAD environment variable\n");
+  unsetenv("LD_PRELOAD");
+}
+
 static void maybe_abort()
 {
   // Abort if we want to trap unexpected IO, and this IO is unexpected.

--- a/src/io_trap.cpp
+++ b/src/io_trap.cpp
@@ -138,6 +138,16 @@ extern "C" int poll(struct pollfd *fds, nfds_t nfds, int timeout)
   HANDLE_NON_FD_CALL(poll, fds, nfds, timeout);
 }
 
+extern "C" int __poll_chk(struct pollfd *fds, nfds_t nfds, int timeout, __SIZE_TYPE__ fds_len)
+{
+  HANDLE_NON_FD_CALL(__poll_chk, fds, nfds, timeout, fds_len);
+}
+
+extern "C" int __poll(struct pollfd *fds, nfds_t nfds, int timeout)
+{
+  HANDLE_NON_FD_CALL(__poll, fds, nfds, timeout);
+}
+
 extern "C" int ppoll(struct pollfd *fds, nfds_t nfds,
                      const struct timespec *tmo_p, const sigset_t *sigmask)
 {

--- a/src/io_trap.cpp
+++ b/src/io_trap.cpp
@@ -14,6 +14,10 @@ extern "C" {
 #include <sys/socket.h>
 #include <stdlib.h>
 #include <dlfcn.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/select.h>
+#include <poll.h>
 }
 
 #include <atomic>
@@ -29,7 +33,7 @@ static void maybe_abort()
   }
 }
 
-#define INTERPOSE(FUNCTION, ...)                                               \
+#define HANDLE_NON_FD_CALL(FUNCTION, ...)                                      \
   using FunctionType = decltype(&FUNCTION);                                    \
   static std::atomic<FunctionType> real_function(nullptr);                     \
   if (!real_function)                                                          \
@@ -41,50 +45,101 @@ static void maybe_abort()
                                                                                \
   return real_function(__VA_ARGS__)
 
+#define HANDLE_FD_CALL(FUNCTION, FD, ...)                                      \
+  using FunctionType = decltype(&FUNCTION);                                    \
+  static std::atomic<FunctionType> real_function(nullptr);                     \
+  if (!real_function)                                                          \
+  {                                                                            \
+    real_function = (FunctionType)dlsym(RTLD_NEXT, #FUNCTION);                 \
+  }                                                                            \
+                                                                               \
+  if ((fcntl((FD), F_GETFL) & O_NONBLOCK) == 0)                                \
+  {                                                                            \
+    maybe_abort();                                                             \
+  }                                                                            \
+                                                                               \
+  return real_function(FD, __VA_ARGS__)
 
 extern "C" ssize_t recv(int sockfd, void *buf, size_t len, int flags)
 {
-  INTERPOSE(recv, sockfd, buf, len, flags);
+  HANDLE_FD_CALL(recv, sockfd, buf, len, flags);
 }
 
 extern "C" ssize_t recvfrom(int sockfd, void *buf, size_t len, int flags,
                             struct sockaddr *dest_addr, socklen_t* addrlen)
 {
-  INTERPOSE(recvfrom, sockfd, buf, len, flags, dest_addr, addrlen);
+  HANDLE_FD_CALL(recvfrom, sockfd, buf, len, flags, dest_addr, addrlen);
 }
 
 extern "C" ssize_t recvmsg(int sockfd, struct msghdr *msg, int flags)
 {
-  INTERPOSE(recvmsg, sockfd, msg, flags);
+  HANDLE_FD_CALL(recvmsg, sockfd, msg, flags);
 }
 
 extern "C" ssize_t send(int sockfd, const void *buf, size_t len, int flags)
 {
-  INTERPOSE(send, sockfd, buf, len, flags);
+  HANDLE_FD_CALL(send, sockfd, buf, len, flags);
 }
 
 extern "C" ssize_t sendto(int sockfd, const void *buf, size_t len, int flags,
                           const struct sockaddr *dest_addr, socklen_t addrlen)
 {
-  INTERPOSE(sendto, sockfd, buf, len, flags, dest_addr, addrlen);
+  HANDLE_FD_CALL(sendto, sockfd, buf, len, flags, dest_addr, addrlen);
 }
 
 extern "C" ssize_t sendmsg(int sockfd, const struct msghdr *msg, int flags)
 {
-  INTERPOSE(sendmsg, sockfd, msg, flags);
+  HANDLE_FD_CALL(sendmsg, sockfd, msg, flags);
 }
 
 extern "C" int connect(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
 {
-  INTERPOSE(connect, sockfd, addr, addrlen);
+  HANDLE_FD_CALL(connect, sockfd, addr, addrlen);
 }
 
 extern "C" int accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
 {
-  INTERPOSE(accept, sockfd, addr, addrlen);
+  HANDLE_FD_CALL(accept, sockfd, addr, addrlen);
 }
 
 extern "C" int accept4(int sockfd, struct sockaddr *addr, socklen_t *addrlen, int flags)
 {
-  INTERPOSE(accept4, sockfd, addr, addrlen, flags);
+  HANDLE_FD_CALL(accept4, sockfd, addr, addrlen, flags);
+}
+
+extern "C" int select(int nfds, fd_set *readfds, fd_set *writefds,
+                      fd_set *exceptfds, struct timeval *timeout)
+{
+  HANDLE_NON_FD_CALL(select, nfds, readfds, writefds, exceptfds, timeout);
+}
+
+extern "C" int pselect(int nfds, fd_set *readfds, fd_set *writefds,
+                       fd_set *exceptfds, const struct timespec *timeout,
+                       const sigset_t *sigmask)
+{
+  HANDLE_NON_FD_CALL(pselect, nfds, readfds, writefds, exceptfds, timeout, sigmask);
+}
+
+extern "C" int epoll_wait(int epfd, struct epoll_event *events,
+                          int maxevents, int timeout)
+{
+  HANDLE_NON_FD_CALL(epoll_wait, epfd, events, maxevents, timeout);
+}
+
+extern "C" int epoll_pwait(int epfd, struct epoll_event *events,
+                           int maxevents, int timeout,
+                           const sigset_t *sigmask)
+{
+  HANDLE_NON_FD_CALL(epoll_pwait, epfd, events, maxevents, timeout, sigmask);
+}
+
+extern "C" int poll(struct pollfd *fds, nfds_t nfds, int timeout)
+{
+  HANDLE_NON_FD_CALL(poll, fds, nfds, timeout);
+}
+
+extern "C" int ppoll(struct pollfd *fds, nfds_t nfds,
+                     const struct timespec *tmo_p, const sigset_t *sigmask)
+{
+  HANDLE_NON_FD_CALL(ppoll, fds, nfds, tmo_p, sigmask);
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -127,7 +127,7 @@ std::string Utils::url_unescape(const std::string& s)
   return r;
 }
 
-// The following function quotes strings in SIP headers as described by RFC 3261 
+// The following function quotes strings in SIP headers as described by RFC 3261
 // Section 25.1
 std::string Utils::quote_string(const std::string& s)
 {
@@ -903,3 +903,31 @@ void Utils::IOHook::io_completes(const std::string& reason)
 }
 
 thread_local std::vector<Utils::IOHook*> Utils::IOHook::_hooks = {};
+
+void Utils::IOMonitor::io_starts(const std::string& reason)
+{
+  _overt_io_depth++;
+}
+
+void Utils::IOMonitor::io_completes(const std::string& reason)
+{
+  _overt_io_depth--;
+}
+
+bool Utils::IOMonitor::thread_doing_overt_io()
+{
+  return _overt_io_depth != 0;
+}
+
+bool Utils::IOMonitor::thread_allows_covert_io()
+{
+  return _covert_io_allowed;
+}
+
+void Utils::IOMonitor::set_thread_allows_covert_io(bool allowed)
+{
+  _covert_io_allowed = allowed;
+}
+
+thread_local int Utils::IOMonitor::_overt_io_depth = 0;
+thread_local bool Utils::IOMonitor::_covert_io_allowed = true;


### PR DESCRIPTION
This PR contains the infrastructure to check that a process is correctly using the `CW_IO_STARTS` and `CW_IO_COMPLETES` macros. I'm calling this the "IO trap".

The idea is that:

* If a project wants to use the IO trap, it compiles `io_trap.cpp` into a separate shared object. 
* Any threads in that process that must use the `CW_IO_*` macros should call `CW_IO_CALLS_REQUIRED()` before doing any IO. This means the threads will be monitored by the IO trap. 
* When running the process you install the IO trap by using `LD_PRELOAD=/path/to/io_trap.so`.
* If one of the monitored threads does any IO without calling `CW_IO_*` the process will abort (and produce a core file and a stack trace). 

I've tested in sprout by hacking out various calls to `CW_IO_*` calls (specifically in the HTTP client, DNS resolver, and memcached client). When I run the live tests with the trap installed the process crashes and produces a stack trace. 

I also unit tested the infrastructure that is always compiled into the product code. 