### PR TITLE
Add PDLogs for when the sas.json file is invalid

### DIFF
--- a/include/cpp_common_pd_definitions.h
+++ b/include/cpp_common_pd_definitions.h
@@ -158,4 +158,37 @@ static const PDLog CL_DNS_FILE_BAD_ENTRY
   "/usr/share/clearwater/clearwater-config-manager/scripts/upload_dns_json"
 );
 
+static const PDLog CL_SAS_FILE_MISSING
+(
+  PDLogBase::CL_CPP_COMMON_ID + 15,
+  LOG_ERR,
+  "The SAS config file is missing.",
+  "The SAS config file /etc/clearwater/sas.json is missing.",
+  "The SAS config has not been updated.  The last valid configuration will "
+  "continue to be used",
+  "The SAS configuration should be defined in /etc/clearwater/sas.json. Populate this file according to the documentation."
+);
+
+static const PDLog CL_SAS_FILE_EMPTY
+(
+  PDLogBase::CL_CPP_COMMON_ID + 16,
+  LOG_ERR,
+  "The SAS config file is empty.",
+  "The SAS config file /etc/clearwater/sas.json is empty.",
+  "The SAS config has not been updated.  The last valid configuration will "
+  "continue to be used",
+  "The SAS configuration should be defined in /etc/clearwater/sas.json. Populate this file according to the documentation."
+);
+
+static const PDLog CL_SAS_FILE_INVALID
+(
+  PDLogBase::CL_CPP_COMMON_ID + 17,
+  LOG_ERR,
+  "The SAS config file is invalid.",
+  "The SAS config file /etc/clearwater/sas.json is invalid.",
+  "The SAS config has not been updated.  The last valid configuration will "
+  "continue to be used",
+  "The SAS configuration should be defined in /etc/clearwater/sas.json. Populate this file according to the documentation."
+);
+
 #endif

--- a/src/sasservice.cpp
+++ b/src/sasservice.cpp
@@ -16,12 +16,14 @@
 #include "rapidjson/document.h"
 #include "rapidjson/error/en.h"
 
+#include "cpp_common_pd_definitions.h"
 #include "json_parse_utils.h"
 #include "namespace_hop.h"
 #include "sasevent.h"
 #include "log.h"
 #include "saslogger.h"
 #include "sasservice.h"
+
 
 SasService::SasService(std::string system_name, std::string system_type, bool sas_signaling_if, std::string configuration) :
   _configuration(configuration),
@@ -50,6 +52,7 @@ void SasService::extract_config()
   {
     TRC_STATUS("No SAS configuration (file %s does not exist)",
                _configuration.c_str());
+    CL_SAS_FILE_MISSING.log();
     return;
   }
 
@@ -64,6 +67,7 @@ void SasService::extract_config()
   {
     TRC_ERROR("Failed to read SAS configuration data from %s",
               _configuration.c_str());
+    CL_SAS_FILE_EMPTY.log();
     return;
   }
 
@@ -76,6 +80,7 @@ void SasService::extract_config()
     TRC_ERROR("Failed to read SAS configuration data: %s\nError: %s",
               sas_str.c_str(),
               rapidjson::GetParseError_En(doc.GetParseError()));
+    CL_SAS_FILE_INVALID.log();
     return;
   }
 
@@ -110,6 +115,7 @@ void SasService::extract_config()
   catch (JsonFormatError err)
   {
     TRC_ERROR("Badly formed SAS configuration file");
+    CL_SAS_FILE_INVALID.log();
   }
 }
 


### PR DESCRIPTION
Adds PDlogs for parsing of invalid sas.json to flag when the on-the-box config file is awrt