### PR TITLE
Enhance logging infrastructure to cope with C and C++ style strings.

### DIFF
--- a/include/log.h
+++ b/include/log.h
@@ -41,6 +41,36 @@ do {                                                                       \
 
 namespace Log
 {
+  //
+  // The following helper functions (that begin with an underscore) are
+  // logically private and should not be called directly.
+  //
+
+  void _write_var(int level, const char *module, int line_number, const char *fmt, ...);
+  void _write(int level, const char *module, int line_number, const char *fmt, va_list args);
+
+  // Functions that convert a value into a version that is suitable for logging.
+  // For most types this is just the identity function (i.e. it passes the value
+  // through) and if this is not an acceptable type we get a compilation error.
+  //
+  // The exception is `std::string`, where we specialize the template to convert
+  // it to a `const char*` by calling c_str(). This is safe because the caller
+  // of `_loggable` always passes it an lvalue which exists for the duration of
+  // the log call.
+  //
+  // Note that we need template parameters for both the argument and the return
+  // type so that the specialization for std::string can return a type that's
+  // different from the argument.
+  template<class T, class R=T>
+  R _loggable(T arg) { return arg; }
+
+  template<class R=const char*>
+  const char* _loggable(const std::string& arg) { return arg.c_str(); }
+
+  //
+  // Constants and variables after this point are public.
+  //
+
   const int ERROR_LEVEL = 0;
   const int WARNING_LEVEL = 1;
   const int STATUS_LEVEL = 2;
@@ -61,8 +91,23 @@ namespace Log
   }
   void setLoggingLevel(int level);
   Logger* setLogger(Logger *log);
-  void write(int level, const char *module, int line_number, const char *fmt, ...);
-  void _write(int level, const char *module, int line_number, const char *fmt, va_list args);
+
+  // write function that is parameterized over all types that may be passed to
+  // it. This converts these arguments into their loggable form before calling
+  // the simple variadic `_write_var` function.
+  template<typename ...Types>
+  void write(int level, const char *module, int line_number, const char *fmt, Types... args)
+  {
+    // C++11 suport parameter packs which are lists of parameters of (possibly)
+    // heterogeneous types. The expression `_loggable(args)...` expands to
+    // calling `_loggable` on each argument.
+    //
+    // For example if args contains two arguments (arg0 and arg1) this expands
+    // to `_loggable(arg0), _loggable(arg1)`, preserving the type information
+    // for arg0 and arg1.
+    _write_var(level, module, line_number, fmt, _loggable(args)...);
+  }
+
   void backtrace(const char* fmt, ...);
   void backtrace_adv();
   void commit();
@@ -71,13 +116,59 @@ namespace Log
 namespace RamRecorder
 {
   extern bool record_everything;
+  void _record(int level,
+               const char* module,
+               int lineno,
+               const char* context,
+               const char* format,
+               va_list args);
+
   void recordEverything();
-  void _record(int level, const char* module, int lineno, const char* context, const char* format, va_list args);
-  void record(int level, const char* module, int lineno, const char* format, ...);
-  void record_with_context(int level, const char* module, int lineno, const char* context, const char* format, ...);
   void reset();
   void write(const char* buffer, size_t length);
   void dump(const std::string& output_dir);
+
+  /// Record methods that work on plain-old-data types (e.g. chars, ints,
+  /// pointers). The caller is responsible for ensuring that any arguments
+  /// passed into these functions are valid until the function returns. For
+  /// example, it is not safe to call `c_str` on a string rvalue and pass the
+  /// resulting `char*` into one of these functions.
+
+  void record_pod(int level,
+                  const char* module,
+                  int lineno,
+                  const char* format,
+                  ...);
+  void record_with_context_pod(int level,
+                               const char* module,
+                               int lineno,
+                               const char* context,
+                               const char* format,
+                               ...);
+
+  /// Template parameterized record functions. These use the same approach as the
+  /// Log::write function.
+
+  template<typename ...Types>
+  void record(int level,
+              const char* module,
+              int lineno,
+              const char* format,
+              Types... args)
+  {
+    record_pod(level, module, lineno, format, Log::_loggable(args)...);
+  }
+
+  template<typename ...Types>
+  void record_with_context(int level,
+                           const char* module,
+                           int lineno,
+                           const char* context,
+                           const char* format,
+                           Types... args)
+  {
+    record_with_context_pod(level, module, lineno, context, format, Log::_loggable(args)...);
+  }
 }
 
 #endif

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -60,7 +60,7 @@ Logger* Log::setLogger(Logger *log)
   return old;
 }
 
