### PR TITLE
[Reviewer: AJH] Change SpawningHandler member access level

### DIFF
--- a/include/diameterstack.h
+++ b/include/diameterstack.h
@@ -797,7 +797,7 @@ public:
     return _dict;
   }
 
-private:
+protected:
   const C* _cfg;
   const Dictionary* _dict;
 };


### PR DESCRIPTION
Changes two private member variables of the `SpawningHandler` to protected, so they can be accessed by derived classes.