### PR TITLE
[No review required] Make IO traps build under clang

### DIFF
--- a/src/io_trap.cpp
+++ b/src/io_trap.cpp
@@ -73,7 +73,7 @@ static void about_to_block()
     {                                                                          \
       func = (FunctionType)dlsym(RTLD_NEXT, #FUNCTION);                        \
     }                                                                          \
-    return func(__VA_ARGS__);                                                  \
+    return (*func)(__VA_ARGS__);                                               \
   } while (0)
 
 


### PR DESCRIPTION
Change to IO traps so that they compile under clang. 

Without this fix you get the following errors, due to the clang implementation of `std::atomic` for a function pointer not auto-dereferencing to the function pointer, which means the call to `()` fails. 

```
/usr/share/clang/scan-build-3.5/c++-analyzer   -MMD -MP -O2 -ggdb3 -std=c++11 -Wall -Werror -fPIC -I../modules/cpp-common/include  -c ../modules/cpp-common/src/io_trap.cpp -o ../build/sprout_io_trap.so/io_trap.o
../modules/cpp-common/src/io_trap.cpp:126:3: error: call to object of type 'std::atomic<FunctionType>' is ambiguous
  HANDLE_FD_CALL(recv, sockfd, buf, len, flags);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../modules/cpp-common/src/io_trap.cpp:115:5: note: expanded from macro 'HANDLE_FD_CALL'
    RETURN_CALL_REAL_FUNCTION(FUNCTION, FD, __VA_ARGS__);                      \
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../modules/cpp-common/src/io_trap.cpp:76:12: note: expanded from macro 'RETURN_CALL_REAL_FUNCTION'
    return func(__VA_ARGS__);                                                  \
           ^~~~
/usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/atomic:304:7: note: conversion candidate of type 'long (*)(int, void *, unsigned long, int)'
      operator __pointer_type() const noexcept
      ^
/usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../include/c++/4.8/atomic:307:7: note: conversion candidate of type 'long (*)(int, void *, unsigned long, int)'
      operator __pointer_type() const volatile noexcept
      ^
```