-void Log::write(int level, const char *module, int line_number, const char *fmt, ...)
+void Log::_write_var(int level, const char *module, int line_number, const char *fmt, ...)
 {
   va_list args;
   va_start(args, fmt);
@@ -286,7 +286,11 @@ void RamRecorder::_record(int level, const char* module, int lineno, const char*
   }
 }
 
-void RamRecorder::record(int level, const char* module, int lineno, const char* format, ...)
+void RamRecorder::record_pod(int level,
+                             const char* module,
+                             int lineno,
+                             const char* format,
+                             ...)
 {
   va_list args;
   va_start(args, format);
@@ -294,7 +298,12 @@ void RamRecorder::record(int level, const char* module, int lineno, const char* 
   va_end(args);
 }
 
-void RamRecorder::record_with_context(int level, const char* module, int lineno, const char* context, const char* format, ...)
+void RamRecorder::record_with_context_pod(int level,
+                                          const char* module,
+                                          int lineno,
+                                          const char* context,
+                                          const char* format,
+                                          ...)
 {
   va_list args;
   va_start(args, format);


### PR DESCRIPTION
This PR enhances our logging infrastructure to allow you to pass in C++ strings. This has two advantages:

* You don't have to tediously type `.c_str()` everywhere. 
* You avoid bugs where you accidentally do things like `TRC_DEBUG("Hello %s", get_name().c_str());` and call .c_str() on an rvalue, which results in a dangling pointer. 

I've tested this by changing one of the logs in Ralf to pass in a C++ string, and checked that the log still works. 

I've wrote this code and disassambled it. 

```cpp
std::string name() { return "Alex"; }
void test() { TRC_DEBUG("Hello %s", name()); }
```

The `test` function calls the correct template instantiation:

```
   0x00000000004615af <+281>:	callq  0x4649b3 <Log::write<std::string>(int, char const*, int, char const*, std::string)>
```

which calls the right instantiation of `_loggable`:

```
   0x00000000004649e6 <+51>:	callq  0x465d47 <Log::_loggable<char const*>(std::string const&)>
```

which does call c_str 🙂 

```
   0x0000000000465d47 <+0>:	push   %rbp
   0x0000000000465d48 <+1>:	mov    %rsp,%rbp
   0x0000000000465d4b <+4>:	sub    $0x10,%rsp
   0x0000000000465d4f <+8>:	mov    %rdi,-0x8(%rbp)
   0x0000000000465d53 <+12>:	mov    0x82ac86(%rip),%rax        # 0xc909e0 <__gcov0._ZN3Log9_loggableIPKcEES2_RKSs>
   0x0000000000465d5a <+19>:	add    $0x1,%rax
   0x0000000000465d5e <+23>:	mov    %rax,0x82ac7b(%rip)        # 0xc909e0 <__gcov0._ZN3Log9_loggableIPKcEES2_RKSs>
   0x0000000000465d65 <+30>:	mov    -0x8(%rbp),%rax
   0x0000000000465d69 <+34>:	mov    %rax,%rdi
   0x0000000000465d6c <+37>:	callq  0x4133d0 <_ZNKSs5c_strEv@plt>
   0x0000000000465d71 <+42>:	mov    0x82ac70(%rip),%rdx        # 0xc909e8 <__gcov0._ZN3Log9_loggableIPKcEES2_RKSs+8>
   0x0000000000465d78 <+49>:	add    $0x1,%rdx
   0x0000000000465d7c <+53>:	mov    %rdx,0x82ac65(%rip)        # 0xc909e8 <__gcov0._ZN3Log9_loggableIPKcEES2_RKSs+8>
   0x0000000000465d83 <+60>:	leaveq 
   0x0000000000465d84 <+61>:	retq   
```

This also confirms that the rvalue that is returned by `name()` is converted to an lvalue by the time that the function that actually does the logging is called. 



